### PR TITLE
bugfix plotting with dimension metadata

### DIFF
--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -107,7 +107,7 @@ name(dim::Dimension) = name(typeof(dim))
 shortname(d::Dimension) = shortname(typeof(d))
 shortname(d::Type{<:Dimension}) = name(d) # Use `name` as fallback
 units(dim::Dimension) =
-    metadata(dim) == nothing ? nothing : get(val(metadata(dim)), :units, nothing)
+    metadata(dim) == nothing ? nothing : get(metadata(dim), :units, nothing)
 
 
 bounds(dim::Dimension) = bounds(mode(dim), dim)


### PR DESCRIPTION
Attempting to plot data where axes contain metadata caused an error due to the `metadata` call being wrapped in `val`.

```julia
using DimensionalData
using Plots
x1 = 0:.1:1;
y1 = cos.(x1);
md = Dict{Any,Any}(:test=>"hello data");
md1 = Dict{Any,Any}(:test=>"hello axis 1");
d = DimensionalArray(y1, (X(x1,metadata=md1), ), metadata=md);
plot(d)
```

PS. first pull request so hope I'm doing this correctly :)