### PR TITLE
Compile time indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.10.11"
+version = "0.11.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -35,7 +35,7 @@ export Aligned, AbstractSampled, Sampled,
 
 export Unaligned, Transformed
 
-export AbstractDimensionalArray, DimensionalArray
+export AbstractDimensionalArray, DimensionalArray, DimArray
 
 export data, dims, refdims, mode, metadata, name, shortname,
        val, label, units, order, bounds, locus, mode, <|

--- a/src/array.jl
+++ b/src/array.jl
@@ -61,10 +61,51 @@ Base.iterate(A::AbDimArray, args...) = iterate(data(A), args...)
 Base.IndexStyle(A::AbstractDimensionalArray) = Base.IndexStyle(data(A))
 Base.parent(A::AbDimArray) = data(A)
 
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, I::StandardIndices...) =
-    rebuildsliced(A, getindex(data(A), I...), I)
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, I::Integer...) =
-    getindex(data(A), I...)
+@inline Base.axes(A::AbstractArray, dims::DimOrDimType) = axes(A, dimnum(A, dims))
+@inline Base.size(A::AbstractArray, dims::DimOrDimType) = size(A, dimnum(A, dims))
+
+@inline rebuildsliced(A, data, I, name::String=name(A)) =
+    rebuild(A, data, slicedims(A, I)..., name)
+
+# Standard indices
+Base.@propagate_inbounds Base.getindex(A::AbDimArray, i::Integer, I::Integer...) =
+    getindex(data(A), i, I...)
+Base.@propagate_inbounds Base.getindex(A::AbDimArray, i::StandardIndices, I::StandardIndices...) =
+    rebuildsliced(A, getindex(data(A), i, I...), (i, I...))
+Base.@propagate_inbounds Base.view(A::AbDimArray, i::StandardIndices, I::StandardIndices...) =
+    rebuildsliced(A, view(data(A), i, I...), (i, I...))
+Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, i::StandardIndices, I::StandardIndices...) =
+    setindex!(data(A), x, i, I...)
+
+# Cartesian indices
+Base.@propagate_inbounds Base.getindex(A::AbDimArray, I::CartesianIndex) =
+    getindex(data(A), I)
+Base.@propagate_inbounds Base.view(A::AbDimArray, I::CartesianIndex) =
+    view(data(A), I)
+Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, I::CartesianIndex) =
+    setindex!(data(A), x, I)
+
+# Dimension indexing. Additional methods for dispatch ambiguity
+Base.@propagate_inbounds Base.getindex(A::AbDimArray, dim::Dimension, dims::Vararg{<:Dimension}) =
+    getindex(A, dims2indices(A, (dim, dims...))...)
+Base.@propagate_inbounds Base.getindex(A::AbstractArray, dim::Dimension, dims::Vararg{<:Dimension}) =
+    getindex(A, dims2indices(A, (dim, dims...))...)
+Base.@propagate_inbounds Base.view(A::AbDimArray, dim::Dimension, dims::Vararg{<:Dimension}) =
+    view(A, dims2indices(A, (dim, dims...))...)
+Base.@propagate_inbounds Base.view(A::AbstractArray, dim::Dimension, dims::Vararg{<:Dimension}) =
+    view(A, dims2indices(A, (dim, dims...))...)
+Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, dim::Dimension, dims::Vararg{<:Dimension}) =
+    setindex!(A, x, dims2indices(A, (dim, dims...))...)
+Base.@propagate_inbounds Base.setindex!(A::AbstractArray, x, dim::Dimension, dims::Vararg{<:Dimension}) =
+    setindex!(A, x, dims2indices(A, (dim, dims...))...)
+
+# Selector indexing without dim wrappers. Must be in the right order!
+Base.@propagate_inbounds Base.getindex(A::AbDimArray, i, I...) =
+    getindex(A, sel2indices(A, maybeselector(i, I...))...)
+Base.@propagate_inbounds Base.view(A::AbDimArray, i, I...) =
+    view(A, sel2indices(A, maybeselector(i, I...))...)
+Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, i, I...) =
+    setindex!(A, x, sel2indices(A, maybeselector(i, I...))...)
 
 # Linear indexing returns Array
 Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, N} where N, i::Union{Colon,AbstractArray}) =
@@ -73,26 +114,12 @@ Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, N} where N, i::Union
 Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, 1}, i::Union{Colon,AbstractArray}) =
     rebuildsliced(A, getindex(data(A), i), (i,))
 
-Base.@propagate_inbounds Base.view(A::AbDimArray, I::StandardIndices...) =
-    rebuildsliced(A, view(data(A), I...), I)
 # Linear indexing returns unwrapped SubArray
 Base.@propagate_inbounds Base.view(A::AbDimArray{<:Any, N} where N, i::StandardIndices) =
     view(data(A), i)
 # Exempt 1D DimArrays
 Base.@propagate_inbounds Base.view(A::AbDimArray{<:Any, 1}, i::StandardIndices) =
     rebuildsliced(A, view(data(A), i), (i,))
-
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, I::StandardIndices...) =
-    setindex!(data(A), x, I...)
-
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, dim::Dimension, dims::Vararg{<:Dimension}) =
-    getindex(A, dims2indices(A, (dim, dims...))...)
-
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, dim::Dimension, dims::Vararg{<:Dimension}) =
-    setindex!(A, x, dims2indices(A, (dim, dims...))...)
-
-Base.@propagate_inbounds Base.view(A::AbDimArray, dim::Dimension, dims::Vararg{<:Dimension}) =
-    view(A, dims2indices(A, (dim, dims...))...)
 
 Base.copy(A::AbDimArray) = rebuild(A, copy(data(A)))
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -158,22 +158,9 @@ struct DimensionalArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na<:Abstract
     refdims::R
     name::Na
     metadata::Me
