### PR TITLE
abstract dims

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -55,13 +55,14 @@ using ConstructionBase, LinearAlgebra, RecipesBase, Statistics, Dates
 
 using Base: tail, OneTo
 
-export AbstractDimension, Dim
+export AbstractDimension, AbstractXDim, AbstractYDim, AbstractZDim, 
+       AbstractCategoricalDim, Dim
 
 export Selector, Near, Between, At
 
 export Locus, Center, Start, End, UnknownLocus
 
-export Sampling, SingleSample, MultiSample, UnknownSampling
+export Sampling, PointSampling, IntervalSampling, UnknownSampling
 
 export Order, Ordered, Unordered
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -55,8 +55,9 @@ using ConstructionBase, LinearAlgebra, RecipesBase, Statistics, Dates
 
 using Base: tail, OneTo
 
-export AbstractDimension, AbstractXDim, AbstractYDim, AbstractZDim, 
-       AbstractCategoricalDim, Dim
+export AbstractDimension, XDim, YDim, ZDim, CategoricalDim
+
+export Dim, X, Y, Z, Ti
 
 export Selector, Near, Between, At
 

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -86,14 +86,14 @@ abstract type Sampling end
 """
 Each cell value represents a siegle discrete sample taken at the index location.
 """
-struct SingleSample <: Sampling end
+struct PointSampling <: Sampling end
 
 """
 Multiple samples from the step combined using method `M`,
 where `M` is `typeof(mean)`, `typeof(sum)` etc.
 """
