### PR TITLE
Use IndexStyle of underlying array

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -19,6 +19,7 @@ dims(A::AbDimArray) = A.dims
 
 Base.size(A::AbDimArray) = size(data(A))
 Base.iterate(A::AbDimArray, args...) = iterate(data(A), args...)
+Base.IndexStyle(A::AbstractDimensionalArray) = Base.IndexStyle(data(A))
 
 Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, N}, I::Vararg{<:Integer, N}) where N =
     getindex(data(A), I...)

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,5 +1,6 @@
 using DimensionalData, Test, Unitful
 using DimensionalData: Start
+using SparseArrays
 
 a = [1 2; 3 4]
 dimz = (X((143, 145)), Y((-38, -36)))
@@ -143,6 +144,15 @@ end
     @test eltype(da2) <: Int
 
     # TODO permute dims to match in broadcast?
+end
+
+@testset "eachindex" begin
+    # Should have linear index
+    da = DimensionalArray(ones(5, 2, 4), (Y((10, 20)), Ti(10:11), X(1:4)))
+    @test eachindex(da) == eachindex(data(da))
+    # Should have cartesian index
+    sda = DimensionalArray(sprand(10, 10, .1), (Y(1:10), X(1:10)))
+    @test eachindex(sda) == eachindex(data(sda))
 end
 
 @testset "convert" begin


### PR DESCRIPTION
Use index style of the underlying array. This should allow outside code to use this information for optimized access.