### PR TITLE
Further improve pretty printing

### DIFF
--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -61,10 +61,10 @@ end
 # printing for DimensionalArray
 function Base.show(io::IO, A::AbDimArray)
     l = nameof(typeof(A))
-    printstyled(io, nameof(typeof(A)); color=:magenta)
+    printstyled(io, nameof(typeof(A)); color=:blue)
     if label(A) != ""
         print(io, " (labelled ")
-        printstyled(io, label(A); color=:magenta)
+        printstyled(io, label(A); color=:blue)
         print(io, ")")
     end
 

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -1,14 +1,73 @@
-# Credit to Sebastian Pfitzner for `printlimited`
-function printlimited(io, x; Δx = 0)
-    sz = displaysize(io)
-    ctx = IOContext(io, :limit => true, :compact => true,
-    :displaysize => (1, sz[2]-Δx))
-    Base.print(ctx, x)
+function printlimited(io, v::AbstractVector)
+    s = string(eltype(v))*"["
+    if length(v) > 5
+        svals = "$(v[1]), $(v[2]), …, $(v[end-1]), $(v[end])"
+    else
+        svals = join((string(va) for va in v), ", ")
+    end
+    print(io, s*svals*"]")
 end
 
+# Thanks to Michael Abbott for the following function
+function custom_show_nd(io::IO, A::AbstractArray{T, N}) where {T,N}
+    o = ones(Int, length(size(A))-2)
+    frame = A[:, :, o...]
+    onestring = join(o, ", ")
+    println(io, "[:, :, $(onestring)]")
+    Base.print_matrix(IOContext(io, :compact => true, :limit=>true), frame)
+    print(io, "\n[and ", prod(size(A,d) for d=3:N) - 1," more slices...]")
+end
+
+custom_show_nd(io::IO, A::AbstractArray{T, 2}) where {T} =
+Base.print_matrix(IOContext(io, :compact => true, :limit=>true), A)
+
+custom_show_nd(io::IO, A::AbstractArray{T, 1}) where {T} =
+Base.show(IOContext(io, :compact => true, :limit=>true), A)
+
+# Full printing version for dimensions
+function Base.show(io::IO, ::MIME"text/plain", dim::AbDim)
+    print(io, "dimension ")
+    printstyled(io, name(dim); color=:red)
+    if name(dim) ≠ string(nameof(typeof(dim)))
+        print(io, " (type ")
+        printstyled(io, nameof(typeof(dim)); color=:red)
+        print(io, ")")
+    end
+    print(io, ": ")
+
+    printstyled(io, "\nval: "; color=:green)
+    printlimited(io, val(dim))
+    printstyled(io, "\ngrid: "; color=:yellow)
+    show(io, grid(dim))
+    printstyled(io, "\nmetadata: "; color=:blue)
+    show(io, metadata(dim))
+    printstyled(io, "\ntype: "; color=:cyan)
+    show(io, typeof(dim))
+end
+
+# short printing version for dimensions
+function Base.show(io::IO, dim::AbDim)
+    printstyled(io, name(dim); color=:red)
+    if name(dim) ≠ string(nameof(typeof(dim)))
+        print(io, " (type ")
+        printstyled(io, nameof(typeof(dim)); color=:red)
+        print(io, ")")
+    end
+    print(io, ": ")
+
+    printlimited(io, val(dim))
+end
+
+# printing for DimensionalArray
 function Base.show(io::IO, A::AbDimArray)
-    l = label(A) != "" ? label(A) : nameof(typeof(A))
-    printstyled(io, l; color=:magenta)
+    l = nameof(typeof(A))
+    printstyled(io, nameof(typeof(A)); color=:magenta)
+    if label(A) != ""
+        print(io, " (labelled ")
+        printstyled(io, label(A); color=:magenta)
+        print(io, ")")
+    end
+
     print(io, " with dimensions:\n")
     for d in dims(A)
         print(io, " ", d, "\n")
@@ -21,28 +80,9 @@ function Base.show(io::IO, A::AbDimArray)
     end
     print(io, "and")
     printstyled(io, " data: "; color=:green)
-    show(IOContext(io, :compact => true), MIME("text/plain"), data(A))
+    dataA = data(A)
+    print(io, summary(dataA), "\n")
+    custom_show_nd(io, data(A))
 end
 
 Base.show(io::IO, ::MIME"text/plain", A::AbDimArray) = show(io, A)
-
-# Full printing version for dimensions
-function Base.show(io::IO, ::MIME"text/plain", dim::AbDim)
-    print(io, "dimension ")
-    printstyled(io, name(dim); color=:red)
-    printstyled(io, "\nval: "; color=:green)
-    printlimited(io, val(dim); Δx = 5)
-    printstyled(io, "\ngrid: "; color=:yellow)
-    show(io, grid(dim))
-    printstyled(io, "\nmetadata: "; color=:blue)
-    show(io, metadata(dim))
-    printstyled(io, "\ntype: "; color=:cyan)
-    show(io, typeof(dim))
-end
-
-# short printing version for dimensions
-function Base.show(io::IO, dim::AbDim)
-    printstyled(io, name(dim), ": "; color=:red)
-    Δx = length(string(nameof(typeof(dim)))) + 2
-    printlimited(io, val(dim); Δx = Δx)
-end

