### PR TITLE
Improve selectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -51,7 +51,7 @@ std(a; dims=Y())
 """
 module DimensionalData
 
-using ConstructionBase, LinearAlgebra, RecipesBase, Statistics
+using ConstructionBase, LinearAlgebra, RecipesBase, Statistics, Dates
 
 using Base: tail, OneTo
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -78,7 +78,7 @@ export AbstractDimensionalArray, DimensionalArray
 export Metadata, AbstractArrayMetadata, ArrayMetadata, AbstractDimMetadata, DimMetadata
 
 export dims, refdims, metadata, name, shortname, 
-       val, label, units, order, bounds, grid, <|
+       val, label, units, order, bounds, locus, grid, <|
 
 include("interface.jl")
 include("metadata.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -7,7 +7,6 @@ const StandardIndices = Union{AbstractArray,Colon,Integer}
 # Interface methods ############################################################
 
 dims(A::AbDimArray) = A.dims
-label(A::AbDimArray) = ""
 bounds(A::AbDimArray) = bounds(dims(A))
 @inline rebuild(x, data, dims=dims(x)) = rebuild(x, data, dims, refdims(x))
 
@@ -48,7 +47,9 @@ Base.similar(A::AbDimArray) = rebuild(A, similar(parent(A)))
 Base.similar(A::AbDimArray, ::Type{T}) where T = rebuild(A, similar(parent(A), T))
 Base.similar(A::AbDimArray, ::Type{T}, I::Tuple{Int64,Vararg{Int64}}) where T = 
     rebuild(A, similar(parent(A), T, I))
-Base.similar(A::AbDimArray, ::Type{T}, I::Tuple{Union{Integer,OneTo},Vararg{Union{Integer,OneTo},N}}) where {T,N} =
+Base.similar(A::AbDimArray, ::Type{T}, I::Tuple{Union{Integer,AbstractRange},Vararg{Union{Integer,AbstractRange},N}}) where {T,N} =
+    rebuildsliced(A, similar(parent(A), T, I...), I)
+Base.similar(A::AbDimArray, ::Type{T}, I::Vararg{<:Integer}) where T =
     rebuildsliced(A, similar(parent(A), T, I...), I)
 Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{AbDimArray}}, ::Type{ElType}) where ElType = begin
     A = find_dimensional(bc)
@@ -58,12 +59,6 @@ end
 
 # Need to cover a few type signatures to avoid ambiguity with base
 # Don't remove these even though they look redundant
-Base.similar(A::AbDimArray, ::Type{T}, I::Vararg{<:Integer}) where T =
-    rebuildsliced(A, similar(parent(A), T, I...), I)
-Base.similar(A::AbDimArray, ::Type{T}, ::Tuple{Int,Vararg{Int}}) where T = 
-    rebuild(A, similar(parent(A), T))
-Base.similar(A::AbDimArray, ::Type{T}, I::Tuple{Union{Integer,OneTo},Vararg{Union{Integer,OneTo},N}}) where {T,N} =
-    rebuildsliced(A, similar(parent(A), T, I...), I)
 
 @inline find_dimensional(bc::Base.Broadcast.Broadcasted) = find_dimensional(bc.args)
 @inline find_dimensional(ext::Base.Broadcast.Extruded) = find_dimensional(ext.x)

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -22,14 +22,15 @@ struct Ordered{D,A} <: Order
 end
 Ordered() = Ordered(Forward(), Forward())
 
+indexorder(order::Ordered) = order.index
+arrayorder(order::Ordered) = order.array
+
 """
 Trait indicating that the array or dimension has no order.
 """
 struct Unordered <: Order end
 
-indexorder(order::Ordered) = order.index
 indexorder(order::Unordered) = Unordered()
-arrayorder(order::Ordered) = order.array
 arrayorder(order::Unordered) = Unordered()
 
 """
@@ -53,6 +54,9 @@ reverseindex(o::Ordered) = Ordered(reverse(indexorder(o)), arrayorder(o))
 
 reversearray(o::Unordered) = Unordered()
 reversearray(o::Ordered) = Ordered(indexorder(o), reverse(arrayorder(o)))
