### PR TITLE
fix reverse

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -83,7 +83,7 @@ end
 
 # This is copied from base as we can't efficiently wrap this function
 # through the kwarg with a rebuild in the generator. Doing it this way
-# wierdly makes it faster toeuse a dim than an integer.
+# also makes it faster to use a dim than an integer.
 if VERSION > v"1.1-"
     Base.eachslice(A::AbDimArray; dims=1, kwargs...) = begin
         if dims isa Tuple && length(dims) != 1
@@ -96,6 +96,7 @@ if VERSION > v"1.1-"
     end
 end
 
+# Duplicated dims
 
 for fname in (:cor, :cov)
     @eval Statistics.$fname(A::AbDimArray{T,2}; dims=1, kwargs...) where T = begin
@@ -159,7 +160,7 @@ for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint),
                      (:Base, :transpose), (:LinearAlgebra, :Transpose)]
     @eval begin
         @inline $pkg.$fname(A::AbDimArray{T,2}) where T =
-            rebuild(A, $fname(data(A)), reverse(dims(A)), refdims(A))
+            rebuild(A, $pkg.$fname(data(A)), reverse(dims(A)), refdims(A))
         @inline $pkg.$fname(A::AbDimArray{T,1}) where T =
             rebuild(A, $pkg.$fname(data(A)), (EmptyDim(), dims(A)...))
     end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -129,10 +129,11 @@ end
 @inline slicedims(d::AbDim{<:AbstractArray}, i::AbstractArray) =
     (rebuild(d, d[_relate(d, i)]),), ()
 
-_relate(d::AbDim, i) = _relate(relationorder(d), d, i)
-_relate(::Forward, d::AbDim, i) = i
-_relate(::Reverse, d::AbDim, i::Integer) = lastindex(d) - i + 1
-_relate(::Reverse, d::AbDim, i::AbstractArray) = reverse(lastindex(d) .- i .+ 1)
+_relate(d::AbDim, i) = _maybeflip(relationorder(d), d, i)
+
+_maybeflip(::Forward, d::AbDim, i) = i
+_maybeflip(::Reverse, d::AbDim, i::Integer) = lastindex(d) - i + 1
+_maybeflip(::Reverse, d::AbDim, i::AbstractArray) = reverse(lastindex(d) .- i .+ 1)
 
 """
     dimnum(A, lookup)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,9 +1,9 @@
-# These do most of the work in the package.
-# They are all @generated or recusive functions for performance.
+# These functions do most of the work in the package.
+# They are all type-stable recusive methods for performance and extensibility.
 
 const UnionAllTupleOrVector = Union{Vector{UnionAll},Tuple{UnionAll,Vararg}}
 
-_dimsmatch(a::DimOrDimType, b::DimOrDimType) = 
+_dimsmatch(a::DimOrDimType, b::DimOrDimType) =
     basetypeof(a) <: basetypeof(b) || basetypeof(dims(grid(a))) <: basetypeof(b)
 
 """
@@ -124,16 +124,15 @@ end
 
 @inline slicedims(d::AbDim, i::Colon) = (d,), ()
 @inline slicedims(d::AbDim, i::Number) =
-    (), (rebuild(d, val(d)[i], slicegrid(grid(d), val(d), i)),)
+    (), (rebuild(d, d[_relate(d, i)], slicegrid(grid(d), val(d), i)),)
 # TODO deal with unordered arrays trashing the index order
 @inline slicedims(d::AbDim{<:AbstractArray}, i::AbstractArray) =
-    (rebuild(d, val(d)[i]),), ()
-@inline slicedims(d::AbDim{<:LinRange}, i::UnitRange) = begin
-    range = val(d)
-    start, stop, len = range[first(i)], range[last(i)], length(i) ÷ step(i)
-    (rebuild(d, LinRange(start, stop, len), slicegrid(grid(d), val(d), i)),), ()
-end
+    (rebuild(d, d[_relate(d, i)]),), ()
 
