### PR TITLE
Constructorof

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
 version = "0.1.1"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -28,7 +28,7 @@ mean(a; dims=X)
 """
 module DimensionalData
 
-using RecipesBase, StaticArrays, Statistics, LinearAlgebra
+using ConstructionBase, LinearAlgebra, RecipesBase, Statistics
 
 using Base: tail, OneTo
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -8,6 +8,7 @@ const StandardIndices = Union{AbstractArray,Colon,Integer}
 
 dims(A::AbDimArray) = A.dims
 label(A::AbDimArray) = ""
+@inline rebuild(x, data, dims=dims(x)) = rebuild(x, data, dims, refdims(x))
 
 
 # Array interface methods ######################################################

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -6,6 +6,8 @@ the same types are used both for storing dimension information and for indexing.
 """
 abstract type AbstractDimension{T,G,M} end
 
+ConstructionBase.constructorof(d::Type{<:AbstractDimension}) = basetypeof(d)
+
 """
 AbstractCombined holds mapping that require multiple dimension
 when `select()` is used, shuch as for situations where they share an
@@ -37,14 +39,17 @@ indexorder(dim::AbDim) = indexorder(order(dim))
 arrayorder(dim::AbDim) = arrayorder(order(dim))
 
 # DimensionalData interface methods
-rebuild(dim::AbDim, val) = basetype(dim)(val, grid(dim), metadata(dim))
+rebuild(dim::D, val, grid=grid(dim)) where D <: AbDim = 
+    rebuild(dim, val, grid, metadata(dim))
+rebuild(dim::D, val, grid, metadata) where D <: AbDim = 
+    constructorof(D)(val, grid, metadata)
 
 dims(x::AbDim) = x
 dims(x::AbDimTuple) = x
 name(dim::AbDim) = name(typeof(dim))
 shortname(d::AbDim) = shortname(typeof(d))
 shortname(d::Type{<:AbDim}) = name(d)
-units(dim::AbDim) = metadata(dim) == nothing ? "" : get(metadata(dim), :units, "")
+units(dim::AbDim) = metadata(dim) == nothing ? nothing : get(metadata(dim), :units, nothing)
 
 bounds(A, args...) = bounds(dims(A), args...)
 bounds(dims::AbDimTuple, lookupdims::Tuple) = bounds(dims[[dimnum(dims, lookupdims)...]]...)
@@ -127,7 +132,7 @@ end
 Dim{X}(val=:; grid=AllignedGrid(), metadata=nothing) where X = Dim{X}(val, grid, metadata)
 name(::Type{<:Dim{X}}) where X = "Dim $X"
 shortname(::Type{<:Dim{X}}) where X = "$X"
-basetype(::Type{<:Dim{X,T,N}}) where {X,T,N} = Dim{X}
+basetypeof(::Type{<:Dim{X}}) where {X} = Dim{X}
 
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -25,21 +25,18 @@ array with more dimensions.
 
 `slicedims(a, dims)` returns a tuple containing the current new dimensions
 and the new reference dimensions. Refdims can be stored in a field or disgarded, 
-as it is mostly to give context to plots. Ignoring refdims will simply leave some 
-captions empty.
-"""
+as it is mostly to give context to plots. Ignoring refdims will simply leave some captions empty.  """
 function refdims end
 refdims(x) = ()
-
 """
-    rebuild(x, data, [dims], [refdims])
+    rebuild(x::AbstractDimensionalArray, data, [dims], [refdims])
+    rebuild(x::AbstractDimension, val, [grid], [metadata])
+    rebuild(x; kwargs...)
 
-Rebuild an object struct with an updated value 
+Rebuild an object struct with updated values.
 """
 function rebuild end
-@inline rebuild(x, data, dims=dims(x)) = rebuild(x, data, dims, refdims(x))
-@inline rebuild(x; data=data(x), dims=dims(x), refdims=refdims(x)) = 
-    rebuild(x, data, dims, refdims)
+rebuild(x; kwargs...) = ConstructionBase.setproperties(x, (;kwargs...))
 
 """
     val(x)
@@ -62,7 +59,7 @@ function metadata end
 Return the units of a dimension. This could be a string, a unitful unit, or nothing. 
 """
 function units end
-units(x) = ""
+units(x) = nothing
 units(xs::Tuple) = map(units, xs)
 
 """