-    function DimensionalArray(data::A, dims::D, refdims::R, name::Na, metadata::Me
-                             ) where {D,R,A<:AbstractArray{T,N},Na,Me} where {T,N}
-        map(dims, size(data)) do d, len
-            if !_matchlen(val(d), len)
-                throw(DimensionMismatch(
-                    "dims must have same size as data. This was not true for $dims and size $(size(data)) $(A)."
-                ))
-            end
-        end
-        new{T,N,D,R,A,Na,Me}(data, dims, refdims, name, metadata)
-    end
 end
 
-_matchlen(::Colon, len) = true
-_matchlen(A::AbstractArray, len) = length(A) == len
-_matchlen(::Val{X}, len) where X = length(X) == len
+const DimArray = DimensionalArray
 
 
 """

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -2,12 +2,25 @@
 Dimension is the abstract supertype of all dimension types.
 
 Example concrete implementations are `X`, `Y`, `Z`, 
-`Ti` (Time), and the arbirary `Dim{:custom}` dimension.
+`Ti` (Time), and the custom `Dim{:custom}` dimension.
 
 `Dimension`s label the axes of an `AbstractDimesnionalArray`, 
-or other dimensional data. They may also provide an alternate index 
-to lookup for each array axis.
+or other dimensional data. 
 
+They may also provide an alternate index to lookup for each array axis.
+This may be any `AbstractArray` matching the array axis length, or a `Val`
+holding a tuple for compile-time index lookups.
+
+`Dimension`s also have `mode` and `metadata` fields. 
+
+`mode` gives more details about the dimension, such as that it is 
+[`Categorical`](@ref) or [`Sampled`](@ref) as [`Points`](@ref) or 
+[`Intervals`](@ref) along some transect. DimensionalData will
+attempt to guess the mode from the passed-in index value.
+
+`metadata` can hold any metadata object adding more information about 
+the array axis - useful for extending DimensionalData for specific 
+contexts, like geospatial data in GeoData.jl. By default it is `nothing`.
 
 Example:
 
@@ -99,7 +112,7 @@ abstract type ZDim{T,IM,M} <: Dimension{T,IM,M} end
 """
 Abstract parent type for all time dimensions.
 
