### PR TITLE
multiply methods

### DIFF
--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -111,6 +111,13 @@ shortname(::Type{<:Dim{X}}) where X = "$X"
 basetypeof(::Type{<:Dim{X}}) where {X} = Dim{X}
 
 
+struct EmptyDim <: AbstractDimension{Int,NoGrid,Nothing} end
+
+val(::EmptyDim) = 1:1
+grid(::EmptyDim) = NoGrid()
+metadata(::EmptyDim) = nothing
+name(::EmptyDim) = "Empty"
+
 """
     @dim typ [name=string(typ)] [shortname=string(typ)]
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -3,6 +3,9 @@
 
 const UnionAllTupleOrVector = Union{Vector{UnionAll},Tuple{UnionAll,Vararg}}
 
+_dimsmatch(a::DimOrDimType, b::DimOrDimType) = 
+    basetypeof(a) <: basetypeof(b) || basetypeof(dims(grid(a))) <: basetypeof(b)
+
 """
 Sort dimensions into the order they take in the array.
 
@@ -10,8 +13,6 @@ Missing dimensions are replaced with `nothing`
 """
 @inline Base.permutedims(tosort::AbDimTuple, perm::Union{Vector{<:Integer},Tuple{<:Integer,Vararg}}) =
     map(p -> tosort[p], Tuple(perm))
-@inline Base.permutedims(tosort::Union{Vector{<:Integer},Tuple{<:Integer,Vararg}}, perm::AbDimTuple) =
-    tosort
 
 @inline Base.permutedims(tosort::AbDimTuple, order::UnionAllTupleOrVector) =
     permutedims(tosort, Tuple(map(d -> constructorof(d)(), order)))
@@ -22,33 +23,25 @@ Missing dimensions are replaced with `nothing`
 @inline Base.permutedims(tosort::AbDimVector, order::AbDimTuple) =
     permutedims(Tuple(tosort), order)
 @inline Base.permutedims(tosort::AbDimTuple, order::AbDimTuple) =
-    Base.permutedims(tosort, order, map(d -> dims(grid(d)), order))
-@generated Base.permutedims(tosort::AbDimTuple, order::AbDimTuple, griddims) =
-    permutedims_inner(tosort, order, griddims)
+    Base.permutedims(tosort, order)
 
-permutedims_inner(tosort::Type, order::Type, griddims::Type) = begin
-    indexexps = []
-    for (i, dim) in enumerate(order.parameters)
-        dimindex = findfirst(d -> basetypeof(d) <: basetypeof(dim), tosort.parameters)
-        if dimindex == nothing
-            # The grid may allow dimensions not in dims
-            # that will be transformed to the actual dimensions (ie for rotations).
-            if griddims <: Nothing
-                push!(indexexps, :(nothing))
-            else
-                gridindex = findfirst(d -> basetypeof(d) <: basetypeof(griddims.parameters[i]), tosort.parameters)
-                if gridindex == nothing
-                    push!(indexexps, :(nothing))
-                else
-                    push!(indexexps, :(tosort[$gridindex]))
-                end
-            end
-        else
-            push!(indexexps, :(tosort[$dimindex]))
-        end
+Base.permutedims(tosort::AbDimTuple, order::AbDimTuple) =
+    _sortdims(tosort, order, ())
+
+_sortdims(tosort::Tuple, order::Tuple, rejected) =
+    # Match dims to the order, and also check if the grid has a
+    # transformed dimension that matches
+    if _dimsmatch(order[1], tosort[1])
+        (tosort[1], _sortdims((rejected..., tail(tosort)...), tail(order), ())...)
+    else
+        _sortdims(tail(tosort), order, (rejected..., tosort[1]))
     end
-    Expr(:tuple, indexexps...)
-end
+# Return nothing and start on a new dim
+_sortdims(tosort::Tuple{}, order::Tuple, rejected) =
+    (nothing, _sortdims(rejected, tail(order), ())...)
+# Return an empty tuple if we run out of dims to sort
+_sortdims(tosort::Tuple, order::Tuple{}, rejected) = ()
+_sortdims(tosort::Tuple{}, order::Tuple{}, rejected) = ()
 
 
 """
