### PR TITLE
Remove auto atol for At

### DIFF
--- a/src/selector.jl
+++ b/src/selector.jl
@@ -49,10 +49,6 @@ struct At{T,A,R} <: Selector{T}
     atol::A
     rtol::R
 end
-At(val::Union{Number,AbstractArray{<:Number},Tuple{<:Number,Vararg}};
-   atol=zero(eltype(val)),
-   rtol=(atol > zero(eltype(val)) ? zero(rtol) : Base.rtoldefault(eltype(val)))
-  ) = At{typeof.((val, atol, rtol))...}(val, atol, rtol)
 At(val; atol=nothing, rtol=nothing) =
     At{typeof.((val, atol, rtol))...}(val, atol, rtol)
 
@@ -270,13 +266,13 @@ end
     i == nothing && selvalnotfound(dim, selval)
     return i
 end
-@inline at(dim::Dimension, selval, atol, rtol) = begin
-    # This is not particularly efficient. It should be separated
-    # out for unordered dims and otherwise treated as an ordered list.
-    i = findfirst(x -> isapprox(x, selval; atol=atol, rtol=rtol), val(dim))
-    i == nothing && selvalnotfound(dim, selval)
-    return i
-end
+# @inline at(dim::Dimension, selval, atol, rtol) = begin
+#     # This is not particularly efficient. It should be separated
+#     # out for unordered dims and otherwise treated as an ordered list.
+#     i = findfirst(x -> isapprox(x, selval; atol=atol, rtol=rtol), val(dim))
+#     i == nothing && selvalnotfound(dim, selval)
+#     return i
+# end
 
 @noinline selvalnotfound(dim, selval) = 
     throw(ArgumentError("$selval not found in $dim"))

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -284,11 +284,9 @@ end
     da = DimensionalArray(a, (Y((10, 30); mode=Sampled()),
                               Ti((1:4)u"s"; mode=Sampled())))
 
-    @test At(10.0) == At(10.0, 0.0, Base.rtoldefault(eltype(10.0)))
-    x = [10.0, 20.0]
-    @test At(x) === At(x, 0.0, Base.rtoldefault(eltype(10.0)))
-    @test At((10.0, 20.0)) === At((10.0, 20.0), 0.0, Base.rtoldefault(eltype(10.0)))
-
+    @test At(10.0) == At(10.0, nothing, nothing)
+    @test At(10.0; atol=0.0, rtol=Base.rtoldefault(Float64)) == 
+        At(10.0, 0.0, Base.rtoldefault(Float64))
     Near([10, 20])
 
     @test Between(10, 20) == Between((10, 20))
@@ -530,11 +528,11 @@ end
          5 6  7  8
          9 10 11 12]
 
-    valdimz = Ti(Val((:one, :two, :three)); mode=Categorical(Ordered())),
+    valdimz = Ti(Val((2.4, 2.5, 2.6)); mode=Categorical(Ordered())),
         Y(Val((:a, :b, :c, :d)); mode=Categorical(Ordered()))
     da = DimensionalArray(a, valdimz)
-    @test da[Val(:one), Val(:c)] == 3
-    @test da[:one, :a] == 1
+    @test da[Val(2.5), Val(:c)] == 7
+    @test da[2.4, :a] == 1
 end
 
 @testset "Where " begin


### PR DESCRIPTION
This allows `At` to be the default action for all non `Int` values. 

If the dimension holds a `Val{(1.0, 1.1, 1.2)}` or similar it can be indexed with no runtime overhead. This currently doesn't work for `Number` because atol/rtol values are set automatically. 

It you need them, set them manually as keyword args: 

```julia
At(x; atol=1e10)
```