-For an index with `Interval` sampling the locus will automatically be
+An index in a `TimeDime` with `Interval` sampling the locus will automatically be
 set to `Start()`, as a date/time index generally defines the start of a 
 month, second etc, not the central point as is more common with spatial data.
 `"""
@@ -153,24 +166,33 @@ bounds(dims::DimTuple, lookupdim::DimOrDimType) = bounds(dims[dimnum(dims, looku
 Base.eltype(dim::Type{<:Dimension{T}}) where T = T
 Base.eltype(dim::Type{<:Dimension{A}}) where A<:AbstractArray{T} where T = T
 Base.size(dim::Dimension) = size(val(dim))
+Base.size(dim::Dimension{<:Val}) = (length(unwrap(val(dim))),)
 Base.axes(dim::Dimension) = axes(val(dim))
+Base.axes(dim::Dimension{<:Val}) = (Base.OneTo(length(dim)),)
 Base.eachindex(dim::Dimension) = eachindex(val(dim))
 Base.length(dim::Dimension{<:Union{AbstractArray,Number}}) = length(val(dim))
+Base.length(dim::Dimension{<:Val}) = length(unwrap(val(dim)))
 Base.ndims(dim::Dimension) = 0
 Base.ndims(dim::Dimension{<:AbstractArray}) = ndims(val(dim))
+Base.ndims(dim::Dimension{<:Val}) = 1
 Base.getindex(dim::Dimension) = val(dim)
 Base.getindex(dim::Dimension{<:AbstractArray}, I...) = getindex(val(dim), I...)
+Base.getindex(dim::Dimension{<:Val}, i) = Val(getindex(unwrap(val(dim)), i))
 Base.iterate(dim::Dimension{<:AbstractArray}, args...) = iterate(val(dim), args...)
 Base.first(dim::Dimension) = val(dim)
 Base.first(dim::Dimension{<:AbstractArray}) = first(val(dim))
+Base.first(dim::Dimension{<:Val}) = first(unwrap(val(dim)))
 Base.last(dim::Dimension) = val(dim)
 Base.last(dim::Dimension{<:AbstractArray}) = last(val(dim))
+Base.last(dim::Dimension{<:Val}) = last(unwrap(val(dim)))
 Base.firstindex(dim::Dimension) = 1
 Base.lastindex(dim::Dimension) = 1
 Base.firstindex(dim::Dimension{<:AbstractArray}) = firstindex(val(dim))
 Base.lastindex(dim::Dimension{<:AbstractArray}) = lastindex(val(dim))
+Base.lastindex(dim::Dimension{<:Val}) = lastindex(unwrap(val(dim)))
 Base.step(dim::Dimension) = step(mode(dim))
 Base.Array(dim::Dimension{<:AbstractArray}) = Array(val(dim))
+Base.Array(dim::Dimension{<:Val}) = [unwrap(val(dim))...]
 Base.:(==)(dim1::Dimension, dim2::Dimension) =
     typeof(dim1) == typeof(dim2) &&
     val(dim1) == val(dim2) &&

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -142,6 +142,8 @@ relationorder(dim::Dimension) = relationorder(order(dim))
 locus(dim::Dimension) = locus(mode(dim))
 sampling(dim::Dimension) = sampling(mode(dim))
 
+index(dim::Dimension) = unwrap(val(dim))
+
 # DimensionalData interface methods
 rebuild(dim::D, val, mode::IndexMode=mode(dim), metadata=metadata(dim)) where D <: Dimension =
     constructorof(D)(val, mode, metadata)

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -199,23 +199,6 @@ Base.:(==)(dim1::Dimension, dim2::Dimension) =
     mode(dim1) == mode(dim2) &&
     metadata(dim1) == metadata(dim2)
 
-# AbstractArray methods where dims are the dispatch argument
-
-@inline rebuildsliced(A, data, I, name::String=name(A)) =
-    rebuild(A, data, slicedims(A, I)..., name)
-
-Base.@propagate_inbounds Base.getindex(A::AbstractArray, dim::Dimension, dims::Vararg{<:Dimension}) =
-    getindex(A, dims2indices(A, (dim, dims...))...)
-
-Base.@propagate_inbounds Base.setindex!(A::AbstractArray, x, dim::Dimension, dims::Vararg{<:Dimension}) =
-    setindex!(A, x, dims2indices(A, (dim, dims...))...)
-
-Base.@propagate_inbounds Base.view(A::AbstractArray, dim::Dimension, dims::Vararg{<:Dimension}) =
-    view(A, dims2indices(A, (dim, dims...))...)
-
-@inline Base.axes(A::AbstractArray, dims::DimOrDimType) = axes(A, dimnum(A, dims))
-@inline Base.size(A::AbstractArray, dims::DimOrDimType) = size(A, dimnum(A, dims))
-
 
 """
 Dimensions with user-set type paremeters

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -172,6 +172,8 @@ end
 @inline reverseindex(dimstorev::Tuple{}, i) = ()
 @inline reverseindex(dim::Dimension) =
     rebuild(dim, reverse(val(dim)), reverseindex(mode(dim)))
+@inline reverseindex(dim::Dimension{<:Val}) =
+    rebuild(dim, Val(reverse(unwrap(val(dim)))), reverseindex(mode(dim)))
 
 
 """

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -502,7 +502,9 @@ identify(mode::IndexMode, dimtype::Type, index) = mode
 identify(mode::Auto, dimtype::Type, index::AbstractArray) =
     identify(Sampled(), dimtype, index)
 identify(mode::Auto, dimtype::Type, index::AbstractArray{<:CategoricalEltypes}) =
-    order(mode) isa AutoOrder ? Categorical() : Categorical(order(mode))
+    order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))
+identify(mode::Auto, dimtype::Type, index::Val) =
+    order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))
 
 # Sampled
 identify(mode::AbstractSampled, dimtype::Type, index::AbstractArray) = begin

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -42,7 +42,7 @@ end
     dim = dims(A, 1)
     :ylabel --> label(A)
     :xlabel --> label(dim)
-    val(dim), parent(A)
+    unwrap(index(dim)), parent(A)
 end
 @recipe function f(::SeriesLike, A::AbstractArray{T,2}) where T
     A = maybe_permute(A, (IndependentDim, DependentDim))
@@ -50,22 +50,22 @@ end
     :xlabel --> label(ind)
     :ylabel --> label(A)
     :legendtitle --> label(dep)
-    :labels --> permutedims(val(dep))
-    val(ind), data(A)
+    :labels --> permutedims(index(dep))
+    index(ind), data(A)
 end
 
 @recipe function f(::HistogramLike, A::AbstractArray{T,1}) where T
     dim = dims(A, 1)
     :xlabel --> label(A)
-    val(dim), data(A)
+    index(dim), data(A)
 end
 @recipe function f(::HistogramLike, A::AbstractArray{T,2}) where T
     A = maybe_permute(A, (IndependentDim, DependentDim))
     ind, dep = dims(A)
     :xlabel --> label(A)
     :legendtitle --> label(dep)
-    :labels --> permutedims(val(dep))
-    val(ind), data(A)
+    :labels --> permutedims(index(dep))
+    index(ind), data(A)
 end
 
 @recipe function f(::ViolinLike, A::AbstractArray{T,1}) where T
@@ -79,7 +79,7 @@ end
     :xlabel --> label(dep)
     :ylabel --> label(A)
     :legendtitle --> label(dep)
-    :labels --> permutedims(val(dep))
+    :labels --> permutedims(index(dep))
     data(A)
 end
 
@@ -87,7 +87,7 @@ end
     dim = dims(A, 1)
     :xlabel --> label(dim)
     :ylabel --> label(A)
-    val(dim), data(A)
+    index(dim), data(A)
 end
 
 @recipe function f(::HeatMapLike, A::AbstractArray{T,2}) where T
@@ -119,5 +119,5 @@ refdims_title(mode::AbstractSampled, dim::Dimension) = begin
          "$start to $stop"
     end
 end
-refdims_title(mode::IndexMode, dim::Dimension) = string(val(dim))
+refdims_title(mode::IndexMode, dim::Dimension) = string(index(dim))
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -16,8 +16,8 @@ const UnionAllTupleOrVector = Union{Vector{UnionAll},Tuple{UnionAll,Vararg}}
 @inline Base.permutedims(tosort::DimTuple, order::DimTuple) =
     _sortdims(tosort, order)
 
-_sortdims(tosort::Tuple, order::Tuple) = _sortdims(tosort, order, ())
-_sortdims(tosort::Tuple, order::Tuple, rejected) =
+@inline _sortdims(tosort::Tuple, order::Tuple) = _sortdims(tosort, order, ())
+@inline _sortdims(tosort::Tuple, order::Tuple, rejected) =
     # Match dims to the order, and also check if the mode has a
     # transformed dimension that matches
     if _dimsmatch(tosort[1], order[1])
@@ -26,13 +26,13 @@ _sortdims(tosort::Tuple, order::Tuple, rejected) =
         _sortdims(tail(tosort), order, (rejected..., tosort[1]))
     end
 # Return nothing and start on a new dim
-_sortdims(tosort::Tuple{}, order::Tuple, rejected) =
+@inline _sortdims(tosort::Tuple{}, order::Tuple, rejected) =
     (nothing, _sortdims(rejected, tail(order), ())...)
 # Return an empty tuple if we run out of dims to sort
-_sortdims(tosort::Tuple, order::Tuple{}, rejected) = ()
-_sortdims(tosort::Tuple{}, order::Tuple{}, rejected) = ()
+@inline _sortdims(tosort::Tuple, order::Tuple{}, rejected) = ()
+@inline _sortdims(tosort::Tuple{}, order::Tuple{}, rejected) = ()
 
-_dimsmatch(dim::DimOrDimType, match::DimOrDimType) =
+@inline _dimsmatch(dim::DimOrDimType, match::DimOrDimType) =
     basetypeof(dim) <: basetypeof(match) || basetypeof(dim) <: basetypeof(dims(mode(match)))
 
 """
@@ -156,11 +156,11 @@ end
 @inline slicedims(d::Dimension{<:Colon}, i::AbstractArray) = (d,), ()
 @inline slicedims(d::Dimension{<:Colon}, i::Number) = (), (d,)
 
-relate(d::Dimension, i) = maybeflip(relationorder(d), d, i)
+@inline relate(d::Dimension, i) = maybeflip(relationorder(d), d, i)
 
-maybeflip(::Forward, d, i) = i
-maybeflip(::Reverse, d, i::Integer) = lastindex(d) - i + 1
-maybeflip(::Reverse, d, i::AbstractArray) = reverse(lastindex(d) .- i .+ 1)
+@inline maybeflip(::Forward, d, i) = i
+@inline maybeflip(::Reverse, d, i::Integer) = lastindex(d) - i + 1
+@inline maybeflip(::Reverse, d, i::AbstractArray) = reverse(lastindex(d) .- i .+ 1)
 
 """
     dimnum(x, lookup)
@@ -169,7 +169,7 @@ Get the number(s) of `Dimension`(s) as ordered in the dimensions of an object.
 
 ## Arguments
 - `x`: any object with a `dims` method, a `Tuple` of `Dimension` or a single `Dimension`.
-- `lookup`: Tuple or single `Dimension` or dimension `Type`.
+- `lookup`: Tuple, Array or single `Dimension` or dimension `Type`.
 
 The return type will be a Tuple of `Int` or a single `Int`,
 depending on wether `lookup` is a `Tuple` or single `Dimension`.
@@ -183,26 +183,28 @@ julia> dimnum(A, Z)
 3
 ```
 """
-@inline dimnum(A, lookup) = dimnum(A, (lookup,))[1]
-@inline dimnum(A, lookup::AbstractArray) = dimnum(A, (lookup...,))
-@inline dimnum(A, lookup::Tuple) = dimnum(dims(A), lookup, (), 1)
+@inline dimnum(A, lookup) = dimnum(dims(A), lookup)
+@inline dimnum(d::Tuple, lookup) = dimnum(d, (lookup,))[1]
+@inline dimnum(d::Tuple, lookup::AbstractArray) = dimnum(d, (lookup...,))
+@inline dimnum(d::Tuple, lookup::Tuple) = _dimnum(d, lookup, (), 1)
+
 # Match dim and lookup, also check if the mode has a transformed dimension that matches
-@inline dimnum(d::Tuple, lookup::Tuple, rejected, n) =
+@inline _dimnum(d::Tuple, lookup::Tuple, rejected, n) =
     if !(d[1] isa Nothing) && _dimsmatch(d[1], lookup[1])
         # Replace found dim with nothing so it isn't found again but n is still correct
-        (n, dimnum((rejected..., nothing, tail(d)...), tail(lookup), (), 1)...)
+        (n, _dimnum((rejected..., nothing, tail(d)...), tail(lookup), (), 1)...)
     else
-        dimnum(tail(d), lookup, (rejected..., d[1]), n + 1)
+        _dimnum(tail(d), lookup, (rejected..., d[1]), n + 1)
     end
 # Numbers are returned as-is
-@inline dimnum(dims::Tuple, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
-@inline dimnum(dims::Tuple{}, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
+@inline _dimnum(dims::Tuple, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
+@inline _dimnum(dims::Tuple{}, lookup::Tuple{Number,Vararg}, rejected, n) = lookup
 # Throw an error if the lookup is not found
-@inline dimnum(dims::Tuple{}, lookup::Tuple, rejected, n) =
+@inline _dimnum(dims::Tuple{}, lookup::Tuple, rejected, n) =
     throw(ArgumentError("No $(basetypeof(lookup[1])) in dims"))
 # Return an empty tuple when we run out of lookups
-@inline dimnum(dims::Tuple, lookup::Tuple{}, rejected, n) = ()
-@inline dimnum(dims::Tuple{}, lookup::Tuple{}, rejected, n) = ()
+@inline _dimnum(dims::Tuple, lookup::Tuple{}, rejected, n) = ()
+@inline _dimnum(dims::Tuple{}, lookup::Tuple{}, rejected, n) = ()
 
 """
     hasdim(x, lookup)