+
+isrev(::Forward) = false
+isrev(::Reverse) = true
 
 
 """

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -21,7 +21,7 @@ struct Ordered{D,A,R} <: Order
     array::A
     relation::R
 end
-Ordered() = Ordered(Forward(), Forward())
+Ordered() = Ordered(Forward(), Forward(), Forward())
 
 indexorder(order::Ordered) = order.index
 arrayorder(order::Ordered) = order.array
@@ -33,6 +33,7 @@ Trait indicating that the array or dimension has no order.
 struct Unordered{R} <: Order 
     relation::R
 end
+Unordered() = Unordered(Forward())
 
 indexorder(order::Unordered) = order
 arrayorder(order::Unordered) = order
@@ -135,6 +136,10 @@ arrayorder(grid::Grid) = arrayorder(order(grid))
 indexorder(grid::Grid) = indexorder(order(grid))
 relationorder(grid::Grid) = relationorder(order(grid))
 
+Base.reverse(g::Grid) = rebuild(g; order=reverse(order(g)))
+reversearray(g::Grid) = rebuild(g; order=reversearray(order(g)))
+reverseindex(g::Grid) = rebuild(g; order=reverseindex(order(g)))
+
 """
 Fallback grid type
 """
@@ -151,10 +156,6 @@ abstract type IndependentGrid{O} <: Grid end
 A grid dimension aligned exactly with a standard dimension, such as lattitude or longitude.
 """
 abstract type AbstractAllignedGrid{O} <: IndependentGrid{O} end
-
-Base.reverse(g::AbstractAllignedGrid) = rebuild(g; order=reverse(order(g)))
-reversearray(g::AbstractAllignedGrid) = rebuild(g; order=reversearray(order(g)))
-reverseindex(g::AbstractAllignedGrid) = rebuild(g; order=reverseindex(order(g)))
 
 order(g::AbstractAllignedGrid) = g.order
 locus(g::AbstractAllignedGrid) = g.locus

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -16,22 +16,27 @@ always happens in smallest to largest order.
 
 Base also defines Forward and Reverse, but they seem overly complicated for our purposes.
 """
-struct Ordered{D,A} <: Order
+struct Ordered{D,A,R} <: Order
     index::D
     array::A
+    relation::R
 end
 Ordered() = Ordered(Forward(), Forward())
 
 indexorder(order::Ordered) = order.index
 arrayorder(order::Ordered) = order.array
+relationorder(order::Ordered) = order.relation
 
 """
 Trait indicating that the array or dimension has no order.
 """
-struct Unordered <: Order end
+struct Unordered{R} <: Order 
+    relation::R
+end
 
-indexorder(order::Unordered) = Unordered()
-arrayorder(order::Unordered) = Unordered()
+indexorder(order::Unordered) = order
+arrayorder(order::Unordered) = order
+relationorder(order::Unordered) = order.relation
 
 """
 Trait indicating that the array or dimension is in the normal forward order.
@@ -46,14 +51,20 @@ struct Reverse <: Order end
 
 Base.reverse(::Reverse) = Forward()
 Base.reverse(::Forward) = Reverse()
-Base.reverse(o::Ordered) = Ordered(reverse(indexorder(o)), reverse(arrayorder(o)))
-Base.reverse(::Unordered) = Unordered()
+# Base.reverse(o::Ordered) = 
+    # Ordered(indexorder(o), reverse(relationorder(o)), reverse(arrayorder(o)))
+# Base.reverse(o::Unordered) = 
+    # Unordered(reverse(relationorder(o)))
 
-reverseindex(o::Unordered) = Unordered()
-reverseindex(o::Ordered) = Ordered(reverse(indexorder(o)), arrayorder(o))
+reverseindex(o::Unordered) = 
+    Unordered(reverse(relationorder(o)))
+reverseindex(o::Ordered) = 
+    Ordered(reverse(indexorder(o)), arrayorder(o), reverse(relationorder(o)))
 
