### PR TITLE
Transpose and PermutedDimsArray the easy way

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
 version = "0.1.1"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -28,7 +28,7 @@ mean(a; dims=X)
 """
 module DimensionalData
 
-using RecipesBase, Statistics
+using RecipesBase, Statistics, LinearAlgebra
 
 using Base: tail, OneTo
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -67,6 +67,8 @@ if VERSION > v"1.1-"
         idx1, idx2 = ntuple(d->(:), dim-1), ntuple(d->(:), ndims(A)-dim)
         return (view(A, idx1..., i, idx2...) for i in axes(A, dim))
     end
+
+
 end
 
 for fname in (:cor, :cov)
@@ -97,12 +99,17 @@ end
 end
 @inline revdims(dims::Tuple{}, i) = ()
 
-for fname in [:permutedims, :transpose, :adjoint]
+for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint), 
+                     (:Base, :transpose), (:LinearAlgebra, :Transpose)]
     @eval begin
-        @inline Base.$fname(A::AbDimArray{T,2}) where T =
+        @inline $pkg.$fname(A::AbDimArray{T,2}) where T =
             rebuild(A, $fname(parent(A)), reverse(dims(A)), refdims(A))
     end
 end
 
-Base.permutedims(A::AbDimArray{T,N}, perm) where {T,N} = 
-    rebuild(A, permutedims(parent(A), dimnum(A, perm)), permutedims(dims(A), perm))
+for fname in [:permutedims, :PermutedDimsArray]
+    @eval begin
+        @inline Base.$fname(A::AbDimArray{T,N}, perm) where {T,N} = 
+            rebuild(A, $fname(parent(A), dimnum(A, perm)), permutedims(dims(A), perm))
+    end
+end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,4 +1,4 @@
-
+using LinearAlgebra: Transpose
 
 @testset "dimension reducing methods" begin
     a = [1 2; 3 4]
@@ -67,25 +67,43 @@ if VERSION > v"1.1-"
 end
 
 
-@testset "dimension reordering methods" begin
+@testset "simple dimension reordering methods" begin
     da = DimensionalArray(zeros(5, 4), (Y(10:20), X(1:4)))
     tda = transpose(da)
+    @test tda == transpose(parent(da))
     @test dims(tda) == (X(LinRange(1.0, 4.0, 4)), Y(LinRange(10.0, 20.0, 5)))
     @test size(tda) == (4, 5)
+
+    tda = Transpose(da)
+    @test tda == Transpose(parent(da))
+    @test dims(tda) == (X(LinRange(1.0, 4.0, 4)), Y(LinRange(10.0, 20.0, 5)))
+    @test size(tda) == (4, 5)
+    @test typeof(tda) <: DimensionalArray
+
     ada = adjoint(da)
+    @test ada == adjoint(parent(da))
     @test dims(ada) == (X(LinRange(1.0, 4.0, 4)), Y(LinRange(10.0, 20.0, 5)))
     @test size(ada) == (4, 5)
 
     dsp = permutedims(da)
-    @test parent(dsp) == permutedims(parent(da))
+    @test permutedims(parent(da)) == parent(dsp)
     @test dims(dsp) == reverse(dims(da))
+end
+
+
+@testset "dimension reordering methods with specified permutation" begin
     da = DimensionalArray(ones(5, 2, 4), (Y(10:20), Time(10:11), X(1:4)))
     dsp = permutedims(da, [3, 1, 2])
 
     @test permutedims(da, [X, Y, Time]) == permutedims(da, (X, Y, Time))
     @test permutedims(da, [X(), Y(), Time()]) == permutedims(da, (X(), Y(), Time()))
     dsp = permutedims(da, (X(), Y(), Time()))
+    @test dsp == permutedims(parent(da), (3, 1, 2)) 
     @test dims(dsp) == (X(LinRange(1.0, 4.0, 4)), Y(LinRange(10.0, 20.0, 5)), Time(LinRange(10.0, 11.0, 2)))
+
+    dsp = PermutedDimsArray(da, (3, 1, 2))
+    @test dsp == PermutedDimsArray(parent(da), (3, 1, 2)) 
+    @test typeof(dsp) <: DimensionalArray
 end
 
 @testset "dimension mirroring methods" begin


### PR DESCRIPTION
Add constructors for `Transpose` and `PermutedDimsArray` that simply wrap them in the dimensional array type and reorder the dims as with `permutedims` etc.

Should probably also add Adjoint for 1.2+