@@ -255,20 +257,23 @@ val(dims(B, Y))
 'a':1:'j'
 ```
 """
-setdims(A, newdims::Union{Dimension,DimTuple}) = rebuild(A, data(A), setdims(dims(A), newdims))
-setdims(dims::DimTuple, newdims::DimTuple) = map(nd -> setdims(dims, nd), newdims)
+@inline setdims(A, newdims::Union{Dimension,DimTuple}) = rebuild(A, data(A), setdims(dims(A), newdims))
+@inline setdims(dims::DimTuple, newdims::DimTuple) = map(nd -> setdims(dims, nd), newdims)
 # TODO handle the multiples of the same dim.
-setdims(dims::DimTuple, newdim::Dimension) = map(d -> setdims(d, newdim), dims)
-setdims(dim::Dimension, newdim::Dimension) =
+@inline setdims(dims::DimTuple, newdim::Dimension) = map(d -> setdims(d, newdim), dims)
+@inline setdims(dim::Dimension, newdim::Dimension) =
     basetypeof(dim) <: basetypeof(newdim) ? newdim : dim
 
 """
     swapdims(x, newdims)
 
-Swap the dimension for the passed in dimensions.
-Dimension wrapper types rewrap the original dimension, keeping
-the values and metadata. Dimension instances replace the original
-dimension, and `nothing` leaves the original dimension as-is.
+Swap dimensions for the passed in dimensions, in the
+order passed.
+
+Passing in the `Dimension` types rewraps the dimension index, 
+keeping the index values and metadata, while constructed `Dimension` 
+objectes replace the original dimension. `nothing` leaves the original 
+dimension as-is.
 
 ## Arguments
 - `x`: any object with a `dims` method, a `Tuple` of `Dimension` or a single `Dimension`.
@@ -286,14 +291,15 @@ julia> dimnum(B, Ti)
 3
 ```
 """
-swapdims(A::AbstractArray, newdims::Tuple) =
+@inline swapdims(A::AbstractArray, newdims::Tuple) =
     rebuild(A, data(A), formatdims(A, swapdims(dims(A), newdims)))
-swapdims(dims::DimTuple, newdims::Tuple) =
+@inline swapdims(dims::DimTuple, newdims::Tuple) =
     map((d, nd) -> _swapdims(d, nd), dims, newdims)
-_swapdims(dim::Dimension, newdim::DimType) =
+
+@inline _swapdims(dim::Dimension, newdim::DimType) =
     basetypeof(newdim)(val(dim), mode(dim), metadata(dim))
-_swapdims(dim::Dimension, newdim::Dimension) = newdim
-_swapdims(dim::Dimension, newdim::Nothing) = dim
+@inline _swapdims(dim::Dimension, newdim::Dimension) = newdim
+@inline _swapdims(dim::Dimension, newdim::Nothing) = dim
 
 
 """
