### PR TITLE
AnonDim

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,7 +27,7 @@ Z
 Ti
 ParametricDimension
 Dim
-PlaceholderDim
+AnonDim
 @dim
 ```
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -16,7 +16,7 @@ using Base: tail, OneTo
 
 
 export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim, 
-       X, Y, Z, Ti, ParametricDimension, Dim, PlaceholderDim
+       X, Y, Z, Ti, ParametricDimension, Dim, AnonDim
 
 export Selector, Between, At, Contains, Near
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -79,12 +79,14 @@ struct DimensionalArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N}} <: Abstract
     refdims::R
     name::String
     function DimensionalArray(data::A, dims::D, refdims::R, name::String) where A <:AbstractArray{T,N} where D where R where T where N
-        if length.(dims) != size(data)
-            throw(DimensionMismatch(
-                "dims must have same size as data. This was not true for $dims and size $(size(data)) $(A)."
-            ))
+        map(dims, size(data)) do d, s
+            if !(val(d) isa Colon) && length(d) != s
+                throw(DimensionMismatch(
+                    "dims must have same size as data. This was not true for $dims and size $(size(data)) $(A)."
+                ))
+            end
         end
-        new{T, N, D, R, A}(data, dims, refdims, name)
+        new{T,N,D,R,A}(data, dims, refdims, name)
     end
 end
 """

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -150,15 +150,17 @@ shortname(::Type{<:Dim{X}}) where X = "$X"
 basetypeof(::Type{<:Dim{X}}) where {X} = Dim{X}
 
 """
-Undefined dimension. Used when extra dimensions are created, 
+Anonymous dimension. Used when extra dimensions are created, 
 such as during transpose of a vector.
 """
-struct PlaceholderDim <: Dimension{Int,NoIndex,Nothing} end
+struct AnonDim{T} <: Dimension{T,NoIndex,Nothing} 
+    val::T
+end
 
-val(::PlaceholderDim) = 1:1
-mode(::PlaceholderDim) = NoIndex()
-metadata(::PlaceholderDim) = nothing
-name(::PlaceholderDim) = "Placeholder"
+val(dim::AnonDim) = dim.val
+mode(::AnonDim) = NoIndex()
+metadata(::AnonDim) = nothing
+name(::AnonDim) = "Anon"
 
 """
     @dim typ [supertype=Dimension] [name=string(typ)] [shortname=string(typ)]

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -115,7 +115,7 @@ Base.:*(A::ADA{<:Any,2}, B::AA{<:Any,1}) = rebuild(A, data(A) * B, dims(A, (1,))
 Base.:*(A::ADA{<:Any,1}, B::AA{<:Any,2}) = rebuild(A, data(A) * B, dims(A, (1, 1)))
 Base.:*(A::ADA{<:Any,2}, B::AA{<:Any,2}) = rebuild(A, data(A) * B, dims(A, (1, 1)))
 Base.:*(A::AA{<:Any,1}, B::ADA{<:Any,2}) = rebuild(B, A * data(B), dims(B, (2, 2)))
-Base.:*(A::AA{<:Any,2}, B::ADA{<:Any,1}) = rebuild(B, A * data(B), (PlaceholderDim(),))
+Base.:*(A::AA{<:Any,2}, B::ADA{<:Any,1}) = rebuild(B, A * data(B), (AnonDim(Base.OneTo(1)),))
 Base.:*(A::AA{<:Any,2}, B::ADA{<:Any,2}) = rebuild(B, A * data(B), dims(B, (2, 2)))
 
 Base.:*(A::ADA{<:Any,1}, B::ADA{<:Any,2}) = begin
@@ -160,7 +160,7 @@ for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint),
         @inline $pkg.$fname(A::AbDimArray{T,2}) where T =
             rebuild(A, $pkg.$fname(data(A)), reverse(dims(A)))
         @inline $pkg.$fname(A::AbDimArray{T,1}) where T =
-            rebuild(A, $pkg.$fname(data(A)), (PlaceholderDim(), dims(A)...))
+            rebuild(A, $pkg.$fname(data(A)), (AnonDim(Base.OneTo(1)), dims(A)...))
     end
 end
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -447,8 +447,8 @@ Empty tuples are allowed
 @inline comparedims(a::DimTuple, b::Tuple{}) = a
 @inline comparedims(a::Tuple{}, b::DimTuple) = b
 @inline comparedims(a::Tuple{}, b::Tuple{}) = ()
-@inline comparedims(a::Dimension, b::PlaceholderDim) = a
-@inline comparedims(a::PlaceholderDim, b::Dimension) = b
+@inline comparedims(a::Dimension, b::AnonDim) = a
+@inline comparedims(a::AnonDim, b::Dimension) = b
 @inline comparedims(a::Dimension, b::Dimension) = begin
     basetypeof(a) == basetypeof(b) ||
         throw(DimensionMismatch("$(basetypeof(a)) and $(basetypeof(b)) dims on the same axis"))

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -12,7 +12,7 @@ using Combinatorics: combinations
     @test length.(dims(A1)) == size(A1)
     @test dims(data(A1) * permutedims(A1)) isa Tuple{<:Ti,<:Ti}
     @test data(A1) * permutedims(A1) == data(A1) * permutedims(data(A1))
-    @test dims(permutedims(A1) * data(A1)) isa Tuple{<:PlaceholderDim}
+    @test dims(permutedims(A1) * data(A1)) isa Tuple{<:AnonDim}
     @test permutedims(A1) * data(A1) == permutedims(data(A1)) * data(A1)
 
     @test length.(dims(permutedims(A1) * data(A1))) == size(permutedims(data(A1)) * data(A1))
@@ -51,7 +51,7 @@ using Combinatorics: combinations
     for flip in (adjoint, transpose, permutedims)
         result = flip(b1) * B1
         @test result ≈ true_result  # Permute dims is not exactly transpose
-        @test dims(result) isa Tuple{<:PlaceholderDim, <:X}
+        @test dims(result) isa Tuple{<:AnonDim, <:X}
         @test length.(dims(result)) == (1, 6)
     end
 


### PR DESCRIPTION
uses AnonDim as anonymous dimension name, and gives it a value (equal to the array axis) so that 
dim length is always the axis length. This alows more flexible use than just cases where `val = 1:1`.

Closes #79