@@ -114,10 +107,6 @@ the new struct but are useful to give context to plots.
 Called at the array level the returned tuple will also include the
 previous reference dims attached to the array.
 """
-@inline slicedims(A, dims::AbDimTuple) = slicedims(A, dims2indices(A, dims))
-@inline slicedims(dims2slice::AbDimTuple, dims::AbDimTuple) =
-    slicedims(dims2slice, dims2indices(dims2slice, dims))
-@inline slicedims(dims2slice::AbDimTuple, dims::Tuple{}) = ()
 # Results are split as (dims, refdims)
 @inline slicedims(A, I::Tuple) = slicedims(dims(A), refdims(A), I)
 @inline slicedims(dims::Tuple, refdims::Tuple, I::Tuple{}) = dims, refdims
@@ -147,36 +136,54 @@ end
 
 
 """
-Get the number of an AbstractDimension as ordered in the array
+    dimnum(A, lookup)
+
+Get the number(s) of `AbstractDimension`(s) as ordered in the
+dimensions of an object.
 """
-@inline dimnum(A, lookup) = dimnum(typeof(dims(A)), lookup)
-@inline dimnum(dimtypes::Type, lookup::AbstractArray) = dimnum(dimtypes, (lookup...,))
-@inline dimnum(dimtypes::Type, lookup::Number) = lookup
-@inline dimnum(dimtypes::Type, lookup::Tuple) =
-    (dimnum(dimtypes, lookup[1]), dimnum(dimtypes, tail(lookup))...,)
-@inline dimnum(dimtypes::Type, lookup::Tuple{}) = ()
-@inline dimnum(dimtypes::Type, lookup::AbDim) = dimnum(dimtypes, typeof(lookup))
-@generated dimnum(dimtypes::Type{DTS}, lookup::Type{D}) where {DTS,D} = begin
-    index = findfirst(dt -> D <: basetypeof(dt), DTS.parameters)
-    if index == nothing
-        :(throw(ArgumentError("No $lookup in $dimtypes")))
+@inline dimnum(A, lookup) = dimnum(A, (lookup,))[1]
+@inline dimnum(A, lookup::AbstractArray) = dimnum(A, (lookup...,))
+@inline dimnum(A, lookup::Tuple) = dimnum(dims(A), lookup, (), 1)
+# Match dim and lookup, also check if the grid has a transformed dimension that matches
+@inline dimnum(d::Tuple, lookup::Tuple, rejected, n) =
+    if !(d[1] isa Nothing) && _dimsmatch(d[1], lookup[1])
+        # Replace found dim with nothing so it isn't found again but n is still correct
+        (n, dimnum((rejected..., nothing, tail(d)...), tail(lookup), (), 1)...)
     else
-        :($index)
+        dimnum(tail(d), lookup, (rejected..., d[1]), n + 1)
     end
-end
+# Numbers are returned as-is
+@inline dimnum(d::Tuple, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
+@inline dimnum(d::Tuple{}, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
+# Throw an error if the lookup is not found
+@inline dimnum(d::Tuple{}, lookup::Tuple, rejected, n) =
+    throw(ArgumentError("No $(basetypeof(lookup[1])) in dims"))
+# Return an empty tuple when we run out of lookups
+@inline dimnum(d::Tuple, lookup::Tuple{}, rejected, n) = ()
+@inline dimnum(d::Tuple{}, lookup::Tuple{}, rejected, n) = ()
 
-hasdim(A, lookup::Tuple) = map(l -> hasdim(A, l), lookup)
-hasdim(A, lookup) = hasdim(typeof(dims(A)), typeof(lookup))
-hasdim(A, lookup::Type) = hasdim(typeof(dims(A)), lookup)
-@generated hasdim(dimtypes::Type{DTS}, lookup::Type{D}) where {DTS,D} = begin
-    index = findfirst(dt -> D <: basetypeof(dt), DTS.parameters)
-    if index == nothing
-        :(false)
+"""
+    hasdim(A, lookup)
+
+Check if an object or tuple contains an `AbstractDimension`,
+or a tuple of dimensions.
+"""
+@inline hasdim(A, lookup::Tuple) = map(l -> hasdim(dims(A), l), lookup)
+@inline hasdim(A, lookup::DimOrDimType) = hasdim(dims(A), lookup)
+@inline hasdim(d::Tuple, lookup::DimOrDimType) =
+    if _dimsmatch(d[1], lookup)
+        true
     else
-        :(true)
+        hasdim(tail(d), lookup)
     end
-end
+@inline hasdim(::Tuple{}, ::DimOrDimType) = false
 
+"""
+    setdim(x, newdim)
+
+Replaces the first dim matching newdim, with newdim, and returns
+a new object or tuple with the dimension updated.
+"""
 setdim(A, newdim::AbDim) = rebuild(A; dims=setdim(dims(A), newdim))
 setdim(dims::AbDimTuple, newdim::AbDim) = map(d -> setdim(d, newdim), dims)
 setdim(dim::AbDim, newdim::AbDim) =
@@ -289,21 +296,31 @@ reducedims(locus::Center, dim) = begin
 end
 
 
-
 """