-struct MultiSample{M} <: Sampling end
-MultiSample() = MultiSample{Nothing}()
+struct IntervalSampling{M} <: Sampling end
+IntervalSampling() = IntervalSampling{Nothing}()
 
 """
 The sampling method is unknown.

--- a/test/array.jl
+++ b/test/array.jl
@@ -85,6 +85,13 @@ a = [1 2 3 4
 b = [4 4 4 4 
      4 4 4 4 
      4 4 4 4]
+
+@testset "indexing into empty dims is just regular indexing" begin
+    ida = DimensionalArray(a, (X(), Y()))
+    ida[Y(3:4), X(2:3)] = [5 6; 6 7]
+end
+
+
 dimz = (Dim{:row}((10, 30)), Dim{:column}((-20, 10)))
 da = DimensionalArray(a, dimz)
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -58,10 +58,10 @@ end
     @test sum(da; dims=Y()) == sum(a; dims=2)
     @test dims(sum(da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2); grid=RegularGrid(;step=2.0)),
-         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=MultiSample())))
+         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=IntervalSampling())))
     @test prod(da; dims=X) == [3 8]
     @test prod(da; dims=2) == [2 12]'
-    resultdimz = (X([143.0]; grid=RegularGrid(;step=4.0, sampling=MultiSample())),
+    resultdimz = (X([143.0]; grid=RegularGrid(;step=4.0, sampling=IntervalSampling())),
             Y(LinRange(-38.0, -36.0, 2); grid=RegularGrid(;step=2.0)))
     @test typeof(dims(prod(da; dims=X()))) == typeof(resultdimz)
     @test bounds(dims(prod(da; dims=X()))) == bounds(resultdimz)
@@ -72,24 +72,24 @@ end
     @test minimum(da; dims=1) == [1 2]
     @test minimum(da; dims=Y()) == [1 3]'
     @test dims(minimum(da; dims=X())) ==
-        (X([143.0]; grid=RegularGrid(;step=4.0, sampling=MultiSample())),
+        (X([143.0]; grid=RegularGrid(;step=4.0, sampling=IntervalSampling())),
          Y(LinRange(-38.0, -36.0, 2); grid=RegularGrid(;step=2.0)))
     @test mean(da; dims=1) == [2.0 3.0]
     @test mean(da; dims=Y()) == [1.5 3.5]'
     @test dims(mean(da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2); grid=RegularGrid(;step=2.0)),
-         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=MultiSample())))
+         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=IntervalSampling())))
     @test mapreduce(x -> x > 3, +, da; dims=X) == [0 1]
     @test mapreduce(x -> x > 3, +, da; dims=2) == [0 1]'
     @test dims(mapreduce(x-> x > 3, +, da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2); grid=RegularGrid(;step=2.0)),
-         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=MultiSample())))
+         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=IntervalSampling())))
     @test reduce(+, da) == reduce(+, a)
     @test reduce(+, da; dims=X) == [4 6]
     @test reduce(+, da; dims=Y()) == [3 7]'
     @test dims(reduce(+, da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2); grid=RegularGrid(;step=2.0)),
-         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=MultiSample())))
+         Y([-38.0]; grid=RegularGrid(; step=4.0, sampling=IntervalSampling())))
     @test std(da) === std(a)
     @test std(da; dims=1) == [1.4142135623730951 1.4142135623730951]
     @test std(da; dims=Y()) == [0.7071067811865476 0.7071067811865476]'
@@ -101,7 +101,7 @@ end
     end
     @test dims(var(da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2); grid=RegularGrid(;step=2.0)),
-         Y([-38.0]; grid=RegularGrid(;step=4.0, sampling=MultiSample())))
+         Y([-38.0]; grid=RegularGrid(;step=4.0, sampling=IntervalSampling())))
     a = [1 2 3; 4 5 6]
     da = DimensionalArray(a, dimz)
     @test median(da) == 3.5
@@ -210,7 +210,7 @@ end
     da = DimensionalArray(a, (Y((10, 30)), Time(1:4)))
     ms = mapslices(sum, da; dims=Y)
     @test ms == [9 12 15 18]
-    @test typeof(dims(ms)) == typeof((Y([10.0]; grid=RegularGrid(; step=30.0, sampling=MultiSample())),
+    @test typeof(dims(ms)) == typeof((Y([10.0]; grid=RegularGrid(; step=30.0, sampling=IntervalSampling())),
                                       Time(1:4; grid=RegularGrid(; step=1))))
     @test refdims(ms) == ()
     ms = mapslices(sum, da; dims=Time)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -63,19 +63,19 @@ end
             (X(3; grid=UnknownGrid()), Y(1; grid=UnknownGrid()))
     @test reducedims((X(3:4; grid=RegularGrid(;step=1)), 
                       Y(1:5; grid=RegularGrid(;step=1))), (X, Y)) ==
-                     (X([3]; grid=RegularGrid(;step=2, sampling=MultiSample())), 
-                      Y([1]; grid=RegularGrid(;step=5, sampling=MultiSample())))
+                     (X([3]; grid=RegularGrid(;step=2, sampling=IntervalSampling())), 
+                      Y([1]; grid=RegularGrid(;step=5, sampling=IntervalSampling())))
     @test reducedims((X(3:4; grid=BoundedGrid(;locus=Start(), bounds=(3, 5))),
                       Y(1:5; grid=BoundedGrid(;locus=End(), bounds=(0, 5)))), (X, Y))[1] ==
-                     (X([3]; grid=BoundedGrid(;sampling=MultiSample(), bounds=(3, 5), locus=Start())),
-                      Y([5]; grid=BoundedGrid(;sampling=MultiSample(), bounds=(0, 5), locus=End())))[1]
+                     (X([3]; grid=BoundedGrid(;sampling=IntervalSampling(), bounds=(3, 5), locus=Start())),
+                      Y([5]; grid=BoundedGrid(;sampling=IntervalSampling(), bounds=(0, 5), locus=End())))[1]
     @test reducedims((X(3:4; grid=BoundedGrid(;locus=Center(), bounds=(2.5, 4.5))),
                       Y(1:5; grid=BoundedGrid(;locus=Center(), bounds=(0.5, 5.5)))), (X, Y))[1] ==
-                     (X([3.5]; grid=BoundedGrid(;sampling=MultiSample(), bounds=(2.5, 4.5), locus=Center())),
-                      Y([3.5]; grid=BoundedGrid(;sampling=MultiSample(), bounds=(0.5, 5.5), locus=Center())))[1]
+                     (X([3.5]; grid=BoundedGrid(;sampling=IntervalSampling(), bounds=(2.5, 4.5), locus=Center())),
+                      Y([3.5]; grid=BoundedGrid(;sampling=IntervalSampling(), bounds=(0.5, 5.5), locus=Center())))[1]
     @test reducedims((X(3:4; grid=AlignedGrid()), Y(1:5; grid=AlignedGrid())), (X, Y)) ==
-                     (X([3]; grid=AlignedGrid(;sampling=MultiSample())), 
-                      Y([1]; grid=AlignedGrid(;sampling=MultiSample())))
+                     (X([3]; grid=AlignedGrid(;sampling=IntervalSampling())), 
+                      Y([1]; grid=AlignedGrid(;sampling=IntervalSampling())))
     @test reducedims((X([:a,:b]; grid=CategoricalGrid()), 
                       Y(["1","2","3","4","5"]; grid=CategoricalGrid())), (X, Y)) ==
                      (X([:combined]; grid=CategoricalGrid()), 


### PR DESCRIPTION
Adds a layer of abstract dimensions so that we can make plot recipes and do other dispatch things with common abstract types, instead of dispatching on concrete dimensions.

This frees users to define new dims at will.

Abstract types are:

```
XDim
YDim
ZDim
CategoricalDim
```

Time, now `Ti`, will inherit from XDim along with X. Y from YDim etc.

Syntax is:
`@dim Y YDim`

Closes #34 