-reversearray(o::Unordered) = Unordered()
-reversearray(o::Ordered) = Ordered(indexorder(o), reverse(arrayorder(o)))
+reversearray(o::Unordered) = 
+    Unordered(reverse(relationorder(o)))
+reversearray(o::Ordered) = 
+    Ordered(indexorder(o), reverse(arrayorder(o)), reverse(relationorder(o)))
 
 isrev(::Forward) = false
 isrev(::Reverse) = true
@@ -122,6 +133,7 @@ abstract type Grid end
 dims(g::Grid) = nothing
 arrayorder(grid::Grid) = arrayorder(order(grid))
 indexorder(grid::Grid) = indexorder(order(grid))
+relationorder(grid::Grid) = relationorder(order(grid))
 
 """
 Fallback grid type

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -216,7 +216,12 @@ regularise(::UnknownGrid, start, stop, len) =
 regularise(grid::Grid, start, stop, len) = grid
 
 spanof(a, b, len) = (b - a)/(len - 1)
-orderof(a, b) = Ordered(a <= b ? Forward() : Reverse(), Forward())
+orderof(a, b) = 
+    if a <= b
+        Ordered(Forward(), Forward(), Forward())
+    else
+        Ordered(Reverse(), Forward(), Forward())
+    end
 
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -157,6 +157,7 @@ Get the number of an AbstractDimension as ordered in the array
     end
 end
 
+hasdim(A, lookup::Tuple) = map(l -> hasdim(A, l), lookup)
 hasdim(A, lookup) = hasdim(typeof(dims(A)), typeof(lookup))
 hasdim(A, lookup::Type) = hasdim(typeof(dims(A)), lookup)
 @generated hasdim(dimtypes::Type{DTS}, lookup::Type{D}) where {DTS,D} = begin

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,3 +1,5 @@
+using DimensionalData, BenchmarkTools
+
 #= Benchmarks
 
 Test how much the recalculation of coordinates and dim types

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -1,11 +1,11 @@
 using DimensionalData, Test, Unitful
-
 using DimensionalData: X, Y, Z, Time, Forward, @dim, slicedims
 
 @dim TestDim "Test dimension" 
 
 @testset "dims creation macro" begin
     @test name(TestDim) == "Test dimension"
+    @test label(TestDim) == "Test dimension"
     @test shortname(TestDim) == "TestDim"
     @test val(TestDim(:test)) == :test
     @test metadata(TestDim(1, UnknownGrid(), "metadata")) == "metadata"

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -45,8 +45,8 @@ da = DimensionalArray(a, dimz)
     @test dims(dimz, X) === dimz[1]
     @test dims(dimz, Y) === dimz[2]
     @test_throws ArgumentError dims(dimz, Time)
-    @test typeof(dims(da)) == Tuple{X{LinRange{Float64},RegularGrid{Ordered{Forward,Forward},Start,UnknownSampling,Float64},Nothing},
-                                Y{LinRange{Float64},RegularGrid{Ordered{Forward,Forward},Start,UnknownSampling,Float64},Nothing}}
+    @test typeof(dims(da)) == Tuple{X{LinRange{Float64},RegularGrid{Ordered{Forward,Forward,Forward},Start,UnknownSampling,Float64},Nothing},
+                                Y{LinRange{Float64},RegularGrid{Ordered{Forward,Forward,Forward},Start,UnknownSampling,Float64},Nothing}}
 end
 
 @testset "arbitrary dim names" begin

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -1,3 +1,7 @@
+using DimensionalData, Test, Unitful
+
+using DimensionalData: X, Y, Z, Time, Forward, @dim, slicedims
+
 @dim TestDim "Test dimension" 
 
 @testset "dims creation macro" begin

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful
-using DimensionalData: X, Y, Z, Time, Forward, Reverse
+using DimensionalData: X, Y, Z, Time, Forward, Reverse, reversearray, reverseindex
 
 @testset "sampling" begin
 
@@ -8,9 +8,23 @@ end
 @testset "reverse" begin
     @test reverse(Reverse()) == Forward()
     @test reverse(Forward()) == Reverse()
-    @test reverse(Unordered()) == Unordered()
-    @test reverse(Ordered(Forward(), Reverse())) == Ordered(Forward(), Forward()) 
-    @test grid(reverse(AllignedGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Reverse()) 
-    @test grid(reverse(RegularGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Forward()) 
-    @test grid(reverse(CategoricalGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Forward()) 
+
+    @test reversearray(Unordered(Forward())) == 
+        Unordered(Reverse())
+    @test reversearray(Ordered(Forward(), Reverse(), Forward())) == 
+        Ordered(Forward(), Forward(), Reverse()) 
+
+    @test reverseindex(Unordered(Forward())) == 
+        Unordered(Reverse())
+    @test reverseindex(Ordered(Forward(), Reverse(), Forward())) == 
+        Ordered(Reverse(), Reverse(), Reverse()) 
+
+    @test order(reverseindex(AllignedGrid(order=Ordered(Forward(), Reverse(), Forward())))) == 
+        Ordered(Reverse(), Reverse(), Reverse()) 
+    @test order(reversearray(AllignedGrid(order=Ordered(Forward(), Reverse(), Forward())))) == 
+        Ordered(Forward(), Forward(), Reverse()) 
+    @test order(reverseindex(RegularGrid(order=Ordered(Forward(), Reverse(), Reverse())))) == 
+        Ordered(Reverse(), Reverse(), Forward()) 
+    @test order(reverseindex(CategoricalGrid(order=Ordered(Forward(), Reverse(), Reverse())))) == 
+        Ordered(Reverse(), Reverse(), Forward())
 end

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -1,10 +1,5 @@
 using DimensionalData, Test, Unitful
-
-using DimensionalData: X, Y, Z, Time, Forward
-
-@testset "bounds" begin
-
-end
+using DimensionalData: X, Y, Z, Time, Forward, Reverse
 
 @testset "sampling" begin
 
@@ -12,10 +7,10 @@ end
 
 @testset "reverse" begin
     @test reverse(Reverse()) == Forward()
-    @test reverse(Forward()) == RegularGrid()
+    @test reverse(Forward()) == Reverse()
     @test reverse(Unordered()) == Unordered()
-    @test reverse(Ordered(Forward(), Reverse())) == Ordered(Reverse(), Forward()) 
-    @test grid(reverse(AllignedGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Forward()) 
+    @test reverse(Ordered(Forward(), Reverse())) == Ordered(Forward(), Forward()) 
+    @test grid(reverse(AllignedGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Reverse()) 
     @test grid(reverse(RegularGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Forward()) 
     @test grid(reverse(CategoricalGrid(grid=Ordered(Forward(), Reverse())))) == Ordered(Reverse(), Forward()) 
 end

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -1,3 +1,7 @@
+using DimensionalData, Test, Unitful
+
+using DimensionalData: X, Y, Z, Time, Forward
+
 @testset "bounds" begin
 
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,3 +1,7 @@
+using DimensionalData, Statistics, Test, Unitful, SparseArrays
+
+using DimensionalData: X, Y, Z, Time
+
 using LinearAlgebra: Transpose
 
 @testset "dimension reducing methods" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,6 +1,6 @@
 using DimensionalData, Test
 
-using DimensionalData: val, basetypeof, slicedims, dims2indices, formatdims, 
+using DimensionalData: val, basetypeof, slicedims, dims2indices, formatdims, hasdim,
       @dim, reducedims, dimnum, X, Y, Z, Time, Forward
 
 dimz = (X(), Y())
@@ -23,13 +23,16 @@ da = DimensionalArray(a, (X((143, 145)), Y((-38, -36))))
 dimz = dims(da) 
 
 @testset "slicedims" begin
-    @test slicedims(dimz, (1:2, 3)) == ((X(LinRange(143,145,2); grid=RegularGrid(span=2.0)),), (Y(-36.0; grid=RegularGrid(span=1.0)),))
+    @test slicedims(dimz, (1:2, 3)) == ((X(LinRange(143,145,2); grid=RegularGrid(span=2.0)),), 
+                                        (Y(-36.0; grid=RegularGrid(span=1.0)),))
     @test slicedims(dimz, (2:2, :)) == ((X(LinRange(145,145,1); grid=RegularGrid(span=2.0)), 
                                          Y(LinRange(-38.0,-36.0,3); grid=RegularGrid(span=1.0))), ())
+    @test slicedims((), (1:2, 3)) == ((), ())
 end
 
 @testset "dims2indices" begin
     emptyval = Colon()
+    @test dims2indices(grid(dimz[1]), dimz[1], Y, Nothing) == Colon()
     @test dims2indices(dimz, (Y(),), emptyval) == (Colon(), Colon())
     @test dims2indices(dimz, (Y(1),), emptyval) == (Colon(), 1)
     # Time is just ignored if it's not in dims. Should this be an error?
@@ -47,8 +50,26 @@ end
     @test dimnum(da, X) == 1
     @test dimnum(da, Y()) == 2
     @test dimnum(da, (Y, X())) == (2, 1)
+    @test_throws ArgumentError dimnum(da, Time) == (2, 1)
 end
 
 @testset "reducedims" begin
     @test reducedims((X(3:4), Y(1:5)), (X, Y)) == (X(3), Y(1))
+end
+
+@testset "dims" begin
+    @test typeof(dims(da, X)) <: X 
+    @test typeof(dims(dims(da), Y)) <: Y 
+    @test dims(da, ()) == ()
+    @test_throws ArgumentError dims(da, Time)
+    d = dims(da[1])
+    @test dims(d) == d
+end
+
+@testset "hasdims" begin
+    @test hasdim(da, X) == true
+    @test hasdim(da, Time) == false
+    @test hasdim(dims(da), Y) == true
+    @test hasdim(dims(da), (X, Y)) == (true, true)
+    @test hasdim(dims(da), (X, Time)) == (true, false)
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -62,8 +62,8 @@ end
     @test typeof(dims(dims(da), Y)) <: Y 
     @test dims(da, ()) == ()
     @test_throws ArgumentError dims(da, Time)
-    d = dims(da[1])
-    @test dims(d) == d
+    x = dims(da, X)
+    @test dims(x) == x
 end
 
 @testset "hasdims" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,3 +1,8 @@
+using DimensionalData, Test
+
+using DimensionalData: val, basetypeof, slicedims, dims2indices, formatdims, 
+      @dim, reducedims, dimnum, X, Y, Z, Time, Forward
+
 dimz = (X(), Y())
 
 @testset "permutedims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 include("dimension.jl")
 include("primitives.jl")
 include("array.jl")
+include("grid.jl")
 include("selector.jl")
 include("methods.jl")
 include("benchmarks.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,3 @@
-using DimensionalData, Statistics, Test, BenchmarkTools, Unitful, SparseArrays
-
-using DimensionalData: val, basetypeof, slicedims, dims2indices, formatdims, 
-      @dim, reducedims, dimnum, X, Y, Z, Time, Forward
-
 include("dimension.jl")
 include("primitives.jl")
 include("array.jl")

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -123,7 +123,7 @@ end
         # Using selectors works the same as indexing with grid
         # dims - it applies the transform function. 
         # It's not clear this should be allowed or makes sense, 
-        # but it works anyway because the permutatoin is correct either way.
+        # but it works anyway because the permutation is correct either way.
         @test da[Dim{:trans1}(At(6)), Dim{:trans2}(At(2))] == 9
     end
 

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1,45 +1,95 @@
-a = [1 2  3  4
-     5 6  7  8
-     9 10 11 12]
-da = DimensionalArray(a, (Y(10:30), Time((1:4)u"s")))
-dims(da)
-
-@testset "selectors with dim wrappers" begin
-    @test da[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [1 4; 9 12]
-    @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1u"s", 4u"s"])]
-    @test view(da, Y<|At(20), Time<|At((3:4)u"s")) == [7, 8]
-    @test view(da, Y<|Near(17), Time<|Near([1.3u"s", 3.3u"s"])) == [5, 7]
-    @test view(da, Y<|Between(9, 31), Time<|At((3:4)u"s")) == [3 4; 7 8; 11 12]
-end
-
-@testset "selectors without dim wrappers" begin
-    @test da[At(20:10:30), At(1u"s")] == [5, 9]
-    @test view(da, Between(9, 31), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
-    @test view(da, Near(22), At(3u"s", 4u"s")) == [7, 8]
-    @test view(da, At(20), At((2:3)u"s")) == [6, 7]
-    @test view(da, Near<|13, Near<|[1.3u"s", 3.3u"s"]) == [1, 3]
-    # Near works with a tuple input
-    @test view(da, Near<|(13,), Near<|(1.3u"s", 3.3u"s")) == [1 3]
-    @test view(da, Between(11, 20), At((2:3)u"s")) == [6 7]
-    # Between also accepts a tuple input
-    @test view(da, Between((11, 20)), Between((2u"s", 3u"s"))) == [6 7]
-end
-
-@testset "setindex! with selectors" begin
-    da[Near(11), At(3u"s")] = 100
-    @test a[1, 3] == 100
-    da[Time<|Near(2.2u"s"), Y<|Between(10, 30)] = [200, 201, 202]
-    @test a[1:3, 2] == [200, 201, 202] 
-end
+using DimensionalData, Test, Unitful
+using DimensionalData: X, Y, Z, Time, Forward, Reverse, Ordered, arrayorder, indexorder
 
 a = [1 2  3  4
      5 6  7  8
      9 10 11 12]
 
-@testset "more Unitful dims" begin
-    dimz = Time<|1.0u"s":1.0u"s":3.0u"s", Y<|(1u"km", 4u"km")
-    da = DimensionalArray(a, dimz)
-    @test da[Y<|Between(2u"km", 3.9u"km"), Time<|At<|3.0u"s"] == [10, 11]
+@testset "Selectors on IndependentGrid" begin
+    da = DimensionalArray(a, (Y(10:30), Time((1:4)u"s")))
+    dims(da)
+
+    @test At(10.0) == At(10.0, 0.0, Base.rtoldefault(eltype(10.0)))
+    x = [10.0, 20.0]
+    @test At(x) === At(x, 0.0, Base.rtoldefault(eltype(10.0)))
+    @test At((10.0, 20.0)) === At((10.0, 20.0), 0.0, Base.rtoldefault(eltype(10.0)))
+
+    Near([10, 20])
+
+    @test Between(10, 20) == Between((10, 20))
+
+    @testset "selectors with dim wrappers" begin
+        @test da[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [1 4; 9 12]
+        @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1u"s", 4u"s"])]
+        @test view(da, Y<|At(20), Time<|At((3:4)u"s")) == [7, 8]
+        @test view(da, Y<|Near(17), Time<|Near([1.5u"s", 3.1u"s"])) == [5, 7]
+        @test view(da, Y<|Between(9, 21), Time<|At((3:4)u"s")) == [3 4; 7 8]
+    end
+
+    @testset "selectors without dim wrappers" begin
+        @test da[At(20:10:30), At(1u"s")] == [5, 9]
+        @test view(da, Between(9, 31), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
+        @test view(da, Near(22), At([3.0u"s", 4.0u"s"])) == [7, 8]
+        @test view(da, At(20), At((2:3)u"s")) == [6, 7]
+        @test view(da, Near<|13, Near<|[1.3u"s", 3.3u"s"]) == [1, 3]
+        # Near works with a tuple input
+        @test view(da, Near<|(13,), Near<|[1.3u"s", 3.3u"s"]) == [1 3]
+        @test view(da, Between(11, 20), At((2:3)u"s")) == [6 7]
+        # Between also accepts a tuple input
+        @test view(da, Between((11, 20)), Between((2u"s", 3u"s"))) == [6 7]
+    end
+
+    @testset "more Unitful dims" begin
+        dimz = Time<|1.0u"s":1.0u"s":3.0u"s", Y<|(1u"km", 4u"km")
+        db = DimensionalArray(a, dimz)
+        @test db[Y<|Between(2u"km", 3.9u"km"), Time<|At<|3.0u"s"] == [10, 11]
+    end
+
+    @testset "selectors work in reverse orders" begin
+        # @testset "all reverse is the same as all forward" begin
+        #     da_rr = DimensionalArray(a, (Y(30:-10:10; grid=RegularGrid(order=Ordered(Reverse(), Forward()))), 
+        #                                  Time((4:-1:1)u"s"; grid=RegularGrid(order=Ordered(Reverse(), Forward())))))
+        #     slice = da_rr[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])]
+        #     @test slice == [12 9; 4 1]
+        #     @test arrayorder(dims(slice, Time)) == Forward()
+        #     @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1.0u"s", 4.0u"s"])]
+        #     @test da_rr[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [6, 5]
+        #     @test da_rr[Y<|Near(7), Time<|Near([1.3u"s", 3.3u"s"])] == [8, 6]
+        #     @test da_rr[Y<|Between(9, 21), Time<|At((3.0:4.0)u"s")] == [3 4; 7 8]
+        # end
+
+        # @testset "all reverse is the same as all forward" begin
+        #     da_rr = DimensionalArray(a, (Y(30:-10:10; grid=RegularGrid(order=Ordered(Reverse(), Reverse()))), 
+        #                                  Time((4:-1:1)u"s"; grid=RegularGrid(order=Ordered(Reverse(), Reverse())))))
+        #     @test da_rr[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [1 4; 9 12]
+        #     @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1u"s", 4u"s"])]
+        #     @test da_rr[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [7, 8]
+        #     @test da_rr[Y<|Near(17), Time<|Near([1.3u"s", 3.3u"s"])] == [5, 7]
+        #     @test da_rr[Y<|Between(9, 21), Time<|At((3:4)u"s")] == [3 4; 7 8]
+        # end
+
+        # @testset "all reverse is the same as all forward" begin
+        #     da_rr = DimensionalArray(a, (Y(10:30; grid=RegularGrid(order=Ordered(Forward(), Reverse()))), 
+        #                                  Time((1:4)u"s"; grid=RegularGrid(order=Ordered(Forward(), Reverse())))))
+        #     @test da_rr[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [1 4; 9 12]
+        #     @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1u"s", 4u"s"])]
+        #     @test da_rr[Y<|At(20), Time<|At((3:4)u"s")] == [7, 8]
+        #     @test da_rr[Y<|Near(17), Time<|Near([1.3u"s", 3.3u"s"])] == [5, 7]
+        #     @test da_rr[Y<|Between(9, 21), Time<|At((3:4)u"s")] == [3 4; 7 8]
+        # end
+
+    end
+
+
+    @testset "setindex! with selectors" begin
+        c = deepcopy(a)
+        dc = DimensionalArray(c, (Y(10:30), Time((1:4)u"s")))
+        dc[Near(11), At(3u"s")] = 100
+        @test c[1, 3] == 100
+        dc[Time<|Near(2.2u"s"), Y<|Between(10, 30)] = [200, 201, 202]
+        @test c[1:3, 2] == [200, 201, 202] 
+    end
+
 end
 
 
@@ -47,7 +97,7 @@ end
     dimz = Time([:one, :two, :three]; grid=CategoricalGrid()), 
            Y([:a, :b, :c, :d]; grid=CategoricalGrid())
     da = DimensionalArray(a, dimz)
-    @test da[Time<|At(:one, :two), Y<|At(:b)] == [2, 6]
+    @test da[Time<|At([:one, :two]), Y<|At(:b)] == [2, 6]
     @test da[At([:one, :three]), At([:b, :c, :d])] == [2 3 4; 10 11 12]
     @test da[At(:two), Between(:b, :d)] == [6, 7, 8]
     # Near doesn't make sense for categories
@@ -66,9 +116,6 @@ end
         @test permutedims((Y(), X()), dimz) == (X(), Y())
     end
 
-    a = [1 2  3  4
-         5 6  7  8
-         9 10 11 12]
     da = DimensionalArray(a, dimz) 
 
     @testset "Indexing with array dims indexes the array as usual" begin


### PR DESCRIPTION
Test and improve selector behaviour, including adding tolerances to `At` selectors. The default eps based tolerance  of `rtol` fixes missed matches due to floating point errors in `LinRange`.