+    dims(A, lookup)
+
 Get the dimension(s) matching the type(s) of the lookup dimension.
+
+Lookup can be an Int or an AbstractDimension, or a tuple containing
+any combination of either.
 """
 @inline dims(A::AbstractArray, lookup) = dims(dims(A), lookup)
-@inline dims(ds::AbDimTuple, lookup::Integer) = ds[lookup]
-@inline dims(ds::AbDimTuple, lookup::Tuple) =
-    (dims(ds, lookup[1]), dims(ds, tail(lookup))...)
-@inline dims(ds::AbDimTuple, lookup::Tuple{}) = ()
-@inline dims(ds::AbDimTuple, lookup) = dims(ds, basetypeof(lookup))
-@generated dims(ds::DT, lookup::Type{L}) where {DT<:AbDimTuple,L} = begin
-    index = findfirst(dt -> dt <: L, DT.parameters)
-    if index == nothing
-        :(throw(ArgumentError("No $lookup in $dims")))
+@inline dims(d::AbDimTuple, lookup) = dims(d, (lookup,))[1]
+@inline dims(d::AbDimTuple, lookup::Tuple) = _dims(d, lookup, (), d)
+
+@inline _dims(d, lookup::Tuple, rejected, remaining) =
+    if !(remaining[1] isa Nothing) && _dimsmatch(remaining[1], lookup[1])
+        # Remove found dim so it isn't found again
+        (remaining[1], _dims(d, tail(lookup), (), (rejected..., tail(remaining)...))...)
     else
-        :(ds[$index])
+        _dims(d, lookup, (rejected..., remaining[1]), tail(remaining))
     end
-end
+# Numbers are returned as-is
+@inline _dims(d, lookup::Tuple{Number,Vararg}, rejected, remaining::Tuple{AbDim,Vararg}) =
+    (d[lookup[1]], _dims(d, tail(lookup), (), (rejected..., remaining...))...)
+# Throw an error if the lookup is not found
+@inline _dims(d, lookup::Tuple, rejected, remaining::Tuple{}) =
+    throw(ArgumentError("No $(basetypeof(lookup[1])) in dims"))
+# Return an empty tuple when we run out of lookups
+@inline _dims(d, lookup::Tuple{}, rejected, remaining::Tuple) = ()
+@inline _dims(d, lookup::Tuple{}, rejected, remaining::Tuple{}) = ()

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful
-using DimensionalData: X, Y, Z, Time, Forward, @dim, slicedims
+using DimensionalData: X, Y, Z, Time, Forward, @dim, slicedims, dimnum, hasdim
 
 @dim TestDim "Test dimension" 
 
@@ -41,8 +41,7 @@ dimz = dims(da)
 a = [1 2 3 4 
      2 3 4 5
      3 4 5 6]
-dimz = (X((143, 145), UnknownGrid(), nothing), 
-        Y((-38, -35), UnknownGrid(), nothing))
+dimz = X((143, 145)), Y((-38, -35))
 da = DimensionalArray(a, dimz)
 
 @testset "dims" begin
@@ -59,4 +58,13 @@ end
     @test name(dimz) == ("Dim row", "Dim column")
     @test shortname(dimz) == ("row", "column")
     @test label(dimz) == ("Dim row, Dim column")
+end
+
+@testset "repeating dims of the same type is allowed" begin
+    dimz = X((143, 145)), X((-38, -35))
+    @test dims(dimz, X) === dimz[1]
+    @test dims(dimz, (X, X)) === dimz
+    @test dimnum(dimz, (X, X)) === (1, 2)
+    @test hasdim(dimz, (X, X)) === (true, true)
+    @test permutedims(dimz, (X, X)) === dimz
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,8 +1,43 @@
-using DimensionalData, Statistics, Test, Unitful, SparseArrays
+using DimensionalData, Statistics, Test, Unitful, SparseArrays, Dates
 
-using DimensionalData: X, Y, Z, Time
+using DimensionalData: X, Y, Z, Time, EmptyDim
 
 using LinearAlgebra: Transpose
+
+@testset "*" begin
+    timespan = DateTime(2001):Month(1):DateTime(2001,12)
+    A1 = DimensionalArray(rand(12), (Time(timespan),)) 
+    A2 = DimensionalArray(rand(12, 1), (Time(timespan), X(10:10:10))) 
+
+    @test length.(dims(A1)) == size(A1)
+    @test dims(data(A1) * permutedims(A1)) isa Tuple{<:Time,<:Time}
+    @test data(A1) * permutedims(A1) == data(A1) * permutedims(data(A1))
+    @test dims(permutedims(A1) * data(A1)) isa Tuple{<:EmptyDim}
+    @test permutedims(A1) * data(A1) == permutedims(data(A1)) * data(A1)
+
+    @test length.(dims(permutedims(A1) * data(A1))) == size(permutedims(data(A1)) * data(A1))
+    @test length.(dims(permutedims(A1) * A1)) == size(permutedims(data(A1)) * data(A1))
+    @test length.(dims(permutedims(data(A1)) * A1)) == size(permutedims(data(A1)) * data(A1))
+
+    @test length.(dims(data(A1) * permutedims(A1))) == size(data(A1) * permutedims(data(A1)))
+    @test length.(dims(A1 * permutedims(A1))) == size(data(A1) * permutedims(data(A1)))
+    @test length.(dims(A1 * permutedims(data(A1)))) == size(data(A1) * permutedims(data(A1)))
+
+    @test length.(dims(A2)) == size(A2)
+    @test length.(dims(A2')) == size(A2')
+
+    sze1 = (12, 12)
+    @test size(data(A2) * data(A2)') == sze1
+    @test length.(dims(A2 * A2')) == sze1
+    @test length.(dims(data(A2) * A2')) == sze1
+    @test length.(dims(A2 * data(A2'))) == sze1
+    sze2 = (1, 1)
+    @test size(data(A2') * data(A2)) == sze2
+    @test length.(dims(A2' * A2)) == sze2
+    @test length.(dims(data(A2') * A2)) == sze2
+    @test length.(dims(A2' * data(A2))) == sze2
+
+end
 
 
 @testset "map" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -86,6 +86,9 @@ end
     @test dims(da, X) isa X
     @test dims(da, (X, Y)) isa Tuple{<:X,<:Y}
     @test dims(dims(da), Y) isa Y
+    @test dims(dims(da), 1) isa X
+    @test dims(dims(da), (2, 1)) isa Tuple{<:Y,<:X}
+    @test dims(dims(da), (2, Y)) isa Tuple{<:Y,<:Y}
     @test dims(da, ()) == ()
     @test_throws ArgumentError dims(da, Time)
     x = dims(da, X)


### PR DESCRIPTION
Closes #47

This is mostly working, although it runs into problems with `Adjoint`/`Transpose`, as multiplying them can return a scalar instead of a length 1 array.

We'll need to match the internal `Adjoint`/`Transpose` arrays with a second method. Which is annoying, and I don't have time for now.