### PR TITLE
Make benchmarks easier to use

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -1,4 +1,4 @@
-using DimensionalData, BenchmarkTools
+using DimensionalData, BenchmarkTools, Unitful, SparseArrays, Dates, Statistics
 
 #= Benchmarks
 
@@ -6,12 +6,13 @@ Test how much the recalculation of coordinates and dim types
 costs over standard getindex/view.
 
 Indexing with Y(1) has no overhead at all, but ranges
-have an overhead for slicing the dimensions.
-=#
+have an overhead for slicing the dimensions. =#
 
+const suite = BenchmarkGroup()
+
+suite["view"] = BenchmarkGroup(["view"])
 g = DimensionalArray(rand(100, 50), (X(51:150), Y(-40:9)))
 
-println("\n\nPerformance of view()\n")
 vi1(g) = view(data(g), 1, 2)
 vd1(g) = view(g, X(1), Y(2))
 vi2(g) = view(data(g), :, :)
@@ -19,22 +20,14 @@ vd2(g) = view(g, X(:), Y(:))
 vi3(g) = view(data(g), 10:40, 1:20)
 vd3(g) = view(g, X(10:40), Y(1:20))
 
-println("Parent indices with Number")
-@btime vi1($g)
-println("Dims with Number")
-@btime vd1($g)
-println()
-println("Parent indices with Colon")
-@btime vi2($g);
-println("Dims with Colon")
-@btime vd2($g);
-println()
-println("Parent indices with UnitRange")
-@btime vi3($g);
-println("Dims with UnitRange")
-@btime vd3($g);
+suite["view"]["Parent indices with Number"] = @benchmarkable vi1($g)
+suite["view"]["Dims with Number"] = @benchmarkable vd1($g)
+suite["view"]["Parent indices with Colon"] = @benchmarkable vi2($g);
+suite["view"]["Dims with Colon"] = @benchmarkable vd2($g);
+suite["view"]["Parent indices with UnitRange"] = @benchmarkable vi3($g);
+suite["view"]["Dims with UnitRange"] = @benchmarkable vd3($g);
 
-println("\n\nPerformance of getindex()\n")
+suite["getindex"] = BenchmarkGroup()
 i1(g) = data(g)[10, 20]
 d1(g) = g[Y(10), X(20)]
 i2(g) = data(g)[:, :]
@@ -42,50 +35,42 @@ d2(g) = g[Y(:), X(:)]
 i3(g) = data(g)[1:20, 10:40]
 d3(g) = g[Y(1:20), X(10:40)]
 
-println("Parent indices with Number")
-@btime i1($g)
-println("Dims with Number")
-@btime d1($g)
-println()
-println("Parent indices with Colon")
-@btime i2($g)
-println("Dims with Colon")
-@btime d2($g)
-println()
-println("Parent indices with UnitRange")
-@btime i3($g)
-println("Dims with UnitRange")
-@btime d3($g);
+suite["getindex"]["Parent indices with Number"] = @benchmarkable i1($g)
+suite["getindex"]["Dims with Number"] = @benchmarkable d1($g)
+suite["getindex"]["Parent indices with Colon"] = @benchmarkable i2($g)
+suite["getindex"]["Dims with Colon"] = @benchmarkable d2($g)
+suite["getindex"]["Parent indices with UnitRange"] = @benchmarkable i3($g)
+suite["getindex"]["Dims with UnitRange"] = @benchmarkable d3($g);
 
 a = rand(5, 4, 3);
 da = DimensionalArray(a, (Y((1u"m", 5u"m")), X(1:4), Ti(1:3)))
 dimz = dims(da)
 
 if VERSION > v"1.1-"
-    println("\n\neachslice: normal, numbers + rebuild, dims + rebuild")
-    @btime (() -> eachslice($a; dims=2))();
-    @btime (() -> eachslice($da; dims=2))();
-    @btime (() -> eachslice($da; dims=Y()))();
-    println("eachslice to vector: normal, numbers + rebuild, dims + rebuild")
-    @btime [slice for slice in eachslice($a; dims=2)];
-    @btime [slice for slice in eachslice($da; dims=2)];
-    @btime [slice for slice in eachslice($da; dims=X())];
-    @test [slice for slice in eachslice(da; dims=1)] == [slice for slice in eachslice(da; dims=Y)]
+    suite["eachslice"] = BenchmarkGroup()
+    suite["eachslice"]["array_intdim"] = @benchmarkable (()->eachslice($a; dims = 2))();
+    suite["eachslice"]["dimarray_intdim"] = @benchmarkable (()->eachslice($da; dims = 2))();
+    suite["eachslice"]["dimarray_dim"] = @benchmarkable (()->eachslice($da; dims = Y()))();
+    suite["eachslice_to_vector"] = BenchmarkGroup()
+    suite["eachslice_to_vector"]["array_intdim"] = @benchmarkable [slice for slice in eachslice($a; dims = 2)];
+    suite["eachslice_to_vector"]["dimarray_intdim"] = @benchmarkable [slice for slice in eachslice($da; dims = 2)];
+    suite["eachslice_to_vector"]["dimarray_dim"] = @benchmarkable [slice for slice in eachslice($da; dims = X())];
+    # @test [slice for slice in eachslice(da; dims=1)] == [slice for slice in eachslice(da; dims=Y)]
 end
 
 