@@ -319,6 +325,7 @@ formatdims(axis::AbstractRange, dim::Dimension{<:AbstractArray}) = begin
     rebuild(dim, val(dim), identify(mode(dim), basetypeof(dim), val(dim)))
 end
 formatdims(axis::AbstractRange, dim::Dimension{<:Val}) = begin
+    checkaxis(dim, axis)
     rebuild(dim, val(dim), identify(mode(dim), basetypeof(dim), val(dim)))
 end
 formatdims(axis::AbstractRange, dim::Dimension{<:NTuple{2}}) = begin
@@ -411,9 +418,9 @@ end
 @inline reducedims(locus::Locus, dim::Dimension) = reducedims(Center(), dim)
 
 # Need to specialise for more types
-centerval(index::AbstractArray{<:AbstractFloat}, len) =
+@inline centerval(index::AbstractArray{<:AbstractFloat}, len) =
     [(index[len ÷ 2] + index[len ÷ 2 + 1]) / 2]
-centerval(index::AbstractArray, len) =
+@inline centerval(index::AbstractArray, len) =
     [index[len ÷ 2 + 1]]
 
 

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -10,15 +10,7 @@ const SelectorOrStandard = Union{Selector, StandardIndices}
 val(sel::Selector) = sel.val
 rebuild(sel::Selector, val) = basetypeof(sel)(val)
 
-# Selector indexing without dim wrappers. Must be in the right order!
-Base.@propagate_inbounds Base.getindex(a::AbDimArray, I...) =
-    getindex(a, sel2indices(a, maybeselector(I))...)
-Base.@propagate_inbounds Base.setindex!(a::AbDimArray, x, I...) =
-    setindex!(a, x, sel2indices(a, maybeselector(I))...)
-Base.@propagate_inbounds Base.view(a::AbDimArray, I...) =
-    view(a, sel2indices(a, maybeselector(I))...)
-
-
+@inline maybeselector(I...) = maybeselector(I)
 @inline maybeselector(I::Tuple) = map(maybeselector, I)
 # Int AbstractArray and Colon do normal indexing
 @inline maybeselector(i::StandardIndices) = i

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -11,12 +11,21 @@ val(sel::Selector) = sel.val
 rebuild(sel::Selector, val) = basetypeof(sel)(val)
 
 # Selector indexing without dim wrappers. Must be in the right order!