+_relate(d::AbDim, i) = _relate(relationorder(d), d, i)
+_relate(::Forward, d::AbDim, i) = i
+_relate(::Reverse, d::AbDim, i::Integer) = lastindex(d) - i + 1
+_relate(::Reverse, d::AbDim, i::AbstractArray) = reverse(lastindex(d) .- i .+ 1)
 
 """
     dimnum(A, lookup)
@@ -275,7 +274,7 @@ end
     rebuild(dim, reducedims(locus(grid), dim), grid)
 end
 @inline reducedims(grid::RegularGrid, dim) = begin
-    grid = RegularGrid(Ordered(), locus(grid), MultiSample(), step(grid) * length(val(dim)))
+    grid = RegularGrid(Ordered(), locus(grid), MultiSample(), step(grid) * length(dim))
     rebuild(dim, reducedims(locus(grid), dim), grid)
 end
 @inline reducedims(grid::DependentGrid, dim) =

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -72,14 +72,14 @@ sel2indices(grid, dim::AbDim, sel::At{<:AbstractVector}) =
 sel2indices(grid::T, dim::AbDim, sel::Near) where T<:Union{CategoricalGrid,UnknownGrid,NoGrid} =
     throw(ArgumentError("`Near` has no meaning with `$T`. Use `At`"))
 sel2indices(grid::AbstractAlignedGrid, dim::AbDim, sel::Near) =
-    near(dim, val(sel))
+    near(dim, sel, val(sel))
 sel2indices(grid::AbstractAlignedGrid, dim::AbDim, sel::Near{<:Tuple}) =
-    [near.(Ref(dim), val(sel))...]
+    [near.(Ref(dim), Ref(sel), val(sel))...]
 sel2indices(grid::AbstractAlignedGrid, dim::AbDim, sel::Near{<:AbstractVector}) =
-    near.(Ref(dim), val(sel))
+    near.(Ref(dim), Ref(sel), val(sel))
 
 # Between selector
-sel2indices(grid, dim::AbDim, sel::Between{<:Tuple}) = between(dim, val(sel))
+sel2indices(grid, dim::AbDim, sel::Between{<:Tuple}) = between(dim, sel)
 
 
 # Transformed grid
@@ -102,42 +102,75 @@ to_int(::Near, x) = round(Int, x)
 at(dim::AbDim, sel::At, val) =
     _relate(dim, at(dim, val, atol(sel), rtol(sel)))
 at(dim::AbDim, selval, atol::Nothing, rtol::Nothing) = begin
-    ind = findfirst(x -> x == selval, val(dim))
-    ind == nothing ? throw(ArgumentError("$selval not found in $dim")) : ind
+    i = findfirst(x -> x == selval, val(dim))
+    i == nothing && throw(ArgumentError("$selval not found in $dim"))
+    return i
 end
 at(dim::AbDim, selval, atol, rtol) = begin
     # This is not particularly efficient.
     # It should be separated out for unordered
     # dims and otherwise treated as an ordered list.
-    ind = findfirst(x -> isapprox(x, selval; atol=atol, rtol=rtol), val(dim))
-    ind == nothing ? throw(ArgumentError("$selval not found in $dim")) : ind
+    i = findfirst(x -> isapprox(x, selval; atol=atol, rtol=rtol), val(dim))
+    i == nothing && throw(ArgumentError("$selval not found in $dim"))
+    return i
 end
 
 
-near(dim::AbDim, selval) =
-    _relate(dim, near(indexorder(dim), dim::AbDim, selval))
-near(indexorder::Unordered, dim, selval) =
+near(dim::AbDim, sel::Near, val) =
+    _relate(dim, near(indexorder(dim), dim::AbDim, val))
+near(::Unordered, dim, selval) =
     throw(ArgumentError("`Near` has no meaning in an `Unordered` grid"))
-near(indexorder, dim, selval) = begin
+near(ord, dim, selval) = begin
     index = val(dim)
-    i = searchsortedfirst(index, selval; rev=isrev(indexorder))
+    i = searchsortedfirst(index, selval; rev=isrev(ord))
+    # Make sure index is withing bounds
     if i > lastindex(index)
         lastindex(index)
     elseif i <= firstindex(index)
         firstindex(index)
-    elseif abs(index[i] - selval) < abs(index[i-1] - selval)
+    # Find nearest index
+    elseif _isnearest(ord, selval, index, i)
         i
     else
         i - 1
     end
 end
 
-between(dim::AbDim, sel) =
-    _relate(dim, between(indexorder(dim), dim, sel))
+_isnearest(::Forward, selval, index, i) = abs(index[i] - selval) <= abs(index[i-1] - selval)
+_isnearest(::Reverse, selval, index, i) = abs(index[i] - selval) < abs(index[i-1] - selval)
+
+between(dim::AbDim, sel::Between) = between(indexorder(dim), dim, val(sel))
 between(::Unordered, dim::AbDim, sel) =
     throw(ArgumentError("Cannot use `Between` on an unordered grid"))
-between(indexorder, dim::AbDim, sel) =
-    searchsortedfirst(val(dim), first(sel); rev=isrev(indexorder)):searchsortedlast(val(dim), last(sel); rev=isrev(indexorder))
+between(ord::Reverse, dim::AbDim, sel) = begin
+    low, high = _sorttuple(sel)
+    a = searchsortedlast(val(dim), high; rev=true)
+    b = searchsortedfirst(val(dim), low; rev=true)
+    a, b = _bounded(a, dim), _bounded(b, dim)
+    _relate(dim, a:b)
+end
+between(ord::Forward, dim::AbDim, sel) = begin
+    low, high = _sorttuple(sel)
+    a = searchsortedfirst(val(dim), low)
+    b = searchsortedlast(val(dim), high)
+    a, b = _bounded(a, dim), _bounded(b, dim)
+    _relate(dim, a:b)
+end
+
+_bounded(x, dim) = 
+    if x > lastindex(dim)
+        lastindex(dim)
+    elseif x <= firstindex(dim)
+        firstindex(dim)
+    else
+        x
+    end
+
+
+_mayberev(::Forward, (a, b)) = (a, b)
+_mayberev(::Reverse, (a, b)) = (b, a)
+
+_sorttuple((a, b)) = a < b ? (a, b) : (b, a)
 
 # Selector indexing without dim wrappers. Must be in the right order!
 Base.@propagate_inbounds Base.getindex(a::AbstractArray, I::Vararg{Selector}) =

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1,5 +1,41 @@
 using DimensionalData, Test, Unitful
-using DimensionalData: X, Y, Z, Time, Forward, Reverse, Ordered, arrayorder, indexorder, relationorder
+using DimensionalData: X, Y, Z, Time, Forward, Reverse, Ordered,
+      arrayorder, indexorder, relationorder, between, at, near
+
+@testset "selector primitives" begin
+    timeforfor = Time((5:30)u"s"; grid=RegularGrid(order=Ordered(Forward(),Forward(),Forward())))
+    timeforrev = Time((5:30)u"s"; grid=RegularGrid(order=Ordered(Forward(),Forward(),Reverse())))
+    timerevfor = Time((30:-1:5)u"s"; grid=RegularGrid(order=Ordered(Reverse(),Forward(),Forward())))
+    timerevrev = Time((30:-1:5)u"s"; grid=RegularGrid(order=Ordered(Reverse(),Forward(),Reverse())))
+
+    @testset "between" begin
+        @test between(timeforfor, Between(10u"s", 15u"s")) === 6:11
+        @test between(timeforrev, Between(10u"s", 15u"s")) === 16:1:21
+        @test between(timerevfor, Between(10u"s", 15u"s")) === 16:21
+        @test between(timerevrev, Between(10u"s", 15u"s")) === 6:1:11
+        # Input order doesn't matter
+        @test between(timeforfor, Between(15u"s", 10u"s")) === 6:11
+    end
+
+    @testset "at" begin
+        @test at(timeforfor, At(30u"s"), 30u"s") == 26
+        @test at(timerevfor, At(30u"s"), 30u"s") == 1
+        @test at(timeforrev, At(30u"s"), 30u"s") == 1
+        @test at(timerevrev, At(30u"s"), 30u"s") == 26
+    end
+
+    @testset "at" begin
+        @test near(timeforfor, Near(29.5u"s"), 29.5u"s") == 26
+        @test near(timerevfor, Near(29.5u"s"), 29.5u"s") == 1
+        @test near(timeforrev, Near(29.5u"s"), 29.5u"s") == 1
+        @test near(timerevrev, Near(29.5u"s"), 29.5u"s") == 26
+        @test near(timeforfor, Near(29.4u"s"), 29.4u"s") == 25
+        @test near(timerevfor, Near(29.4u"s"), 29.4u"s") == 2
+        @test near(timeforrev, Near(29.4u"s"), 29.4u"s") == 2
+        @test near(timerevrev, Near(29.4u"s"), 29.4u"s") == 25
+    end
+
+end
 
 a = [1 2  3  4
      5 6  7  8
@@ -21,7 +57,7 @@ a = [1 2  3  4
         @test da[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [1 4; 9 12]
         @test_throws ArgumentError da[Y<|At([9, 30]), Time<|At([1u"s", 4u"s"])]
         @test view(da, Y<|At(20), Time<|At((3:4)u"s")) == [7, 8]
-        @test view(da, Y<|Near(17), Time<|Near([1.5u"s", 3.1u"s"])) == [5, 7]
+        @test view(da, Y<|Near(17), Time<|Near([1.5u"s", 3.1u"s"])) == [6, 7]
         @test view(da, Y<|Between(9, 21), Time<|At((3:4)u"s")) == [3 4; 7 8]
     end
 
@@ -45,25 +81,51 @@ a = [1 2  3  4
     end
 
     @testset "selectors work in reverse orders" begin
+        a = [1 2  3  4
+             5 6  7  8
+             9 10 11 12]
+
         @testset "forward index with reverse relation" begin
-            da_ffr = DimensionalArray(a, (Y(10:10:30; grid=RegularGrid(order=Ordered(Forward(), Forward(), Reverse()))), 
+            da_ffr = DimensionalArray(a, (Y(10:10:30; grid=RegularGrid(order=Ordered(Forward(), Forward(), Reverse()))),
                                          Time((1:1:4)u"s"; grid=RegularGrid(order=Ordered(Forward(), Forward(), Reverse())))))
             @test indexorder(dims(da_ffr, Time)) == Forward()
             @test arrayorder(dims(da_ffr, Time)) == Forward()
             @test relationorder(dims(da_ffr, Time)) == Reverse()
-            @test da_ffr[Y<|At([10, 30]), Time<|At([1u"s", 4u"s"])] == [12 9; 4 1]
             @test da_ffr[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [6, 5]
-            @test da_ffr[Y<|Near(7), Time<|Near([1.3u"s", 3.3u"s"])] == [12, 10]
-            @test da_ffr[Y<|Between(9, 21), Time<|At((3.0:4.0)u"s")] == [10 9; 6 5]
+            @test da_ffr[Y<|At([20, 30]), Time<|At((3.0:4.0)u"s")] == [6 5; 2 1]
+            @test da_ffr[Y<|Near(22), Time<|Near([3.3u"s", 4.3u"s"])] == [6, 5]
+            @test da_ffr[Y<|Near([22, 42]), Time<|Near([3.3u"s", 4.3u"s"])] == [6 5; 2 1]
+            # Between hasn't reverse the index order
+            @test da_ffr[Y<|Between(19, 35), Time<|Between(3.0u"s", 4.0u"s")] == [1 2; 5 6] 
+        end
+        @testset "reverse index with forward relation" begin
+            da_rff = DimensionalArray(a, (Y(30:-10:10; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Forward()))),
+                                         Time((4:-1:1)u"s"; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Forward())))))
+            @test da_rff[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [6, 5]
+            @test da_rff[Y<|At([20, 30]), Time<|At((3.0:4.0)u"s")] == [6 5; 2 1]
+            @test da_rff[Y<|Near(22), Time<|Near([3.3u"s", 4.3u"s"])] == [6, 5]
+            @test da_rff[Y<|Near([22, 42]), Time<|Near([3.3u"s", 4.3u"s"])] == [6 5; 2 1]
+            # Between hasn't reverse the index order
+            @test da_rff[Y<|Between(20, 30), Time<|Between(3.0u"s", 4.0u"s")] == [1 2; 5 6] 
         end
 
-        @testset "is the same as reverse index with forward realation" begin
-            da_rff = DimensionalArray(a, (Y(30:-10:10; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Forward()))), 
-                                         Time((4:-1:1)u"s"; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Forward())))))
-            @test da_rff[Y<|At((10, 30)), Time<|At([1u"s", 4u"s"])] == [12 9; 4 1]
-            @test da_rff[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [6, 5]
-            @test da_rff[Y<|Near(7), Time<|Near([1.3u"s", 3.3u"s"])] == [12, 10]
-            @test da_rff[Y<|Between(9, 21), Time<|At((3.0:4.0)u"s")] == [10 9; 6 5]
+        @testset "forward index with forward relation" begin
+            da_fff = DimensionalArray(a, (Y(10:10:30; grid=RegularGrid(order=Ordered(Forward(), Forward(), Forward()))),
+                                         Time((1:4)u"s"; grid=RegularGrid(order=Ordered(Forward(), Forward(), Forward())))))
+            @test da_fff[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [7, 8]
+            @test da_fff[Y<|At([20, 30]), Time<|At((3.0:4.0)u"s")] == [7 8; 11 12]
+            @test da_fff[Y<|Near(22), Time<|Near([3.3u"s", 4.3u"s"])] == [7, 8]
+            @test da_fff[Y<|Near([22, 42]), Time<|Near([3.3u"s", 4.3u"s"])] == [7 8; 11 12]
+            @test da_fff[Y<|Between(20, 30), Time<|Between(3.0u"s", 4.0u"s")] == [7 8; 11 12] 
+        end
+        @testset "reverse index with reverse relation" begin
+            da_rfr = DimensionalArray(a, (Y(30:-10:10; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Reverse()))),
+                                         Time((4:-1:1)u"s"; grid=RegularGrid(order=Ordered(Reverse(), Forward(), Reverse())))))
+            @test da_rfr[Y<|At(20), Time<|At((3.0:4.0)u"s")] == [7, 8]
+            @test da_rfr[Y<|At([20, 30]), Time<|At((3.0:4.0)u"s")] == [7 8; 11 12]
+            @test da_rfr[Y<|Near(22), Time<|Near([3.3u"s", 4.3u"s"])] == [7, 8]
+            @test da_rfr[Y<|Near([22, 42]), Time<|Near([3.3u"s", 4.3u"s"])] == [7 8; 11 12]
+            @test da_rfr[Y<|Between(20, 30), Time<|Between(3.0u"s", 4.0u"s")] == [7 8; 11 12] 
         end
 
     end
@@ -75,21 +137,21 @@ a = [1 2  3  4
         dc[Near(11), At(3u"s")] = 100
         @test c[1, 3] == 100
         dc[Time<|Near(2.2u"s"), Y<|Between(10, 30)] = [200, 201, 202]
-        @test c[1:3, 2] == [200, 201, 202] 
+        @test c[1:3, 2] == [200, 201, 202]
     end
 
 end
 
 
 @testset "CategoricalGrid" begin
-    dimz = Time([:one, :two, :three]; grid=CategoricalGrid()), 
+    dimz = Time([:one, :two, :three]; grid=CategoricalGrid()),
            Y([:a, :b, :c, :d]; grid=CategoricalGrid())
     da = DimensionalArray(a, dimz)
     @test da[Time<|At([:one, :two]), Y<|At(:b)] == [2, 6]
     @test da[At([:one, :three]), At([:b, :c, :d])] == [2 3 4; 10 11 12]
     @test da[At(:two), Between(:b, :d)] == [6, 7, 8]
     # Near doesn't make sense for categories
-    @test_throws ArgumentError da[Near(:two), At([:b, :c, :d])] 
+    @test_throws ArgumentError da[Near(:two), At([:b, :c, :d])]
 end
 
 @testset "TranformedGrid " begin
@@ -97,20 +159,20 @@ end
 
     m = LinearMap([0.5 0.0; 0.0 0.5])
 
-    dimz = Dim{:trans1}(m; grid=TransformedGrid(X())),  
+    dimz = Dim{:trans1}(m; grid=TransformedGrid(X())),
            Dim{:trans2}(m, grid=TransformedGrid(Y()))
 
     @testset "permutedims works on grid dimensions" begin
         @test permutedims((Y(), X()), dimz) == (X(), Y())
     end
 
-    da = DimensionalArray(a, dimz) 
+    da = DimensionalArray(a, dimz)
 
     @testset "Indexing with array dims indexes the array as usual" begin
         @test da[Dim{:trans1}(3), Dim{:trans2}(1)] == 9
         # Using selectors works the same as indexing with grid
-        # dims - it applies the transform function. 
-        # It's not clear this should be allowed or makes sense, 
+        # dims - it applies the transform function.
+        # It's not clear this should be allowed or makes sense,
         # but it works anyway because the permutation is correct either way.
         @test da[Dim{:trans1}(At(6)), Dim{:trans2}(At(2))] == 9
     end


### PR DESCRIPTION
Fixes reverse and handling of relationship between array order and index order when using dims and selectors. It's overly complicated, but some files just come like this, and the option of always reversing them on load/save seems worse.

Needs more tests.