### PR TITLE
export @dim macro

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -78,6 +78,8 @@ export AbstractDimensionalArray, DimensionalArray
 export data, dims, refdims, metadata, name, shortname, 
        val, label, units, order, bounds, locus, grid, <|
 
+export @dim
+
 include("interface.jl")
 include("grid.jl")
 include("dimension.jl")


### PR DESCRIPTION
This is an important macro in the case where a dimension does not pre-exist, and as far as I can tell, the go-to way to create a dimension with a specified name instead of `Dim{:symbol}`. The readme docs also use it as unspecified.