--- a/test/prettyprinting.jl
+++ b/test/prettyprinting.jl
@@ -1,15 +1,29 @@
-using Dates, DimensionalData
-using DimensionalData: Time, X
+using DimensionalData, Test
+using DimensionalData: Time, Z, @dim
+using Dates: DateTime, Month
+
+# define dims with both long name and Type name
+@dim Lon "Longitude" "lon"
+@dim Lat "Latitude" "lat"
+
 timespan = DateTime(2001):Month(1):DateTime(2001,12)
 t = Time(timespan)
-x = X(Vector(10:10:500))
-A = DimensionalArray(rand(12,length(x)), (t, x))
+x = Lon(Vector(0.5:1.0:359.5))
+y = Lat(Vector{Union{Float32, Missing}}(-89.5:1.0:89.5))
+z = Z('a':'z')
+d = (x, y, z, t)
 
-s1 = sprint(show, A)
-s2 = sprint(show, x)
-s3 = sprint(show, MIME("text/plain"), x)
+A = DimensionalArray(rand(length.(d)...), d)
+B = DimensionalArray(rand(length(x), length(y)), (x,y))
+C = DimensionalArray(rand(length(x)), (x,))
 
-@test occursin("DimensionalArray with dimensions:", s1)
-@test occursin("X", s1)
-@test occursin("X:", s2)
-@test occursin("dimension X", s3)
+# s1 = sprint(show, A)
+# s2 = sprint(show, x)
+# s3 = sprint(show, MIME("text/plain"), x)
+
+# @test occursin("DimensionalArray with dimensions:", s1)
+# @test occursin("X", s1)
+# @test occursin("X:", s2)
+# @test occursin("dimension X", s3)
+
+# Test again but now with labelled array A

--- a/test/prettyprinting.jl
+++ b/test/prettyprinting.jl
@@ -14,8 +14,8 @@ z = Z('a':'z')
 d = (x, y, z, t)
 
 A = DimensionalArray(rand(length.(d)...), d)
-B = DimensionalArray(rand(length(x), length(y)), (x,y))
-C = DimensionalArray(rand(length(x)), (x,))
+a = DimensionalArray(rand(length(x), length(y)), (x,y))
+B = DimensionalArray(rand(length(x)), (x,))
 
 s1 = sprint(show, A)
 s2 = sprint(show, x)

--- a/test/prettyprinting.jl
+++ b/test/prettyprinting.jl
@@ -17,13 +17,14 @@ A = DimensionalArray(rand(length.(d)...), d)
 B = DimensionalArray(rand(length(x), length(y)), (x,y))
 C = DimensionalArray(rand(length(x)), (x,))
 
-# s1 = sprint(show, A)
-# s2 = sprint(show, x)
-# s3 = sprint(show, MIME("text/plain"), x)
+s1 = sprint(show, A)
+s2 = sprint(show, x)
+s3 = sprint(show, MIME("text/plain"), x)
 
-# @test occursin("DimensionalArray with dimensions:", s1)
-# @test occursin("X", s1)
-# @test occursin("X:", s2)
-# @test occursin("dimension X", s3)
+@test occursin("DimensionalArray", s1)
+for s in (s1, s2, s3)
+    @test occursin("Lon", s)
+    @test occursin("Longitude", s)
+end
 
 # Test again but now with labelled array A


### PR DESCRIPTION
Closes #53 

Alright, I think this leaves noone unsatisfied! We now do
```julia
using DimensionalData, Test
using DimensionalData: Time, Z, @dim
using Dates: DateTime, Month

# define dims with both long name and Type name
@dim Lon "Longitude" "lon"
@dim Lat "Latitude" "lat"

timespan = DateTime(2001):Month(1):DateTime(2001,12)
t = Time(timespan)
x = Lon(Vector(0.5:1.0:359.5))
y = Lat(Vector{Union{Float32, Missing}}(-89.5:1.0:89.5))
z = Z('a':'z')
d = (x, y, z, t)

A = DimensionalArray(rand(length.(d)...), d)
```
and get:
![image](https://user-images.githubusercontent.com/19669089/73659747-2865fd00-4697-11ea-95c8-f9293c6b84e7.png)

![image](https://user-images.githubusercontent.com/19669089/73659828-4af81600-4697-11ea-9468-6bab4e567a81.png)

By the way, if you want to have same "only first frame printing" for all your Julia multidim arrays you can put this in your startup.jl:

```julia
function Base.show_nd(io::IO, A::AbstractArray, print_matrix::Function, lab::Bool)
    o = ones(Int, length(size(A))-2)
    frame = A[:, :, o...]
    onestring = join(o, ", ")
    println(io, "[:, :, $(onestring)]")
    print_matrix(IOContext(io, :compact => true, :limit=>true), frame)
    print(io, "\n[and ", prod(size(A,d) for d=3:ndims(A)) - 1," more slices...]")
end
```

I did it already :D 

---

updating the tests now, the this can be reviewed/merged. 