### PR TITLE
Dispatch to efficient methods for map(func, AbDimArray) and reduce(..., dims=:)

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -35,6 +35,8 @@ Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractArray, dims::A
     rebuild(A, Base._mapreduce_dim(f, op, nt, parent(A), dimnum(A, dims)), reducedims(A, dims))
 Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbDimArray, dims::Union{Int,Base.Dims}) =
     rebuild(A, Base._mapreduce_dim(f, op, nt, parent(A), dimnum(A, dims)), reducedims(A, dims))
+Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbDimArray, dims::Colon) =
+    Base._mapreduce_dim(f, op, nt, parent(A), dims)
 # Unfortunately Base/accumulate.jl kwargs methods all force dims to be Integer.
 # accumulate wont work unless that is relaxed, or we copy half of the file here.
 Base._accumulate!(op, B, A, dims::AllDimensions, init::Union{Nothing, Some}) =
@@ -46,6 +48,8 @@ Base._dropdims(A::AbstractArray, dims::AbDimTuple) =
     rebuildsliced(A, Base._dropdims(A, dimnum(A, dims)), 
                   dims2indices(A, Tuple((basetype(d)(1) for d in dims))))
 
+
+@inline Base.map(f, A::AbDimArray) = rebuild(A, map(f, parent(A)), dims(A))
 
 # TODO cov, cor mapslices, eachslice, reverse, sort and sort! need _methods without kwargs in base so
 # we can dispatch on dims. Instead we dispatch on array type for now, which means

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -114,3 +114,13 @@ println("copy: regular sparse")
 @btime copy($sparse_a)
 println("copy: dims sparse")
 @btime copy($sparse_d)
+
+println("reduce: regular sparse")
+@btime reduce(+, $sparse_a)
+println("reduce: dims sparse")
+@btime reduce(+, $sparse_a)
+
+println("map: regular sparse")
+@btime map(sin, $sparse_a)
+println("map: dims sparse")
+@btime map(sin, $sparse_a)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -22,6 +22,7 @@ using LinearAlgebra: Transpose
     @test mapreduce(x -> x > 3, +, da; dims=X) == [0 1]
     @test mapreduce(x -> x > 3, +, da; dims=Y()) == [0 1]'
     @test dims(mapreduce(x-> x > 3, +, da; dims=Y())) == (X(LinRange(143.0, 145.0, 2)), Y(-38.0))
+    @test reduce(+, da) == reduce(+, a)
     @test reduce(+, da; dims=X) == [4 6]
     @test reduce(+, da; dims=Y()) == [3 7]'
     @test dims(reduce(+, da; dims=Y())) == (X(LinRange(143.0, 145.0, 2)), Y(-38.0))
@@ -56,6 +57,7 @@ if VERSION > v"1.1-"
         da = DimensionalArray(a, (Y(10:30), Time(1:4)))
         @test [mean(s) for s in eachslice(da; dims=Time)] == [3.0, 4.0, 5.0, 6.0]
         slices = [s .* 2 for s in eachslice(da; dims=Y)] 
+        @test map(sin, da) == map(sin, a)
         @test slices[1] == [2, 4, 6, 8]
         @test slices[2] == [6, 8, 10, 12]
         @test slices[3] == [10, 12, 14, 16]


### PR DESCRIPTION
Adding a couple more methods I found that are slower than they could be. Using this setup:

```julia
using DimensionalData
using DimensionalData: X, Y
using SparseArrays
using BenchmarkTools

s = sprand(1000, 1000, .1)
sd = DimensionalArray(s, (X <| 1:1000, Y <| 1:1000))
```

On 9a6b121cc:

```julia
julia> @btime map(sin, $s);
  944.490 μs (6 allocations: 1.54 MiB)

julia> @btime map(sin, $sd);
  3.355 s (10 allocations: 3.07 MiB)

julia> @btime reduce(+, $s);
  19.714 μs (1 allocation: 48 bytes)

julia> @btime reduce(+, $sd);
  11.689 ms (8 allocations: 160 bytes)
```

In this PR:

```julia
julia> @btime map(sin, $s);
  941.790 μs (6 allocations: 1.54 MiB)

julia> @btime map(sin, $sd);
  941.316 μs (7 allocations: 1.54 MiB)

julia> @btime reduce(+, $s);
  19.799 μs (1 allocation: 48 bytes)

julia> @btime reduce(+, $sd);
  19.812 μs (1 allocation: 48 bytes)
```


This doesn't cover the case of `map(f, ::Varargs{<:AbDimArray, N})` since I wasn't sure what to do if the dimensions don't match.