-Base.@propagate_inbounds Base.getindex(a::AbDimArray, I::Vararg{SelectorOrStandard}) =
-    getindex(a, sel2indices(a, I)...)
-Base.@propagate_inbounds Base.setindex!(a::AbDimArray, x, I::Vararg{SelectorOrStandard}) =
-    setindex!(a, x, sel2indices(a, I)...)
-Base.view(a::AbDimArray, I::Vararg{SelectorOrStandard}) =
-    view(a, sel2indices(a, I)...)
+Base.@propagate_inbounds Base.getindex(a::AbDimArray, I...) =
+    getindex(a, sel2indices(a, maybeselector(I))...)
+Base.@propagate_inbounds Base.setindex!(a::AbDimArray, x, I...) =
+    setindex!(a, x, sel2indices(a, maybeselector(I))...)
+Base.@propagate_inbounds Base.view(a::AbDimArray, I...) =
+    view(a, sel2indices(a, maybeselector(I))...)
+
+
+@inline maybeselector(I::Tuple) = map(maybeselector, I)
+# Int AbstractArray and Colon do normal indexing
+@inline maybeselector(i::StandardIndices) = i
+# Selectors are allready selectors
+@inline maybeselector(i::Selector) = i
+# Anything else becomes `At`
+@inline maybeselector(i) = At(i)
 
 """
     At(x, atol, rtol)
@@ -168,26 +177,26 @@ val(sel::Where) = sel.f
 # Get the dims in the same order as the mode
 # This would be called after RegularIndex and/or Categorical
 # dimensions are removed
-_dims2indices(mode::Transformed, dims::Tuple, lookups::Tuple, emptyval) =
+@inline _dims2indices(mode::Transformed, dims::Tuple, lookups::Tuple, emptyval) =
     sel2indices(mode, dims, map(val, permutedims(dimz, dims(mode))))
 
-sel2indices(A::AbstractArray, lookup) = sel2indices(dims(A), lookup)
-sel2indices(dims::Tuple, lookup) = sel2indices(dims, (lookup,))
-sel2indices(dims::Tuple, lookup::Tuple) =
+@inline sel2indices(A::AbstractArray, lookup) = sel2indices(dims(A), lookup)
+@inline sel2indices(dims::Tuple, lookup) = sel2indices(dims, (lookup,))
+@inline sel2indices(dims::Tuple, lookup::Tuple) =
     map((d, l) -> sel2indices(l, mode(d), d), dims, lookup)
 
 # First filter based on rough selector properties -----------------
 # Mode is passed in from dims2indices
 
 # Standard indices are just returned.
-sel2indices(sel::StandardIndices, ::IndexMode, ::Dimension) = sel
+@inline sel2indices(sel::StandardIndices, ::IndexMode, ::Dimension) = sel
 # Vectors are mapped
-sel2indices(sel::Selector{<:AbstractVector}, mode::IndexMode, dim::Dimension) =
+@inline sel2indices(sel::Selector{<:AbstractVector}, mode::IndexMode, dim::Dimension) =
     [sel2indices(mode, dim, rebuild(sel, v)) for v in val(sel)]
-sel2indices(sel::Selector, mode::IndexMode, dim::Dimension) =
+@inline sel2indices(sel::Selector, mode::IndexMode, dim::Dimension) =
     sel2indices(mode, dim, sel)
 
-sel2indices(sel::Where, mode::IndexMode, dim::Dimension) =
+@inline sel2indices(sel::Where, mode::IndexMode, dim::Dimension) =
     [i for (i, v) in enumerate(val(dim)) if sel.f(v)]
 
 # Then dispatch based on IndexMode -----------------
@@ -195,12 +204,12 @@ sel2indices(sel::Where, mode::IndexMode, dim::Dimension) =
 # NoIndex
 # This just converts the selector to standard indices. Implemented just
 # so the Selectors actually work, not because what they do is useful or interesting.
-sel2indices(mode::NoIndex, dim::Dimension, sel::Union{At,Near,Contains}) = val(sel)
-sel2indices(mode::NoIndex, dim::Dimension, sel::Union{Between}) =
+@inline sel2indices(mode::NoIndex, dim::Dimension, sel::Union{At,Near,Contains}) = val(sel)
+@inline sel2indices(mode::NoIndex, dim::Dimension, sel::Union{Between}) =
     val(sel)[1]:val(sel)[2]
 
 # Categorical
-sel2indices(mode::Categorical, dim::Dimension, sel::Selector) =
+@inline sel2indices(mode::Categorical, dim::Dimension, sel::Selector) =
     if sel isa Union{Contains,Near}
         sel2indices(Points(), mode, dim, At(val(sel)))
     else
@@ -208,17 +217,17 @@ sel2indices(mode::Categorical, dim::Dimension, sel::Selector) =
     end
 
 # Sampled
-sel2indices(mode::AbstractSampled, dim::Dimension, sel::Selector) =
+@inline sel2indices(mode::AbstractSampled, dim::Dimension, sel::Selector) =
     sel2indices(sampling(mode), mode, dim, sel)
 
 # For Sampled filter based on sampling type and selector -----------------
 
 # At selector
-sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::At) =
+@inline sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::At) =
     at(sampling, mode, dim, sel)
 
 # Near selector
-sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Near) = begin
+@inline sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Near) = begin
     if span(mode) isa Irregular && locus(mode) isa Union{Start,End}
         error("Near is not implemented for Irregular with Start or End loci. Use Contains")
     end
@@ -226,13 +235,13 @@ sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Near) = be
 end
 
 # Contains selector
-sel2indices(sampling::Points, mode::T, dim::Dimension, sel::Contains) where T =
+@inline sel2indices(sampling::Points, mode::T, dim::Dimension, sel::Contains) where T =
     throw(ArgumentError("`Contains` has no meaning with `Points`. Use `Near`"))
-sel2indices(sampling::Intervals, mode::IndexMode, dim::Dimension, sel::Contains) =
+@inline sel2indices(sampling::Intervals, mode::IndexMode, dim::Dimension, sel::Contains) =
     contains(sampling, mode, dim, sel)
 
 # Between selector
-sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Between{<:Tuple}) =
+@inline sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Between{<:Tuple}) =
     between(sampling, mode, dim, sel)
 
 
@@ -240,7 +249,7 @@ sel2indices(sampling::Sampling, mode::IndexMode, dim::Dimension, sel::Between{<:
 
 # We use the transformation from the first Transformed dim.
 # In practice the others could be empty.
-sel2indices(sel::Tuple{Vararg{<:Selector}}, modes::Tuple{Vararg{<:Transformed}}, 
+@inline sel2indices(sel::Tuple{Vararg{<:Selector}}, modes::Tuple{Vararg{<:Transformed}}, 
             dims::DimTuple) =
     map(_to_int, sel, transform(modes[1])([map(val, sel)...]))
 
@@ -250,23 +259,35 @@ _to_int(::Near, x) = round(Int, x)
 
 # Selector methods
 
-at(dim::Dimension, sel::At) =
+@inline at(dim::Dimension, sel::At) =
     at(sampling(mode(dim)), mode(dim), dim, sel)
-at(::Sampling, mode::IndexMode, dim::Dimension, sel::At) =
+@inline at(::Sampling, mode::IndexMode, dim::Dimension, sel::At) =
     relate(dim, at(dim, val(sel), atol(sel), rtol(sel)))
-at(dim::Dimension, selval, atol::Nothing, rtol::Nothing) = begin
-    i = findfirst(x -> x == selval, val(dim))
-    i == nothing && throw(ArgumentError("$selval not found in $dim"))
+@inline at(dim::Dimension{<:Val{Index}}, selval, atol::Nothing, rtol::Nothing) where Index = begin
+    i = findfirst(x -> x == selval, Index)
+    i == nothing && selvalnotfound(dim, selval)
     return i
 end
-at(dim::Dimension, selval, atol, rtol) = begin
+@inline at(dim::Dimension{<:Val{Index}}, selval::Val, atol::Nothing, rtol::Nothing) where Index = begin
+    i = findfirst(x -> x == unwrap(selval), Index)
+    i == nothing && selvalnotfound(dim, selval)
+    return i
+end
+@inline at(dim::Dimension, selval, atol::Nothing, rtol::Nothing) = begin
+    i = findfirst(x -> x == selval, val(dim))
+    i == nothing && selvalnotfound(dim, selval)
+    return i
+end
+@inline at(dim::Dimension, selval, atol, rtol) = begin
     # This is not particularly efficient. It should be separated
     # out for unordered dims and otherwise treated as an ordered list.
     i = findfirst(x -> isapprox(x, selval; atol=atol, rtol=rtol), val(dim))
-    i == nothing && throw(ArgumentError("$selval not found in $dim"))
+    i == nothing && selvalnotfound(dim, selval)
     return i
 end
 
+@noinline selvalnotfound(dim, selval) = 
+    throw(ArgumentError("$selval not found in $dim"))
 
 near(dim::Dimension, sel::Near) =
     near(sampling(mode(dim)), mode(dim), dim, sel)
@@ -459,9 +480,17 @@ end
 
 _searchlast(::Forward, dim::Dimension, v) = searchsortedlast(val(dim), v)
 _searchlast(::Reverse, dim::Dimension, v) = searchsortedlast(val(dim), v; rev=true)
+_searchlast(::Forward, dim::Dimension{<:Val{Index}}, v) where Index = 
+    searchsortedlast(Index, v)
+_searchlast(::Reverse, dim::Dimension{<:Val{Index}}, v) where Index = 
+    searchsortedlast(Index, v; rev=true)
 
-_searchfirst(::Forward, dim::Dimension, v) = searchsortedfirst(val(dim), v)
-_searchfirst(::Reverse, dim::Dimension, v) = searchsortedfirst(val(dim), v; rev=true)
+@inline _searchfirst(::Forward, dim::Dimension, v) = searchsortedfirst(val(dim), v)
+@inline _searchfirst(::Reverse, dim::Dimension, v) = searchsortedfirst(val(dim), v; rev=true)
+@inline _searchfirst(::Forward, dim::Dimension{<:Val{Index}}, v) where Index = 
+    searchsortedfirst(Index, v)
+@inline _searchfirst(::Reverse, dim::Dimension{<:Val{Index}}, v) where Index = 
+    searchsortedfirst(Index, v; rev=true)
 
 _locus_adjustment(mode::AbstractSampled, span::Regular) =
     _locus_adjustment(locus(mode), abs(step(span)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,3 +5,6 @@ end
 
 # Left pipe operator for cleaning up brackets
 f <| x = f(x)
+
+unwrap(::Val{X}) where X = X
+unwrap(::Type{Val{X}}) where X = X

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,3 +8,4 @@ f <| x = f(x)
 
 unwrap(::Val{X}) where X = X
 unwrap(::Type{Val{X}}) where X = X
+unwrap(x) = x

--- a/test/array.jl
+++ b/test/array.jl
@@ -259,7 +259,6 @@ end
 
 @testset "constructor" begin
     da = DimensionalArray(rand(5, 4), (X, Y))
-    @test_throws DimensionMismatch DimensionalData.rebuild(da, data(da), (X(1:5), Y(1:2)))
     @test_throws DimensionMismatch DimensionalArray(1:5, X(1:6))
     @test_throws MethodError DimensionalArray(1:5, (X(1:5), Y(1:2)))
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -49,11 +49,9 @@ using DimensionalData, Test
         v = DimensionalArray(zeros(3,), X)
         m = DimensionalArray(ones(3, 3), (X, Y))
         s = 0
-
         @test v .+ m == ones(3, 3) == m .+ v
         @test s .+ m == ones(3, 3) == m .+ s
         @test s .+ v .+ m == ones(3, 3) == m .+ s .+ v
-
         @test dims(v .+ m) == dims(m .+ v)
         @test dims(s .+ m) == dims(m .+ s)
         @test dims(s .+ v .+ m) == dims(m .+ s .+ v)
@@ -78,7 +76,6 @@ using DimensionalData, Test
             A -> A[:, 1:1], # Single Column Matrix
             first, # Scalar
          )
-
         for (T1, T2, T3) in Iterators.product(casts, casts, casts)
             all(isequal(identity), (T1, T2, T3)) && continue
             !any(isequal(DimensionalArray), (T1, T2, T3)) && continue
@@ -86,7 +83,6 @@ using DimensionalData, Test
             @test total == 6ones(3, 6)
             @test dims(total) == (X(), Y())
         end
-
     end
 
     @testset "in-place assignment .=" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -44,6 +44,16 @@ dimz = dims(da)
               Y([10.0, 20.0], Sampled(Ordered(), Irregular(0.0, 30.0), Intervals(Center())), nothing)), ())
         @test slicedims((), (1:2, 3)) == ((), ())
     end
+    @testset "Val index" begin
+        da = DimensionalArray(a, (X(Val((143, 145))), Y(Val((:x, :y, :z)))))
+        dimz = dims(da)
+        @test slicedims(dimz, (1:2, 3)) == 
+            ((X(Val((143,145)), Categorical(), nothing),),
+             (Y(Val(:z), Categorical(), nothing),))
+        @test slicedims(dimz, (2:2, :)) == 
+            ((X(Val((145,)), Categorical(), nothing), 
+              Y(Val((:x, :y, :z)), Categorical(), nothing)), ())
+    end
 end
 
 @testset "dims2indices" begin

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -9,8 +9,7 @@ a = [1 2  3  4
 dims_ = X(10:10:20; mode=Sampled(sampling=Intervals())),
         Y(5:7; mode=Sampled(sampling=Intervals()))
 A = DimensionalArray([1 2 3; 4 5 6], dims_)
-A[X(Contains(8)), Y(Contains(6.8))]
-3
+
 
 @testset "selector primitives" begin
 
@@ -518,6 +517,7 @@ end
     da = DimensionalArray(a, dimz)
     @test da[Ti(At([:one, :two])), Y(Contains(:b))] == [2, 6]
     @test da[At(:two), Between(:b, :d)] == [6, 7, 8]
+    @test da[:two, :b] == 6
     # Near and contains are just At
     @test da[Contains([:one, :three]), Near([:b, :c, :d])] == [2 3 4; 10 11 12]
    
@@ -525,6 +525,16 @@ end
         Y([:a, :b, :c, :d]; mode=Categorical(Unordered()))
     da = DimensionalArray(a, dimz)
     @test_throws ArgumentError da[At(:two), Between(:b, :d)] == [6, 7, 8]
+
+    a = [1 2  3  4
+         5 6  7  8
+         9 10 11 12]
+
+    valdimz = Ti(Val((:one, :two, :three)); mode=Categorical(Ordered())),
+        Y(Val((:a, :b, :c, :d)); mode=Categorical(Ordered()))
+    da = DimensionalArray(a, valdimz)
+    @test da[Val(:one), Val(:c)] == 3
+    @test da[:one, :a] == 1
 end
 
 @testset "Where " begin


### PR DESCRIPTION
This PR adds compile-time indexing using a `Tuple` index wrapped in `Val()` for the index, which will be assigned the `Categorical` mode by default.

You can then index with Val(:x) or :x (constant propagation should work for this).

This also changes a core assumption of DimensionalData.jl: now if you index with anything besides `Integer`, `Colon`, `AbstractArray` or `CartesianIndex` it will be guessed that you are trying to use the `At` selector, and wrap the value in `At()`. Previously this would just give an error.

This means you can do `A[:a, 25.0]` or `A[X(:a), Y(25.0)]`.

The main downside of this is it's a little confusing when your index values are in `Integer` - you
still have to us `At(3)` etc.

You also can't yet use `Between`, `Contains` etc on the `Val` index yet.