-println("\n\nmean: normal, numbers + rebuild, dims + rebuild")
-@btime mean($a; dims=2);
-@btime mean($da; dims=2);
-@btime mean($da; dims=X());
-println("permutedims: normal, numbers + rebuild, dims + rebuild")
-@btime permutedims($a, (2, 1, 3))
-@btime permutedims($da, (2, 1, 3))
-@btime permutedims($da, (Y(), X(), Ti()))
-println("reverse: normal, numbers + rebuild, dims + rebuild")
-@btime reverse($a; dims=1) 
-@btime reverse($da; dims=1) 
-@btime reverse($da; dims=Y()) 
+suite["mean"] = BenchmarkGroup()
+suite["mean"]["array_intdim"] = @benchmarkable mean($a; dims = 2);
+suite["mean"]["dimarray_intdim"] = @benchmarkable mean($da; dims = 2);
+suite["mean"]["dimarray_dim"] = @benchmarkable mean($da; dims = X());
+suite["permutedims"] = BenchmarkGroup()
+suite["permutedims"]["array_intdim"] = @benchmarkable permutedims($a, (2, 1, 3))
+suite["permutedims"]["dimarray_intdim"] = @benchmarkable permutedims($da, (2, 1, 3))
+suite["permutedims"]["dimarray_dim"] = @benchmarkable permutedims($da, (Y(), X(), Ti()))
+suite["reverse"] = BenchmarkGroup()
+suite["reverse"]["array_intdim"] = @benchmarkable reverse($a; dims = 1) 
+suite["reverse"]["dimarray_intdim"] = @benchmarkable reverse($da; dims = 1) 
+suite["reverse"]["dimarray_dim"] = @benchmarkable reverse($da; dims = Y()) 
 
 # Sparse (and similar specialised arrays)
 
@@ -101,28 +86,37 @@ mean(sparse_a, dims=2)
 mean(sparse_d, dims=Var())
 mean(sparse_d, dims=Obs())
 
+suite["sparse"] = BenchmarkGroup()
 # Benchmarks
-println("mean with dims arge: regular sparse")
-@btime mean($sparse_a, dims=$1)
-println("mean with dims arge: dims sparse")
-@btime mean($sparse_d, dims=$(Var()))
+suite["sparse"]["mean with dims arge: regular sparse"] = @benchmarkable mean($sparse_a, dims = $1)
+suite["sparse"]["mean with dims arge: dims sparse"] = @benchmarkable mean($sparse_d, dims = $(Var()))
 
-println("mean: regular sparse")
-@btime mean($sparse_a)
-println("mean: dims sparse")
-@btime mean($sparse_d)
+suite["sparse"]["mean: regular sparse"] = @benchmarkable mean($sparse_a)
+suite["sparse"]["mean: dims sparse"] = @benchmarkable mean($sparse_d)
 
-println("copy: regular sparse")
-@btime copy($sparse_a)
-println("copy: dims sparse")
-@btime copy($sparse_d)
+suite["sparse"]["copy: regular sparse"] = @benchmarkable copy($sparse_a)
+suite["sparse"]["copy: dims sparse"] = @benchmarkable copy($sparse_d)
 
-println("reduce: regular sparse")
-@btime reduce(+, $sparse_a)
-println("reduce: dims sparse")
-@btime reduce(+, $sparse_a)
+suite["sparse"]["reduce: regular sparse"] = @benchmarkable reduce(+, $sparse_a)
+suite["sparse"]["reduce: dims sparse"] = @benchmarkable reduce(+, $sparse_a)
 
-println("map: regular sparse")
-@btime map(sin, $sparse_a)
-println("map: dims sparse")
-@btime map(sin, $sparse_a)
+suite["sparse"]["map: regular sparse"] = @benchmarkable map(sin, $sparse_a)
+suite["sparse"]["map: dims sparse"] = @benchmarkable map(sin, $sparse_a)
+
+paramspath = joinpath(dirname(@__FILE__), "params.json")
+resultpath = joinpath(dirname(@__FILE__), "$(string(Dates.now()))_suite.json")
+
+if isfile(paramspath)
+    println("Found tuning info at $(paramspath)")
+    loadparams!(suite, BenchmarkTools.load(paramspath)[1], :evals);
+else
+    println("Running tuning...")
+    tune!(suite)
+    BenchmarkTools.save(paramspath, params(suite));
+    println("Tuning results cached to $(paramspath)")
+end
+
+
+results = run(suite, verbose = true)
+println("Writing results to: $(resultpath)")
+BenchmarkTools.save(resultpath, results)


### PR DESCRIPTION
Some low hanging fruit to make the benchmarks a bit easier to use.

Basically:

* Use the benchmarking tooling to save the results
* Use the repo status to name results files

This should make it easier to compare performance differences between commits.