@@ -92,8 +89,5 @@ Get a plot label for data or a dimension. This will include the name and units
 if they exist, and anything else that should be shown on a plot.
 """
 function label end
-label(x) = begin
-    u = getstring(units(x))
-    string(name(x), (u == "" ? "" : string(" ", u)))
-end
+label(x) = string(name(x), (units(x) === nothing ? "" : string(" ", units(x))))
 label(xs::Tuple) = join(map(label, xs), ", ")

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -43,10 +43,10 @@ Base._accumulate!(op, B, A, dims::AllDimensions, init::Union{Nothing, Some}) =
     Base._accumulate!(op, B, A, dimnum(A, dims), init)
 
 Base._dropdims(A::AbstractArray, dim::Union{AbDim,Type{<:AbDim}}) = 
-    rebuildsliced(A, Base._dropdims(A, dimnum(A, dim)), dims2indices(A, basetype(dim)(1)))
+    rebuildsliced(A, Base._dropdims(A, dimnum(A, dim)), dims2indices(A, basetypeof(dim)(1)))
 Base._dropdims(A::AbstractArray, dims::AbDimTuple) = 
     rebuildsliced(A, Base._dropdims(A, dimnum(A, dims)), 
-                  dims2indices(A, Tuple((basetype(d)(1) for d in dims))))
+                  dims2indices(A, Tuple((basetypeof(d)(1) for d in dims))))
 
 
 @inline Base.map(f, A::AbDimArray) = rebuild(A, map(f, parent(A)), dims(A))

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -67,7 +67,7 @@ sel2indices(grid::IndependentGrid{Unordered}, dim::AbDim, sel::Between{<:Tuple})
 # In practice the others could be empty.
 sel2indices(grids::Tuple{Vararg{<:TransformedGrid}}, dims::AbDimTuple, 
             sel::Tuple{Vararg{<:Selector}}) = 
-    map(to_int, sel, val(dims[1])(SVector(map(val, sel))))
+    map(to_int, sel, val(dims[1])([map(val, sel)...]))
 
 to_int(::At, x) = convert(Int, x) 
 to_int(::Near, x) = round(Int, x) 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,13 +1,10 @@
-basetype(x) = basetype(typeof(x))
-basetype(t::Type) = t.name.wrapper
-basetype(t::UnionAll) = t
+basetypeof(x) = basetypeof(typeof(x))
+basetypeof(t::Type) = t.name.wrapper
+basetypeof(t::UnionAll) = basetypeof(t.body)
 
+# Left pipe operator for cleaning up brackets
 f <| x = f(x) 
 
 # This shouldn't be hard coded, but it makes plots tolerable for now
 shorten(x::AbstractFloat) = round(x, sigdigits=3)
 shorten(x) = x
-
-# Nothing doesn't string
-getstring(::Nothing) = ""
-getstring(x) = string(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,7 @@
 basetypeof(x) = basetypeof(typeof(x))
-basetypeof(t::Type) = t.name.wrapper
-basetypeof(t::UnionAll) = basetypeof(t.body)
+@generated function basetypeof(::Type{T}) where T
+    getfield(parentmodule(T), nameof(T))
+end
 
 # Left pipe operator for cleaning up brackets
 f <| x = f(x) 

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -5,7 +5,7 @@
     @test shortname(TestDim) == "TestDim"
     @test val(TestDim(:test)) == :test
     @test metadata(TestDim(1, AllignedGrid(), "metadata")) == "metadata"
-    @test units(TestDim) == ""
+    @test units(TestDim) == nothing
     @test label(TestDim) == "Test dimension" 
     @test eltype(TestDim(1)) == Int
     @test eltype(TestDim([1,2,3])) == Vector{Int}
@@ -25,7 +25,7 @@ dimz = dims(da)
 @test slicedims(dimz, (2:4, 3)) == ((X(LinRange(142,146,3)),), (Y(8.0),))
 @test name(dimz) == ("X", "Y") 
 @test shortname(dimz) == ("X", "Y") 
-@test units(dimz) == ("", "") 
+@test units(dimz) == (nothing, nothing) 
 @test label(dimz) == ("X, Y") 
 
 a = [1 2 3 4 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using DimensionalData, Statistics, Test, BenchmarkTools, Unitful, SparseArrays
 
-using DimensionalData: val, basetype, slicedims, dims2indices, formatdims, 
-      @dim, reducedims, dimnum, basetype, X, Y, Z, Time, Forward
+using DimensionalData: val, basetypeof, slicedims, dims2indices, formatdims, 
+      @dim, reducedims, dimnum, X, Y, Z, Time, Forward
 
 include("dimension.jl")
 include("primitives.jl")

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -54,7 +54,7 @@ end
 end
 
 @testset "TranformedGrid " begin
-    using CoordinateTransformations, StaticArrays
+    using CoordinateTransformations
 
     m = LinearMap([0.5 0.0; 0.0 0.5])
 


### PR DESCRIPTION
Add constructorof methods and depend on construction base.

here `constructorof` wraps `basetypeof` that is both the base type and constructor (base as in it can't be deduced from the fields).

Fixing label string handling got mixed in by accident.