### PR TITLE
tweak rebuild

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -8,9 +8,11 @@ const StandardIndices = Union{AbstractArray,Colon,Integer}
 # Interface methods ############################################################
 
 dims(A::AbDimArray) = A.dims
-@inline rebuild(x, data, dims=dims(x)) = rebuild(x, data, dims, refdims(x))
-@inline rebuild(x::AbDimArray, data, dims=dims(x)) =
-    rebuild(x, data, dims, refdims(x))
+@inline rebuild(A::AbstractArray, data, dims::Tuple=dims(A), refdims=refdims(A)) = 
+    rebuild(A, data, dims, refdims, name(A))
+# Rebuild for name-updating methods, to avoid having to add dims and refdims
+@inline rebuild(A::AbstractArray, data, name::String) =
+    rebuild(A, data, dims(A), refdims(A), name)
 
 
 # Array interface methods ######################################################
@@ -105,15 +107,14 @@ DimensionalArray(A::AbstractArray, dims, name::String = ""; refdims=()) =
 # Getters
 refdims(A::DimensionalArray) = A.refdims
 data(A::DimensionalArray) = A.data
-label(A::DimensionalArray) = A.name
+name(A::DimensionalArray) = A.name
+label(A::DimensionalArray) = name(A)
 
 # DimensionalArray interface
-@inline rebuild(A::DimensionalArray, data, dims::Tuple, refdims::Tuple, name::String = A.name) =
+@inline rebuild(A::DimensionalArray, data::AbstractArray, dims::Tuple, 
+                refdims::Tuple, name::String) =
     DimensionalArray(data, dims, refdims, name)
-@inline rebuild(A::DimensionalArray, data, dims::Tuple, name::String = A.name; refdims = refdims(A)) =
-    DimensionalArray(data, dims, refdims, name)
-@inline rebuild(A::DimensionalArray, data::AbstractArray, name::String) =
-    DimensionalArray(data, dims(A), refdims(A), name)
+
 # Array interface (AbstractDimensionalArray takes care of everything else)
 Base.@propagate_inbounds Base.setindex!(A::DimensionalArray, x, I::Vararg{StandardIndices}) =
     setindex!(data(A), x, I...)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -42,7 +42,7 @@ function Broadcast.copy(bc::Broadcasted{DimensionalStyle{S}}) where S
     return if A isa Nothing || _dims isa Nothing
         data
     else
-        rebuild(A, data, _dims, "")
+        rebuild(A, data, _dims, refdims(A), "")
     end
 end
 
@@ -53,7 +53,7 @@ function Base.copyto!(dest::AbstractArray, bc::Broadcasted{DimensionalStyle{S}})
     return if A isa Nothing || _dims isa Nothing
         dest
     else
-        rebuild(A, data(dest), _dims, "")
+        rebuild(A, data(dest), _dims, refdims(A), "")
     end
 end
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -74,8 +74,8 @@ Base.:(==)(dim1::AbDim, dim2::AbDim) =
 
 # AbstractArray methods where dims are the dispatch argument
 
-@inline rebuildsliced(A, data, I, name::String = A.name) =
-    rebuild(A, data, slicedims(A, I)...,name)
+@inline rebuildsliced(A, data, I, name::String=name(A)) =
+    rebuild(A, data, slicedims(A, I)..., name)
 
 Base.@propagate_inbounds Base.getindex(A::AbstractArray, dim::AbDim, dims::Vararg{<:AbDim}) =
     getindex(A, dims2indices(A, (dim, dims...))...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -41,7 +41,8 @@ as it is mostly to give context to plots. Ignoring refdims will simply leave som
 function refdims end
 refdims(x) = ()
 """
-    rebuild(x::AbstractDimensionalArray, data, [dims], [refdims])
+    rebuild(x::AbstractDimensionalArray, data, [dims], [refdims], [name])
+    rebuild(x::AbstractDimensionalArray, data, [name])
     rebuild(x::AbstractDimension, val, [grid], [metadata])
     rebuild(x; kwargs...)
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -73,7 +73,7 @@ Base._dropdims(A::AbstractArray, dims::AbDimTuple) =
 
 # Function application
 
-@inline Base.map(f, A::AbDimArray) = rebuild(A, map(f, data(A)), dims(A))
+@inline Base.map(f, A::AbDimArray) = rebuild(A, map(f, data(A)))
 
 Base.mapslices(f, A::AbDimArray; dims=1, kwargs...) = begin
     dimnums = dimnum(A, dims)
@@ -141,7 +141,7 @@ _checkmatch(a, b) =
     newdims = reversearray(DimensionalData.dims(A), dnum)
     # Reverse the data
     newdata = reverse(data(A); dims=dnum)
-    rebuild(A, newdata, newdims, refdims(A))
+    rebuild(A, newdata, newdims)
 end
 
 @inline reversearray(dimstorev::Tuple, dnum) = begin
@@ -160,7 +160,7 @@ for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint),
                      (:Base, :transpose), (:LinearAlgebra, :Transpose)]
     @eval begin
         @inline $pkg.$fname(A::AbDimArray{T,2}) where T =
-            rebuild(A, $pkg.$fname(data(A)), reverse(dims(A)), refdims(A))
+            rebuild(A, $pkg.$fname(data(A)), reverse(dims(A)))
         @inline $pkg.$fname(A::AbDimArray{T,1}) where T =
             rebuild(A, $pkg.$fname(data(A)), (EmptyDim(), dims(A)...))
     end
@@ -197,7 +197,7 @@ Base._cat(catdims::AllDimensions, As::AbstractArray...) = begin
         newdims = (dims(A1)..., add_dims...)
     end
     newA = Base._cat(dnum, map(data, As)...)
-    rebuild(A1; data=newA, dims=formatdims(newA, newdims))
+    rebuild(A1, newA, formatdims(newA, newdims))
 end
 
 _catifcatdim(catdims::Tuple, ds) =

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -187,7 +187,7 @@ or a tuple of dimensions.
 Replaces the first dim matching newdim, with newdim, and returns
 a new object or tuple with the dimension updated.
 """
-setdim(A, newdim::AbDim) = rebuild(A; dims=setdim(dims(A), newdim))
+setdim(A, newdim::AbDim) = rebuild(A, data(A), setdim(dims(A), newdim))
 setdim(dims::AbDimTuple, newdim::AbDim) = map(d -> setdim(d, newdim), dims)
 setdim(dim::AbDim, newdim::AbDim) =
     basetypeof(dim) <: basetypeof(newdim) ? newdim : dim


### PR DESCRIPTION
@Datseris a few tweaks to your rebuild PR ( probably should have done during the PR...)

Name is also good to have on `AbstractDimensionalArray` instead of just `DimensionalArray` - that way it will all work in GeoData too, which already has a name field. So name is opt-out in `rebuild`: implementations can just ignore the name argument if they don't use it.
I also removed the kwarg version of `rebuild` - `ConstructionBase.setproperties` just does that automatically for all fields of any `AbstractDimensionalArray`, as magical as that sounds.

https://github.com/rafaqz/DimensionalData.jl/blob/master/src/interface.jl#L51

Lastly I cleaned up all the unnecessary parameters I had been passing to `rebuild` - we can let the optional args take care of that.