### PR TITLE
use DimArray and AbstractDimArray everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ selector is assumed, and can be dropped completely:
 
 ```julia
 julia> A = DimArray(rand(3, 3), (X(Val((:a, :b, :c))), Y([25.6, 25.7, 25.8])))
-DimensionalArray with dimensions:
+DimArray with dimensions:
  X: Val{(:a, :b, :c)}()
  Y: Float64[25.6, 25.7, 25.8]
 and data: 3×3 Array{Float64,2}
@@ -109,13 +109,13 @@ _Example usage:_
 ```julia
 using Dates, DimensionalData
 timespan = DateTime(2001,1):Month(1):DateTime(2001,12)
-A = DimensionalArray(rand(12,10), (Ti(timespan), X(10:10:100)))
+A = DimArray(rand(12,10), (Ti(timespan), X(10:10:100)))
 
 julia> A[X(Near(35)), Ti(At(DateTime(2001,5)))]
 0.658404535807791
 
 julia> A[Near(DateTime(2001, 5, 4)), Between(20, 50)]
-DimensionalArray with dimensions:
+DimArray with dimensions:
  X: 20:10:50
 and referenced dimensions:
  Time (type Ti): 2001-05-01T00:00:00
@@ -145,7 +145,7 @@ Base and Statistics methods:
 _Example usage:_
 
 ```julia
-A = DimensionalArray(rand(20,10), (X, Y))
+A = DimArray(rand(20,10), (X, Y))
 size(A, Y)
 using Statistics
 mean(A, dims=X)

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -45,7 +45,7 @@ have an overhead for slicing the dimensions. =#
 const suite = BenchmarkGroup()
 
 suite["view"] = BenchmarkGroup(["view"])
-g = DimensionalArray(rand(100, 50), (X(51:150), Y(-40:9)))
+g = DimArray(rand(100, 50), (X(51:150), Y(-40:9)))
 
 vi1(g) = view(data(g), 1, 2)
 vd1(g) = view(g, X(1), Y(2))
@@ -77,7 +77,7 @@ suite["getindex"]["Parent indices with UnitRange"] = @benchmarkable i3($g)
 suite["getindex"]["Dims with UnitRange"] = @benchmarkable d3($g);
 
 a = rand(5, 4, 3);
-da = DimensionalArray(a, (Y((1u"m", 5u"m")), X(1:4), Ti(1:3)))
+da = DimArray(a, (Y((1u"m", 5u"m")), X(1:4), Ti(1:3)))
 dimz = dims(da)
 
 if VERSION > v"1.1-"
@@ -112,7 +112,7 @@ suite["reverse"]["dimarray_dim"] = @benchmarkable reverse($da; dims = Y())
 @dim Obs "Observation"
 
 sparse_a = sprand(1000, 1000, 0.1)
-sparse_d = DimensionalArray(sparse_a, (Var <| 1:1000, Obs <| 1:1000))
+sparse_d = DimArray(sparse_a, (Var <| 1:1000, Obs <| 1:1000))
 
 suite["sparse"] = BenchmarkGroup()
 # Benchmarks

--- a/benchmarks/runbencmarks.jl
+++ b/benchmarks/runbencmarks.jl
@@ -7,7 +7,7 @@ for N ∈ (10, 100, 1000)
 x = X(range(1; length = N))
 y = Y(range(1; length = N))
 d = (x, y)
-A = DimensionalArray(rand(length.(d)...), d)
+A = DimArray(rand(length.(d)...), d)
 
 println("N=$(N). Time to access via X(1:3)")
 @btime $(A)[$(X(1:3))];

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,13 +1,13 @@
 
 # API
 
-To use the functionality of DimensionalData in your module, dispatch on `AbstractDimensionalArray` and `AbstractDimension`.
+To use the functionality of DimensionalData in your module, dispatch on `AbstractDimArray` and `AbstractDimension`.
 
 Arrays:
 
 ```@docs
-AbstractDimensionalArray
-DimensionalArray
+AbstractDimArray
+DimArray
 ```
 
 ## Core types

--- a/docs/src/course.md
+++ b/docs/src/course.md
@@ -5,21 +5,21 @@ This is brief a tutorial for DimensionalData.jl.
 The main functionality is explained here, but the full list of features is
 listed at the [API](@ref) page.
 
-## Dimensions and DimensionalArrays
+## Dimensions and DimArrays
 
 The core type of DimensionalData.jl is the [`Dimension`](@ref) and the types
 that inherit from it, such as `Ti`, `X`, `Y`, `Z`, the generic `Dim{:x}`, or
 others that you define manually using the [`@dim`](@ref) macro.
 
-`Dimension`s are primarily used in [`DimensionalArray`](@ref), other
-[`AbstractDimensionalArray`](@ref).
+`Dimension`s are primarily used in [`DimArray`](@ref), other
+[`AbstractDimArray`](@ref).
 
 We can use dimensions without a value index - these simply label the axis.
-A `DimensionalArray` with labelled dimensions is constructed by:
+A `DimArray` with labelled dimensions is constructed by:
 
 ```@example main
 using DimensionalData
-A = DimensionalArray(rand(5, 5), (X, Y))
+A = DimArray(rand(5, 5), (X, Y))
 ```
 
 But often we want to provide values for the dimension.
@@ -34,11 +34,11 @@ Here both `X` and `Ti` are dimensions from `DimensionalData`. The currently
 exported dimensions are `X, Y, Z, Ti`. `Ti` is shortening of `Time` -
 to avoid the conflict with `Dates.Time`.
 
-We pass a `Tuple` of the dimensions to the constructor of `DimensionalArray`,
+We pass a `Tuple` of the dimensions to the constructor of `DimArray`,
 after the array:
 
 ```@example main
-A = DimensionalArray(rand(12, 10), (t, x))
+A = DimArray(rand(12, 10), (t, x))
 ```
 
 The length of each dimension index has to match the size of the corresponding
@@ -66,8 +66,8 @@ A[X(1:3:10)]
 ```
 
 !!! info "Indexing"
-    Indexing `AbstractDimensionalArray`s works with `getindex`, `setindex!` and
-    `view`. The result is still an `AbstracDimensionalArray`.
+    Indexing `AbstractDimArray`s works with `getindex`, `setindex!` and
+    `view`. The result is still an `AbstracDimArray`.
 
 
 ## Selecting by name and value
@@ -117,7 +117,7 @@ A[1:5]
 
 selects the first 5 entries of the underlying array. In the case that `A` has
 only one dimension, it will be retained. Multidimensional
-`AbstracDimensionalArray` indexed this way will return a regular array.
+`AbstracDimArray` indexed this way will return a regular array.
 
 
 
@@ -125,7 +125,7 @@ only one dimension, it will be retained. Multidimensional
 
 In many Julia functions like `size, sum`, you can specify the dimension along
 which to perform the operation, as an `Int`. It is also possible to do this
-using `Dimension` types with `AbstractDimensionalArray`:
+using `Dimension` types with `AbstractDimArray`:
 
 ```@example main
 sum(A; dims=X)
@@ -133,17 +133,17 @@ sum(A; dims=X)
 
 ## Numeric operations on dimension arrays and dimensions
 
-Numeric operations on a `AbstractDimensionalArray` match base Julia as much as
+Numeric operations on a `AbstractDimArray` match base Julia as much as
 possible. Standard broadcasting and other type of operations across dimensional
 arrays typically perform as expected while still returning an
-`AbstractDimensionalArray` type with correct dimensions.
+`AbstractDimArray` type with correct dimensions.
 
 In cases where you would like to do some operation on the dimension index, e.g.
 take the cosines of the values of the dimension `X` while still keeping the
 dimensional information of `X`, you can use the syntax:
 
 ```@example main
-DimensionalArray(cos, x)
+DimArray(cos, x)
 ```
 
 ## Referenced dimensions

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -34,7 +34,7 @@ Both AxisArrays and NamedDims use concrete types for dispatch on arrays, and for
 dimension type `Axis` in AxisArrays. This makes them hard to extend.
 
 Its a little easier with DimensionalData.jl. You can inherit from
-`AbstractDimensionalArray`, or just implement `dims` and `rebuild` methods. Dims
+`AbstractDimArray`, or just implement `dims` and `rebuild` methods. Dims
 and selectors in DimensionalData.jl are also extensible. Recursive primitive
 methods allow inserting whatever methods you want to add extra types.
 `@generated` is only used to match and permute arbitrary tuples of types, and
@@ -54,13 +54,13 @@ DimensionalData.jl provides the concrete `DimenstionalArray` type. But it's
 core purpose is to be easily used with other array types.
 
 Some of the functionality in DimensionalData.jl will work without inheriting
-from `AbstractDimensionalArray`. The main requirement define a `dims` method
+from `AbstractDimArray`. The main requirement define a `dims` method
 that returns a `Tuple` of `AbstractDimension` that matches the dimension order
 and axis values of your data. Define `rebuild`, and base methods for `similar`
 and `parent` if you want the metadata to persist through transformations (see
-the `DimensionalArray` and `AbstractDimensionalArray` types). A `refdims` method
+the `DimArray` and `AbstractDimArray` types). A `refdims` method
 returns the lost dimensions of a previous transformation, passed in to the
 `rebuild` method. `refdims` can be discarded, the main loss being plot labels.
 
-Inheriting from `AbstractDimensionalArray` will give all the functionality
-of using `DimensionalArray`.
+Inheriting from `AbstractDimArray` will give all the functionality
+of using `DimArray`.

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -40,7 +40,7 @@ export Aligned, AbstractSampled, Sampled,
 
 export Unaligned, Transformed
 
-export AbstractDimensionalArray, DimensionalArray, DimArray
+export AbstractDimArray, DimArray, AbstractDimensionalArray, DimensionalArray
 
 export data, dims, refdims, mode, metadata, name, shortname,
        val, label, units, order, bounds, locus, mode, <|
@@ -52,6 +52,7 @@ export order, indexorder, arrayorder,
        reorderarray, reorderrelation
 
 export @dim
+
 
 include("interface.jl")
 include("mode.jl")
@@ -65,5 +66,9 @@ include("primitives.jl")
 include("utils.jl")
 include("plotrecipes.jl")
 include("prettyprint.jl")
+
+# For compat with old versions
+const AbstractDimensionalArray = AbstractDimArray
+const DimensionalArray = DimArray
 
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -2,10 +2,8 @@
 """
 Parent type for all dimensional arrays.
 """
-abstract type AbstractDimensionalArray{T,N,D<:Tuple,A} <: AbstractArray{T,N} end
+abstract type AbstractDimArray{T,N,D<:Tuple,A} <: AbstractArray{T,N} end
 
-const AbDimArray = AbstractDimensionalArray
-const AbstractDimArray = AbstractDimensionalArray
 const AbstractDimVector = AbstractDimArray{T,1} where T
 const AbstractDimMatrix = AbstractDimArray{T,2} where T
 
@@ -34,35 +32,35 @@ bounds(A::AbstractArray, dims::DimOrDimType) =
 Returns the bounds for the specified dimension(s).
 `dims` can be a `Dimension`, a dimension type, or a tuple of either.
 """
-metadata(A::AbstractDimensionalArray, dim) = metadata(dims(A, dim))
-metadata(A::AbstractDimensionalArray, dims::Tuple) =
+metadata(A::AbstractDimArray, dim) = metadata(dims(A, dim))
+metadata(A::AbstractDimArray, dims::Tuple) =
     map(metadata, DimensionalData.dims(A, dims))
 
 # Standard fields
 
-dims(A::AbDimArray) = A.dims
-refdims(A::AbDimArray) = A.refdims
-data(A::AbDimArray) = A.data
-name(A::AbDimArray) = A.name
-metadata(A::AbDimArray) = A.metadata
-label(A::AbDimArray) = name(A)
+dims(A::AbstractDimArray) = A.dims
+refdims(A::AbstractDimArray) = A.refdims
+data(A::AbstractDimArray) = A.data
+name(A::AbstractDimArray) = A.name
+metadata(A::AbstractDimArray) = A.metadata
+label(A::AbstractDimArray) = name(A)
 
 @inline rebuild(A::AbstractArray, data, dims::Tuple=dims(A), refdims=refdims(A),
                 name=name(A), metadata=metadata(A)) =
     rebuild(A, data, dims, refdims, name, metadata)
 
-order(A::AbstractDimensionalArray, args...) = order(dims(A, args...))
-arrayorder(A::AbstractDimensionalArray, args...) = arrayorder(dims(A, args...))
-indexorder(A::AbstractDimensionalArray, args...) = indexorder(dims(A, args...))
+order(A::AbstractDimArray, args...) = order(dims(A, args...))
+arrayorder(A::AbstractDimArray, args...) = arrayorder(dims(A, args...))
+indexorder(A::AbstractDimArray, args...) = indexorder(dims(A, args...))
    
 
 # Array interface methods ######################################################
 
-Base.size(A::AbDimArray) = size(data(A))
-Base.axes(A::AbDimArray) = axes(data(A))
-Base.iterate(A::AbDimArray, args...) = iterate(data(A), args...)
-Base.IndexStyle(A::AbstractDimensionalArray) = Base.IndexStyle(data(A))
-Base.parent(A::AbDimArray) = data(A)
+Base.size(A::AbstractDimArray) = size(data(A))
+Base.axes(A::AbstractDimArray) = axes(data(A))
+Base.iterate(A::AbstractDimArray, args...) = iterate(data(A), args...)
+Base.IndexStyle(A::AbstractDimArray) = Base.IndexStyle(data(A))
+Base.parent(A::AbstractDimArray) = data(A)
 
 @inline Base.axes(A::AbstractDimArray, dims::DimOrDimType) = axes(A, dimnum(A, dims))
 @inline Base.size(A::AbstractDimArray, dims::DimOrDimType) = size(A, dimnum(A, dims))
@@ -71,88 +69,88 @@ Base.parent(A::AbDimArray) = data(A)
     rebuild(A, data, slicedims(A, I)..., name)
 
 # Standard indices
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, i::Integer, I::Integer...) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray, i::Integer, I::Integer...) =
     getindex(data(A), i, I...)
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, i::StandardIndices, I::StandardIndices...) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray, i::StandardIndices, I::StandardIndices...) =
     rebuildsliced(A, getindex(data(A), i, I...), (i, I...))
-Base.@propagate_inbounds Base.view(A::AbDimArray, i::StandardIndices, I::StandardIndices...) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray, i::StandardIndices, I::StandardIndices...) =
     rebuildsliced(A, view(data(A), i, I...), (i, I...))
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, i::StandardIndices, I::StandardIndices...) =
+Base.@propagate_inbounds Base.setindex!(A::AbstractDimArray, x, i::StandardIndices, I::StandardIndices...) =
     setindex!(data(A), x, i, I...)
 
 # No indices
-Base.@propagate_inbounds Base.getindex(A::AbDimArray) = getindex(data(A))
-Base.@propagate_inbounds Base.view(A::AbDimArray) = view(data(A))
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x) = setindex!(data(A), x)
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray) = getindex(data(A))
+Base.@propagate_inbounds Base.view(A::AbstractDimArray) = view(data(A))
+Base.@propagate_inbounds Base.setindex!(A::AbstractDimArray, x) = setindex!(data(A), x)
 
 # Cartesian indices
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, I::CartesianIndex) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray, I::CartesianIndex) =
     getindex(data(A), I)
-Base.@propagate_inbounds Base.view(A::AbDimArray, I::CartesianIndex) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray, I::CartesianIndex) =
     view(data(A), I)
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, I::CartesianIndex) =
+Base.@propagate_inbounds Base.setindex!(A::AbstractDimArray, x, I::CartesianIndex) =
     setindex!(data(A), x, I)
 
 # Dimension indexing. Additional methods for dispatch ambiguity
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, dim::Dimension, dims::Dimension...) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray, dim::Dimension, dims::Dimension...) =
     getindex(A, dims2indices(A, (dim, dims...))...)
 Base.@propagate_inbounds Base.getindex(A::AbstractArray, dim::Dimension, dims::Dimension...) =
     getindex(A, dims2indices(A, (dim, dims...))...)
-Base.@propagate_inbounds Base.view(A::AbDimArray, dim::Dimension, dims::Dimension...) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray, dim::Dimension, dims::Dimension...) =
     view(A, dims2indices(A, (dim, dims...))...)
 Base.@propagate_inbounds Base.view(A::AbstractArray, dim::Dimension, dims::Dimension...) =
     view(A, dims2indices(A, (dim, dims...))...)
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, dim::Dimension, dims::Dimension...) =
+Base.@propagate_inbounds Base.setindex!(A::AbstractDimArray, x, dim::Dimension, dims::Dimension...) =
     setindex!(A, x, dims2indices(A, (dim, dims...))...)
 Base.@propagate_inbounds Base.setindex!(A::AbstractArray, x, dim::Dimension, dims::Dimension...) =
     setindex!(A, x, dims2indices(A, (dim, dims...))...)
 
 # Selector indexing without dim wrappers. Must be in the right order!
-Base.@propagate_inbounds Base.getindex(A::AbDimArray, i, I...) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray, i, I...) =
     getindex(A, sel2indices(A, maybeselector(i, I...))...)
-Base.@propagate_inbounds Base.view(A::AbDimArray, i, I...) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray, i, I...) =
     view(A, sel2indices(A, maybeselector(i, I...))...)
-Base.@propagate_inbounds Base.setindex!(A::AbDimArray, x, i, I...) =
+Base.@propagate_inbounds Base.setindex!(A::AbstractDimArray, x, i, I...) =
     setindex!(A, x, sel2indices(A, maybeselector(i, I...))...)
 
 # Linear indexing returns Array
-Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, N} where N, i::Union{Colon,AbstractArray}) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray{<:Any, N} where N, i::Union{Colon,AbstractArray}) =
     getindex(data(A), i)
 # Exempt 1D DimArrays
-Base.@propagate_inbounds Base.getindex(A::AbDimArray{<:Any, 1}, i::Union{Colon,AbstractArray}) =
+Base.@propagate_inbounds Base.getindex(A::AbstractDimArray{<:Any, 1}, i::Union{Colon,AbstractArray}) =
     rebuildsliced(A, getindex(data(A), i), (i,))
 
 # Linear indexing returns unwrapped SubArray
-Base.@propagate_inbounds Base.view(A::AbDimArray{<:Any, N} where N, i::StandardIndices) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray{<:Any, N} where N, i::StandardIndices) =
     view(data(A), i)
 # Exempt 1D DimArrays
-Base.@propagate_inbounds Base.view(A::AbDimArray{<:Any, 1}, i::StandardIndices) =
+Base.@propagate_inbounds Base.view(A::AbstractDimArray{<:Any, 1}, i::StandardIndices) =
     rebuildsliced(A, view(data(A), i), (i,))
 
-Base.copy(A::AbDimArray) = rebuild(A, copy(data(A)))
+Base.copy(A::AbstractDimArray) = rebuild(A, copy(data(A)))
 
 
-Base.copy!(dst::AbDimArray{T,N}, src::AbDimArray{T,N}) where {T,N} = copy!(parent(dst), parent(src))
-Base.copy!(dst::AbDimArray{T,N}, src::AbstractArray{T,N}) where {T,N} = copy!(parent(dst), src)
-Base.copy!(dst::AbstractArray{T,N}, src::AbDimArray{T,N}) where {T,N}  = copy!(dst, parent(src))
+Base.copy!(dst::AbstractDimArray{T,N}, src::AbstractDimArray{T,N}) where {T,N} = copy!(parent(dst), parent(src))
+Base.copy!(dst::AbstractDimArray{T,N}, src::AbstractArray{T,N}) where {T,N} = copy!(parent(dst), src)
+Base.copy!(dst::AbstractArray{T,N}, src::AbstractDimArray{T,N}) where {T,N}  = copy!(dst, parent(src))
 # Most of these methods are for resolving ambiguity errors
-Base.copy!(dst::SparseArrays.SparseVector, src::AbDimArray{T,1}) where T = copy!(dst, parent(src))
-Base.copy!(dst::AbDimArray{T,1}, src::AbstractArray{T,1}) where T = copy!(parent(dst), src)
-Base.copy!(dst::AbstractArray{T,1}, src::AbDimArray{T,1}) where T = copy!(dst, parent(src))
-Base.copy!(dst::AbDimArray{T,1}, src::AbDimArray{T,1}) where T = copy!(parent(dst), parent(src))
+Base.copy!(dst::SparseArrays.SparseVector, src::AbstractDimArray{T,1}) where T = copy!(dst, parent(src))
+Base.copy!(dst::AbstractDimArray{T,1}, src::AbstractArray{T,1}) where T = copy!(parent(dst), src)
+Base.copy!(dst::AbstractArray{T,1}, src::AbstractDimArray{T,1}) where T = copy!(dst, parent(src))
+Base.copy!(dst::AbstractDimArray{T,1}, src::AbstractDimArray{T,1}) where T = copy!(parent(dst), parent(src))
 
-Base.Array(A::AbDimArray) = data(A)
+Base.Array(A::AbstractDimArray) = data(A)
 
 # Need to cover a few type signatures to avoid ambiguity with base
 # Don't remove these even though they look redundant 
-Base.similar(A::AbDimArray) = 
+Base.similar(A::AbstractDimArray) = 
     rebuild(A, similar(data(A)), dims(A), refdims(A), "")
-Base.similar(A::AbDimArray, ::Type{T}) where T = 
+Base.similar(A::AbstractDimArray, ::Type{T}) where T = 
     rebuild(A, similar(data(A), T), dims(A), refdims(A), "")
 # If the shape changes, use the wrapped array:
-Base.similar(A::AbDimArray, ::Type{T}, I::Tuple{Int,Vararg{Int}}) where T = 
+Base.similar(A::AbstractDimArray, ::Type{T}, I::Tuple{Int,Vararg{Int}}) where T = 
     similar(data(A), T, I)
-Base.similar(A::AbDimArray, ::Type{T}, i::Integer, I::Vararg{<:Integer}) where T = 
+Base.similar(A::AbstractDimArray, ::Type{T}, i::Integer, I::Vararg{<:Integer}) where T = 
     similar(data(A), T, i, I...)
 
 
@@ -160,13 +158,13 @@ Base.similar(A::AbDimArray, ::Type{T}, i::Integer, I::Vararg{<:Integer}) where T
 # Concrete implementation ######################################################
 
 """
-    DimensionalArray(data, dims, refdims, name)
+    DimArray(data, dims, refdims, name)
 
-The main subtype of `AbstractDimensionalArray`.
+The main subtype of `AbstractDimArray`.
 Maintains and updates its dimensions through transformations and moves dimensions to
 `refdims` after reducing operations (like e.g. `mean`).
 """
-struct DimensionalArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na<:AbstractString,Me} <: AbstractDimensionalArray{T,N,D,A}
+struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na<:AbstractString,Me} <: AbstractDimArray{T,N,D,A}
     data::A
     dims::D
     refdims::R
@@ -174,11 +172,11 @@ struct DimensionalArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na<:Abstract
     metadata::Me
 end
 
-const DimArray = DimensionalArray
+const DimArray = DimArray
 
 
 """
-    DimensionalArray(data, dims::Tuple [, name::String]; refdims=(), metadata=nothing)
+    DimArray(data, dims::Tuple [, name::String]; refdims=(), metadata=nothing)
 
 Constructor with optional `name`, and keyword `refdims` and `metadata`.
 
@@ -188,38 +186,39 @@ using Dates, DimensionalData
 
 ti = (Ti(DateTime(2001):Month(1):DateTime(2001,12)),
 x = X(10:10:100))
-A = DimensionalArray(rand(12,10), (ti, x), "example")
+A = DimArray(rand(12,10), (ti, x), "example")
 
 julia> A[X(Near([12, 35])), Ti(At(DateTime(2001,5)))];
 
 julia> A[Near(DateTime(2001, 5, 4)), Between(20, 50)];
 ```
 """
-DimensionalArray(A::AbstractArray, dims, name::String=""; refdims=(), metadata=nothing) =
-    DimensionalArray(A, formatdims(A, _to_tuple(dims)), refdims, name, metadata)
-DimensionalArray(A::AbstractDimensionalArray; dims=dims(A), refdims=refdims(A), name=name(A), metadata=metadata(A)) =
-    DimensionalArray(A, formatdims(data(A), _to_tuple(dims)), refdims, name, metadata)
-DimensionalArray(; data, dims, refdims=(), name="", metadata=nothing) = 
-    DimensionalArray(A, formatdims(A, _to_tuple(dims)), refdims, name, metadata)
+DimArray(A::AbstractArray, dims, name::String=""; refdims=(), metadata=nothing) =
+    DimArray(A, formatdims(A, _to_tuple(dims)), refdims, name, metadata)
+DimArray(A::AbstractDimArray; dims=dims(A), refdims=refdims(A), name=name(A), metadata=metadata(A)) =
+    DimArray(A, formatdims(data(A), _to_tuple(dims)), refdims, name, metadata)
+DimArray(; data, dims, refdims=(), name="", metadata=nothing) = 
+    DimArray(A, formatdims(A, _to_tuple(dims)), refdims, name, metadata)
 
 _to_tuple(t::T where T <: Tuple) = t
 _to_tuple(t) = tuple(t)
 
-# AbstractDimensionalArray interface
-@inline rebuild(A::DimensionalArray, data::AbstractArray, dims::Tuple,
+# AbstractDimArray interface
+@inline rebuild(A::DimArray, data::AbstractArray, dims::Tuple,
                 refdims::Tuple, name::AbstractString, metadata) =
-    DimensionalArray(data, dims, refdims, name, metadata)
+    DimArray(data, dims, refdims, name, metadata)
 
-# Array interface (AbstractDimensionalArray takes care of everything else)
-Base.@propagate_inbounds Base.setindex!(A::DimensionalArray, x, I::Vararg{StandardIndices}) =
+# Array interface (AbstractDimArray takes care of everything else)
+Base.@propagate_inbounds Base.setindex!(A::DimArray, x, I::Vararg{StandardIndices}) =
     setindex!(data(A), x, I...)
 
 """
-    DimensionalArray(f::Function, dim::Dimension [, name])
+    DimArray(f::Function, dim::Dimension [, name])
 
 Apply function `f` across the values of the dimension `dim`
 (using `broadcast`), and return the result as a dimensional array with
 the given dimension. Optionally provide a name for the result.
 """
-DimensionalArray(f::Function, dim::Dimension, name=string(nameof(f), "(", name(dim), ")")) =
-     DimensionalArray(f.(val(dim)), (dim,), name)
+DimArray(f::Function, dim::Dimension, name=string(nameof(f), "(", name(dim), ")")) =
+     DimArray(f.(val(dim)), (dim,), name)
+

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -3,7 +3,7 @@ import Base.Broadcast: BroadcastStyle, DefaultArrayStyle, Style
 """
     DimensionalStyle{S}
 
-This is a `BroadcastStyle` for AbstractAbstractDimensionalArray's
+This is a `BroadcastStyle` for AbstractAbstractDimArray's
 It preserves the dimension names.
 `S` should be the `BroadcastStyle` of the wrapped type.
 
@@ -23,7 +23,7 @@ DimensionalStyle(a::BroadcastStyle, b::BroadcastStyle) = begin
     end
 end
 
-BroadcastStyle(::Type{<:AbstractDimensionalArray{T,N,D,A}}) where {T,N,D,A} = begin
+BroadcastStyle(::Type{<:AbstractDimArray{T,N,D,A}}) where {T,N,D,A} = begin
     inner_style = typeof(BroadcastStyle(A))
     return DimensionalStyle{inner_style}()
 end
@@ -60,7 +60,7 @@ function Base.copyto!(dest::AbstractArray, bc::Broadcasted{DimensionalStyle{S}})
     end
 end
 
-function Base.copyto!(dest::AbstractDimensionalArray, bc::Broadcasted{DimensionalStyle{S}}) where S
+function Base.copyto!(dest::AbstractDimArray, bc::Broadcasted{DimensionalStyle{S}}) where S
     _dims = comparedims(dims(dest), _broadcasted_dims(bc))
     copyto!(parent(dest), _unwrap_broadcasted(bc))
     A = _firstdimarray(bc)
@@ -76,19 +76,19 @@ Base.similar(bc::Broadcast.Broadcasted{DimensionalStyle{S}}, ::Type{T}) where {S
     rebuildsliced(A, similar(_unwrap_broadcasted(bc), T, axes(bc)...), axes(bc), "")
 end
 
-# Recursively unwraps `AbstractDimensionalArray`s and `DimensionalStyle`s.
-# replacing the `AbstractDimensionalArray`s with the wrapped array,
+# Recursively unwraps `AbstractDimArray`s and `DimensionalStyle`s.
+# replacing the `AbstractDimArray`s with the wrapped array,
 # and `DimensionalStyle` with the wrapped `BroadcastStyle`.
 _unwrap_broadcasted(bc::Broadcasted{DimensionalStyle{S}}) where S = begin
     innerargs = map(_unwrap_broadcasted, bc.args)
     return Broadcasted{S}(bc.f, innerargs)
 end
 _unwrap_broadcasted(x) = x
-_unwrap_broadcasted(nda::AbstractDimensionalArray) = data(nda)
+_unwrap_broadcasted(nda::AbstractDimArray) = data(nda)
 
 # Get the first dimensional array inthe broadcast
 _firstdimarray(x::Broadcasted) = _firstdimarray(x.args)
-_firstdimarray(x::Tuple{<:AbDimArray,Vararg}) = x[1]
+_firstdimarray(x::Tuple{<:AbstractDimArray,Vararg}) = x[1]
 _fistdimarray(ext::Base.Broadcast.Extruded) = _firstdimarray(ext.x)
 _firstdimarray(x::Tuple{<:Broadcasted,Vararg}) = begin
     found = _firstdimarray(x[1])
@@ -105,5 +105,5 @@ _firstdimarray(x::Tuple{}) = nothing
 # Make sure all arrays have the same dims, and return them
 _broadcasted_dims(bc::Broadcasted) = _broadcasted_dims(bc.args...)
 _broadcasted_dims(a, bs...) = comparedims(_broadcasted_dims(a), _broadcasted_dims(bs...))
-_broadcasted_dims(a::AbstractDimensionalArray) = dims(a)
+_broadcasted_dims(a::AbstractDimArray) = dims(a)
 _broadcasted_dims(a) = nothing

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -34,7 +34,7 @@ A = DimArray(rand(3, 5, 12), (y, x, ti))
 
 # output
 
-DimensionalArray with dimensions:
+DimArray with dimensions:
  Y: Char[a, b, c]
  X: 2:2:10
  Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
@@ -54,7 +54,7 @@ x = A[X(2), Y(3)]
 
 # output
 
-DimensionalArray with dimensions:
+DimArray with dimensions:
  Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
 and referenced dimensions:
  Y: c
@@ -70,7 +70,7 @@ x = A[X(Between(3, 4)), Y(At('b'))]
 
 # output
 
-DimensionalArray with dimensions:
+DimArray with dimensions:
  X: 4:2:4
  Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
 and referenced dimensions:

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -7,7 +7,7 @@ Return the data wrapped by the dimentional array. This may not be
 the same as `Base.parent`, as it should never include data outside the
 bounds of the dimensions.
 
-In a disk based [`AbstractDimensionalArray`](@ref), `data` may need to
+In a disk based [`AbstractDimArray`](@ref), `data` may need to
 load data from disk.
 """
 function data end

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -273,11 +273,11 @@ An [`IndexMode`](@ref) that is identical to the array axis.
 
 ## Example
 
-Defining a [`DimensionalArray`](@ref) without passing an index
+Defining a [`DimArray`](@ref) without passing an index
 to the dimension, the IndexMode will be `NoIndex`:
 
 ```jldoctest
-A = DimensionalArray(rand(3, 3), (X, Y))
+A = DimArray(rand(3, 3), (X, Y))
 map(mode, dims(A))
 
 # output
@@ -288,7 +288,7 @@ map(mode, dims(A))
 Is identical to:
 
 ```jldoctest
-A = DimensionalArray(rand(3, 3), (X(; mode=NoIndex()), Y(; mode=NoIndex())))
+A = DimArray(rand(3, 3), (X(; mode=NoIndex()), Y(; mode=NoIndex())))
 map(mode, dims(A))
 
 # output
@@ -392,7 +392,7 @@ Create an array with [`Interval`] sampling.
 ```jldoctest
 dims_ = (X(100:-10:10; mode=Sampled(sampling=Intervals())),
          Y([1, 4, 7, 10]; mode=Sampled(span=Regular(2), sampling=Intervals())))
-A = DimensionalArray(rand(10, 4), dims_)
+A = DimArray(rand(10, 4), dims_)
 map(mode, dims(A))
 
 # output
@@ -442,7 +442,7 @@ Create an array with [`Interval`] sampling.
 
 ```jldoctest
 dims_ = X(["one", "two", "thee"]), Y([:a, :b, :c, :d])
-A = DimensionalArray(rand(3, 4), dims_)
+A = DimArray(rand(3, 4), dims_)
 map(mode, dims(A))
 
 # output
@@ -495,7 +495,7 @@ A = [1 2  3  4
      9 10 11 12];
 dimz = Dim{:t1}(mode=Transformed(m, X)),
               Dim{:t2}(mode=Transformed(m, Y))
-da = DimensionalArray(A, dimz)
+da = DimArray(A, dimz)
 
 da[X(At(6)), Y(At(2))]
 

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -7,7 +7,7 @@ struct ViolinLike end
 
 struct DimensionalPlot end
 
-@recipe function f(A::AbstractDimensionalArray) 
+@recipe function f(A::AbstractDimArray) 
     DimensionalPlot(), A
 end
 

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -1,5 +1,5 @@
-# Full printing for DimensionalArray
-Base.show(io::IO, A::AbDimArray) = begin
+# Full printing for DimArray
+Base.show(io::IO, A::AbstractDimArray) = begin
     l = nameof(typeof(A))
     printstyled(io, nameof(typeof(A)); color=:blue)
     if label(A) != ""
@@ -24,8 +24,8 @@ Base.show(io::IO, A::AbDimArray) = begin
     print(io, summary(dataA), "\n")
     custom_show(io, data(A))
 end
-# Short printing for DimensionalArray
-Base.show(io::IO, ::MIME"text/plain", A::AbDimArray) = show(io, A)
+# Short printing for DimArray
+Base.show(io::IO, ::MIME"text/plain", A::AbstractDimArray) = show(io, A)
 # Full printing version for dimensions
 Base.show(io::IO, ::MIME"text/plain", dim::Dimension) = begin
     print(io, "dimension ")

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -181,7 +181,7 @@ depending on wether `lookup` is a `Tuple` or single `Dimension`.
 
 ## Example
 ```jldoctest
-julia> A = DimensionalArray(ones(10, 10, 10), (X, Y, Z));
+julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 
 julia> dimnum(A, Z)
@@ -222,7 +222,7 @@ Check if an object or tuple contains an `Dimension`, or a tuple of dimensions.
 
 ## Example
 ```jldoctest
-julia> A = DimensionalArray(ones(10, 10, 10), (X, Y, Z));
+julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 julia> hasdim(A, X)
 true
@@ -253,7 +253,7 @@ a new object or tuple with the dimension updated.
 
 # Example
 ```jldoctest
-A = DimensionalArray(ones(10, 10), (X, Y(10:10:100)))
+A = DimArray(ones(10, 10), (X, Y(10:10:100)))
 B = setdims(A, Y('a':'j'))
 val(dims(B, Y))
 
@@ -286,7 +286,7 @@ dimension as-is.
 
 # Example
 ```jldoctest
-julia> A = DimensionalArray(ones(10, 10, 10), (X, Y, Z));
+julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 
 julia> B = swapdims(A, (Z, Dim{:custom}, Ti));
@@ -391,7 +391,7 @@ any combination of either.
 
 ## Example
 ```jldoctest
-julia> A = DimensionalArray(ones(10, 10, 10), (X, Y, Z));
+julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 
 julia> dims(A, Z)

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -36,7 +36,7 @@ and wont be used.
 ## Example
 
 ```jldoctest
-A = DimensionalArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
+A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(At(20)), Y(At(6))]
 
 # output
@@ -67,7 +67,7 @@ index value for [`Start`](@ref) and [`End`](@ref) loci.
 ## Example
 
 ```jldoctest
-A = DimensionalArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
+A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(Near(23)), Y(Near(5.1))] 
 
 # output
@@ -92,7 +92,7 @@ Can only be used for [`Intervals`](@ref) or [`Categorical`](@ref).
 ```jldoctest
 dims_ = X(10:10:20; mode=Sampled(sampling=Intervals())),
         Y(5:7; mode=Sampled(sampling=Intervals()))
-A = DimensionalArray([1 2 3; 4 5 6], dims_)
+A = DimArray([1 2 3; 4 5 6], dims_)
 A[X(Contains(8)), Y(Contains(6.8))]
 
 # output
@@ -117,12 +117,12 @@ results with the same index and values - this is the intended behaviour.
 ## Example
 
 ```jldoctest
-A = DimensionalArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
+A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(Between(15, 25)), Y(Between(4, 6.5))] 
 
 # output
 
-DimensionalArray with dimensions:
+DimArray with dimensions:
  X: 20:10:20
  Y: 5:6
 and data: 1×2 Array{Int64,2}
@@ -144,12 +144,12 @@ a single value from the index and returns a `Bool`.
 ## Example
 
 ```jldoctest
-A = DimensionalArray([1 2 3; 4 5 6], (X(10:10:20), Y(19:21)))
+A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(19:21)))
 A[X(Where(x -> x > 15)), Y(Where(x -> x in (19, 21)))]
 
 # output
 
-DimensionalArray with dimensions:
+DimArray with dimensions:
  X: Int64[20]
  Y: Int64[19, 21]
 and data: 1×2 Array{Int64,2}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,7 @@
 for func in (:reversearray, :reverseindex, :fliparray, :flipindex, :fliprelation)
     if func != :reversearray
         @eval begin
-            ($func)(A::AbDimArray{T,N}; dims=1) where {T,N} = begin
+            ($func)(A::AbstractDimArray{T,N}; dims=1) where {T,N} = begin
                 dnum = dimnum(A, dims)
                 # Reverse the dimension. TODO: make this type stable
                 newdims = $func(DimensionalData.dims(A), dnum)
@@ -24,7 +24,7 @@ for func in (:reversearray, :reverseindex, :fliparray, :flipindex, :fliprelation
     end
 end
 
-reversearray(A::AbDimArray{T,N}; dims=1) where {T,N} = begin
+reversearray(A::AbstractDimArray{T,N}; dims=1) where {T,N} = begin
     dnum = dimnum(A, dims)
     # Reverse the dimension. TODO: make this type stable
     newdims = reversearray(DimensionalData.dims(A), dnum)
@@ -95,39 +95,39 @@ for target in (:index, :array, :relation)
     end
     @eval begin
 
-        ($reorder)(A::AbstractDimensionalArray, order::Tuple, args...) = begin
+        ($reorder)(A::AbstractDimArray, order::Tuple, args...) = begin
             for dim in _sortdims(order, dims(A))
                 A = ($reorder)(A, dim, args...)
             end
             A
         end
-        ($reorder)(A::AbstractDimensionalArray, orderdim::Dimension{<:Order}) =
+        ($reorder)(A::AbstractDimArray, orderdim::Dimension{<:Order}) =
             ($reorder)(A, orderdim, val(orderdim))
-        ($reorder)(A::AbstractDimensionalArray, order::Nothing) = A
-        ($reorder)(A::AbstractDimensionalArray, order::Order=Forward()) = begin
+        ($reorder)(A::AbstractDimArray, order::Nothing) = A
+        ($reorder)(A::AbstractDimArray, order::Order=Forward()) = begin
             for dim in dims(A)
                 A = ($reorder)(A, dim, order)
             end
             A
         end
-        ($reorder)(A::AbstractDimensionalArray, dim::DimOrDimType, order::Order) =
+        ($reorder)(A::AbstractDimArray, dim::DimOrDimType, order::Order) =
             if order == ($order)(dims(A, dim))
                 A
             else
                 ($reverse)(A; dims=dim)
             end
-        ($reorder)(A::AbstractDimensionalArray, dim::DimOrDimType, order::Unordered) = A
+        ($reorder)(A::AbstractDimArray, dim::DimOrDimType, order::Unordered) = A
     end
 end
 
 
 """
-    modify(f, A::AbstractDimensionalArray)
+    modify(f, A::AbstractDimArray)
 
-Modify the parent data, rebuilding the `AbstractDimensionalArray` wrapper.
+Modify the parent data, rebuilding the `AbstractDimArray` wrapper.
 `f` must return a `AbstractArray` of the same size as the original.
 """
-modify(f, A::AbstractDimensionalArray) = begin
+modify(f, A::AbstractDimArray) = begin
     newdata = f(data(A))
     size(newdata) == size(A) || error("$f returns an array with a different size")
     rebuild(A, newdata)

--- a/test/array.jl
+++ b/test/array.jl
@@ -5,7 +5,7 @@ a = [1 2; 3 4]
 dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "X")),
         Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "Y")))
 refdimz = (Ti(1:1),)
-da = DimensionalArray(a, dimz, "test"; refdims=refdimz, metadata=Dict(:meta => "da"))
+da = DimArray(a, dimz, "test"; refdims=refdimz, metadata=Dict(:meta => "da"))
 
 @testset "getindex for single integers returns values" begin
     @test da[X(1), Y(2)] == 2
@@ -17,13 +17,13 @@ end
 
 @testset "LinearIndex getindex returns an Array, except Vector" begin
     @test da[1:2] isa Array
-    @test da[1, :][1:2] isa DimensionalArray
+    @test da[1, :][1:2] isa DimArray
 end
 
 @testset "getindex returns DimensionArray slices with the right dimensions" begin
     a = da[X(1:2), Y(1)]
     @test a == [1, 3]
-    @test typeof(a) <: DimensionalArray{Int,1}
+    @test typeof(a) <: DimArray{Int,1}
     @test dims(a) == (X(LinRange(143.0, 145.0, 2),
                         Sampled(Ordered(), Regular(2.0), Points()), Dict(:meta => "X")),)
     @test refdims(a) == 
@@ -37,7 +37,7 @@ end
 
     a = da[X(1), Y(1:2)]
     @test a == [1, 2]
-    @test typeof(a) <: DimensionalArray{Int,1}
+    @test typeof(a) <: DimArray{Int,1}
     @test typeof(data(a)) <: Array{Int,1}
     @test dims(a) == 
         (Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), Dict(:meta => "Y")),)
@@ -50,7 +50,7 @@ end
 
     a = da[X(:), Y(:)]
     @test a == [1 2; 3 4]
-    @test typeof(a) <: DimensionalArray{Int,2}
+    @test typeof(a) <: DimArray{Int,2}
     @test typeof(data(a)) <: Array{Int,2}
     @test typeof(dims(a)) <: Tuple{<:X,<:Y}
     @test dims(a) == (X(LinRange(143.0, 145.0, 2),
@@ -66,7 +66,7 @@ end
 @testset "view returns DimensionArray containing views" begin
     v = @inferred view(da, Y(1), X(1))
     @test v[] == 1
-    @test typeof(v) <: DimensionalArray{Int,0}
+    @test typeof(v) <: DimArray{Int,0}
     @test typeof(data(v)) <:SubArray{Int,0}
     @test typeof(dims(v)) == Tuple{}
     @test dims(v) == ()
@@ -79,7 +79,7 @@ end
 
     v = @inferred view(da, Y(1), X(1:2))
     @test v == [1, 3]
-    @test typeof(v) <: DimensionalArray{Int,1}
+    @test typeof(v) <: DimArray{Int,1}
     @test typeof(data(v)) <: SubArray{Int,1}
     @test typeof(dims(v)) <: Tuple{<:X}
     @test dims(v) == 
@@ -93,7 +93,7 @@ end
 
     v = @inferred view(da, Y(1:2), X(1:1))
     @test v == [1 2]
-    @test typeof(v) <: DimensionalArray{Int,2}
+    @test typeof(v) <: DimArray{Int,2}
     @test typeof(data(v)) <: SubArray{Int,2}
     @test typeof(dims(v)) <: Tuple{<:X,<:Y}
     @test dims(v) == 
@@ -123,13 +123,13 @@ b2 = [4 4 4 4
       4 4 4 4]
 
 @testset "indexing into empty dims is just regular indexing" begin
-    ida = @inferred DimensionalArray(a2, (X(), Y()))
+    ida = @inferred DimArray(a2, (X(), Y()))
     ida[Y(3:4), X(2:3)] = [5 6; 6 7]
 end
 
 
 dimz2 = (Dim{:row}((10, 30)), Dim{:column}((-20, 10)))
-da2 = DimensionalArray(a2, dimz2, "test2"; refdims=refdimz)
+da2 = DimArray(a2, dimz2, "test2"; refdims=refdimz)
 
 @testset "arbitrary dimension names also work for indexing" begin
     @test da2[Dim{:row}(2)] == [3, 4, 5, 6]
@@ -150,10 +150,10 @@ end
     oa = OffsetArray(a2, -1:1, 5:8)
     @testset "Regular dimensions don't work: axes must match" begin
         dimz = (X(100:100:300), Y([:a, :b, :c, :d]))
-        @test_throws DimensionMismatch DimensionalArray(oa, dimz)
+        @test_throws DimensionMismatch DimArray(oa, dimz)
     end
     odimz = (X(OffsetArray(100:100:300, -1:1)), Y(OffsetArray([:a, :b, :c, :d], 5:8)))
-    oda = DimensionalArray(oa, odimz)
+    oda = DimArray(oa, odimz)
     @testset "Indexing and selectors work with offsets" begin
         @test axes(oda) == (-1:1, 5:8)
         @test oda[-1, 5] == oa[-1, 5] == 1
@@ -183,7 +183,7 @@ end
     @test eltype(da_size_float) == Float64
     @test size(da_size_float) == (10, 10)
 
-    sda = DimensionalArray(sprand(Float64, 10, 10, .5), (X, Y))
+    sda = DimArray(sprand(Float64, 10, 10, .5), (X, Y))
     sparse_size_int = similar(sda, Int64, (5, 5))
     @test eltype(sparse_size_int) == Int64 != eltype(sda)
     @test size(sparse_size_int) == (5, 5)
@@ -196,7 +196,7 @@ end
 end
 
 @testset "broadcast" begin
-    da = DimensionalArray(ones(Int, 5, 2, 4), (Y((10, 20)), Ti(10:11), X(1:4)))
+    da = DimArray(ones(Int, 5, 2, 4), (Y((10, 20)), Ti(10:11), X(1:4)))
     dab = da .* 2.0
     @test dab == fill(2.0, 5, 2, 4)
     @test eltype(dab) <: Float64
@@ -213,10 +213,10 @@ end
 
 @testset "eachindex" begin
     # Should have linear index
-    da = DimensionalArray(ones(5, 2, 4), (Y(10:2:18), Ti(10:11), X(1:4)))
+    da = DimArray(ones(5, 2, 4), (Y(10:2:18), Ti(10:11), X(1:4)))
     @test eachindex(da) == eachindex(data(da))
     # Should have cartesian index
-    sda = DimensionalArray(sprand(10, 10, .1), (Y(1:10), X(1:10)))
+    sda = DimArray(sprand(10, 10, .1), (Y(1:10), X(1:10)))
     @test eachindex(sda) == eachindex(data(sda))
 end
 
@@ -247,8 +247,8 @@ if VERSION > v"1.1-"
     dimz = (X(LinRange(143.0, 145.0, 3); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "X")),
             Y(LinRange(-38.0, -36.0, 4); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "Y")))
     @testset "copy!" begin
-        db = DimensionalArray(deepcopy(b2), dimz)
-        dc = DimensionalArray(deepcopy(b2), dimz)
+        db = DimArray(deepcopy(b2), dimz)
+        dc = DimArray(deepcopy(b2), dimz)
         @test db != da2
         @test b2 != da2
 
@@ -262,8 +262,8 @@ if VERSION > v"1.1-"
 end
 
 @testset "constructor" begin
-    da = DimensionalArray(rand(5, 4), (X, Y))
-    @test_throws DimensionMismatch DimensionalArray(1:5, X(1:6))
-    @test_throws MethodError DimensionalArray(1:5, (X(1:5), Y(1:2)))
+    da = DimArray(rand(5, 4), (X, Y))
+    @test_throws DimensionMismatch DimArray(1:5, X(1:6))
+    @test_throws MethodError DimArray(1:5, (X(1:5), Y(1:2)))
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,7 +3,7 @@ using DimensionalData, Test
 # Tests taken from NamedDims. Thanks @oxinabox
 
 @testset "Binary broadcasting operations (.+)" begin
-    da = DimensionalArray(ones(3), X)
+    da = DimArray(ones(3), X)
     @test Base.BroadcastStyle(typeof(da)) isa DimensionalData.DimensionalStyle
 
     @testset "standard case" begin
@@ -20,13 +20,13 @@ using DimensionalData, Test
 
     @testset "Dimension disagreement" begin
         @test_throws DimensionMismatch begin
-            DimensionalArray(zeros(3, 3, 3), (X, Y, Z)) .+
-            DimensionalArray(ones(3, 3, 3), (Y, Z, X))
+            DimArray(zeros(3, 3, 3), (X, Y, Z)) .+
+            DimArray(ones(3, 3, 3), (Y, Z, X))
         end
     end
 
     @testset "dims and regular" begin
-        da = DimensionalArray(ones(3, 3, 3), (X, Y, Z))
+        da = DimArray(ones(3, 3, 3), (X, Y, Z))
         left_sum = da .+ ones(3, 3, 3)
         @test left_sum == fill(2, 3, 3, 3)
         @test dims(left_sum) == dims(da)
@@ -36,18 +36,18 @@ using DimensionalData, Test
     end
 
     @testset "changing type" begin
-        @test (da .> 0) isa DimensionalArray
-        @test (da .* da .> 0) isa DimensionalArray
-        @test (da  .> 0 .> rand(3)) isa DimensionalArray
-        @test (da .* rand(3) .> 0.0) isa DimensionalArray
-        @test (0 .> da .> 0 .> rand(3)) isa DimensionalArray
-        @test (rand(3) .> da  .> 0 .* rand(3)) isa DimensionalArray
-        @test (rand(3) .> 1 .> 0 .* da) isa DimensionalArray
+        @test (da .> 0) isa DimArray
+        @test (da .* da .> 0) isa DimArray
+        @test (da  .> 0 .> rand(3)) isa DimArray
+        @test (da .* rand(3) .> 0.0) isa DimArray
+        @test (0 .> da .> 0 .> rand(3)) isa DimArray
+        @test (rand(3) .> da  .> 0 .* rand(3)) isa DimArray
+        @test (rand(3) .> 1 .> 0 .* da) isa DimArray
     end
 
     @testset "broadcasting" begin
-        v = DimensionalArray(zeros(3,), X)
-        m = DimensionalArray(ones(3, 3), (X, Y))
+        v = DimArray(zeros(3,), X)
+        m = DimArray(ones(3, 3), (X, Y))
         s = 0
         @test v .+ m == ones(3, 3) == m .+ v
         @test s .+ m == ones(3, 3) == m .+ s
@@ -58,8 +58,8 @@ using DimensionalData, Test
     end
 
     @testset "adjoint broadcasting" begin
-        a = DimensionalArray(reshape(1:12, (4, 3)), (X, Y))
-        b = DimensionalArray(1:3, Y)
+        a = DimArray(reshape(1:12, (4, 3)), (X, Y))
+        b = DimArray(1:3, Y)
         @test_throws DimensionMismatch a .* b
         @test_throws DimensionMismatch data(a) .* data(b)
         @test data(a) .* data(b)' == data(a .* b')
@@ -68,9 +68,9 @@ using DimensionalData, Test
 
     @testset "Mixed array types" begin
         casts = (
-            A -> DimensionalArray(A, (X, Y)),  # Named Matrix
-            A -> DimensionalArray(A[:, 1], X),  # Named Vector
-            A -> DimensionalArray(A[:, 1:1], (X, Y)),  # Named Single Column Matrix
+            A -> DimArray(A, (X, Y)),  # Named Matrix
+            A -> DimArray(A[:, 1], X),  # Named Vector
+            A -> DimArray(A[:, 1:1], (X, Y)),  # Named Single Column Matrix
             identity, # Matrix
             A -> A[:, 1], # Vector
             A -> A[:, 1:1], # Single Column Matrix
@@ -78,7 +78,7 @@ using DimensionalData, Test
          )
         for (T1, T2, T3) in Iterators.product(casts, casts, casts)
             all(isequal(identity), (T1, T2, T3)) && continue
-            !any(isequal(DimensionalArray), (T1, T2, T3)) && continue
+            !any(isequal(DimArray), (T1, T2, T3)) && continue
             total = T1(ones(3, 6)) .+ T2(2ones(3, 6)) .+ T3(3ones(3, 6))
             @test total == 6ones(3, 6)
             @test dims(total) == (X(), Y())
@@ -86,10 +86,10 @@ using DimensionalData, Test
     end
 
     @testset "in-place assignment .=" begin
-        ab = DimensionalArray(rand(2,2), (X, Y))
-        ba = DimensionalArray(rand(2,2), (Y, X))
-        ac = DimensionalArray(rand(2,2), (X, Z))
-        a_ = DimensionalArray(rand(2,2), (X(), AnonDim()))
+        ab = DimArray(rand(2,2), (X, Y))
+        ba = DimArray(rand(2,2), (Y, X))
+        ac = DimArray(rand(2,2), (X, Z))
+        a_ = DimArray(rand(2,2), (X(), AnonDim()))
         z = zeros(2,2)
 
         @test_throws DimensionMismatch z .= ab .+ ba
@@ -113,13 +113,13 @@ end
 
 # TODO make this work
 # @testset "Competing Wrappers" begin
-#     da = DimensionalArray(ones(4), X)
+#     da = DimArray(ones(4), X)
 #     ta = TrackedArray(5 * ones(4))
-#     dt = DimensionalArray(TrackedArray(5 * ones(4)), X)
+#     dt = DimArray(TrackedArray(5 * ones(4)), X)
 #     arrays = (da, ta, dt)
 #     @testset "$a .- $b" for (a, b) in Iterators.product(arrays, arrays)
 #         a === b && continue
-#         @test typeof(da .- ta) <: DimensionalArray
+#         @test typeof(da .- ta) <: DimArray
 #         @test typeof(parent(da .- ta)) <: TrackedArray
 #     end
 # end

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -37,9 +37,9 @@ end
 a = ones(5, 4)
 # Must construct with a tuple for dims/refdims
 
-@test_throws MethodError DimensionalArray(a, X((140, 148)))
-@test_throws MethodError DimensionalArray(a, (X((140, 148)), Y((2, 11))), Z(1))
-da = DimensionalArray(a, (X((140, 148)), Y((2, 11))))
+@test_throws MethodError DimArray(a, X((140, 148)))
+@test_throws MethodError DimArray(a, (X((140, 148)), Y((2, 11))), Z(1))
+da = DimArray(a, (X((140, 148)), Y((2, 11))))
 
 dimz = dims(da)
 @test d = typeof(slicedims(dimz, (2:4, 3))) == 
@@ -53,7 +53,7 @@ dimz = dims(da)
 a = [1 2 3 4
      2 3 4 5
      3 4 5 6]
-da = DimensionalArray(a, (X((143, 145)), Y((-38, -35))))
+da = DimArray(a, (X((143, 145)), Y((-38, -35))))
 dimz = dims(da) 
 
 @testset "dims" begin
@@ -85,7 +85,7 @@ end
 
 @testset "applying function on a dimension" begin
     d = X(0:0.01:2π)
-    a = DimensionalArray(cos, d)
+    a = DimArray(cos, d)
     @test length(dims(a)) == 1
     @test typeof(dims(a)[1]) <: X
     @test a.data == cos.(d.val)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -6,8 +6,8 @@ using Combinatorics: combinations
 
 @testset "*" begin
     timespan = DateTime(2001):Month(1):DateTime(2001,12)
-    A1 = DimensionalArray(rand(12), (Ti(timespan),)) 
-    A2 = DimensionalArray(rand(12, 1), (Ti(timespan), X(10:10:10))) 
+    A1 = DimArray(rand(12), (Ti(timespan),)) 
+    A2 = DimArray(rand(12, 1), (Ti(timespan), X(10:10:10))) 
 
     @test length.(dims(A1)) == size(A1)
     @test dims(parent(A1) * permutedims(A1)) isa Tuple{<:AnonDim,<:Ti}
@@ -37,9 +37,9 @@ using Combinatorics: combinations
     @test length.(dims(parent(A2') * A2)) == sze2
     @test length.(dims(A2' * parent(A2))) == sze2
 
-    B1 = DimensionalArray(rand(12, 6), (Ti(timespan), X(1:6)))
-    B2 = DimensionalArray(rand(8, 12), (Y(1:8), Ti(timespan)))
-    b1 = DimensionalArray(rand(12), Ti(timespan))
+    B1 = DimArray(rand(12, 6), (Ti(timespan), X(1:6)))
+    B2 = DimArray(rand(8, 12), (Y(1:8), Ti(timespan)))
+    b1 = DimArray(rand(12), Ti(timespan))
 
     # Test dimension propagation
     @test (B2 * B1) == (parent(B2) * parent(B1))

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -7,15 +7,15 @@ using DimensionalData: Forward, Reverse, Rot90, Rot180, Rot270, Rot360, rotdims,
 @testset "map" begin
     a = [1 2; 3 4]
     dimz = (X((143, 145)), Y((-38, -36)))
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test map(x -> 2x, da) == [2 4; 6 8]
-    @test map(x -> 2x, da) isa DimensionalArray{Int64,2}
+    @test map(x -> 2x, da) isa DimArray{Int64,2}
 end
 
 @testset "dimension reducing methods" begin
     a = [1 2; 3 4]
     dimz = X((143, 145); mode=Sampled()), Y((-38, -36); mode=Sampled())
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test sum(da; dims=X()) == sum(a; dims=1)
     @test sum(da; dims=Y()) == sum(a; dims=2)
     @test dims(sum(da; dims=Y())) ==
@@ -66,7 +66,7 @@ end
         (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
          Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
     a = [1 2 3; 4 5 6]
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test median(da) == 3.5
     @test median(da; dims=X()) == [2.5 3.5 4.5]
     @test median(da; dims=2) == [2.0 5.0]'
@@ -75,11 +75,11 @@ end
 @testset "dimension dropping methods" begin
     a = [1 2 3; 4 5 6]
     dimz = X((143, 145); mode=Sampled()), Y((-38, -36); mode=Sampled())
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     # Dimensions must have length 1 to be dropped
     @test dropdims(da[X(1:1)]; dims=X) == [1, 2, 3]
     @test dropdims(da[2:2, 1:1]; dims=(X(), Y()))[] == 4
-    @test typeof(dropdims(da[2:2, 1:1]; dims=(X(), Y()))) <: DimensionalArray{Int,0,Tuple{}}
+    @test typeof(dropdims(da[2:2, 1:1]; dims=(X(), Y()))) <: DimArray{Int,0,Tuple{}}
     @test refdims(dropdims(da[X(1:1)]; dims=X)) == 
         (X(143.0; mode=Sampled(Ordered(), Regular(2.0), Points())),)
     dropped = dropdims(da[X(1:1)]; dims=X)
@@ -93,7 +93,7 @@ if VERSION > v"1.1-"
              3 4 5 6
              5 6 7 8]
         # eachslice
-        da = DimensionalArray(a, (Y((10, 30)), Ti(1:4)))
+        da = DimArray(a, (Y((10, 30)), Ti(1:4)))
         @test [mean(s) for s in eachslice(da; dims=Ti)] == [3.0, 4.0, 5.0, 6.0]
         @test [mean(s) for s in eachslice(da; dims=2)] == [3.0, 4.0, 5.0, 6.0]
         slices = [s .* 2 for s in eachslice(da; dims=Y)]
@@ -110,7 +110,7 @@ if VERSION > v"1.1-"
 end
 
 @testset "simple dimension permuting methods" begin
-    da = DimensionalArray(zeros(5, 4), (Y((10, 20); mode=Sampled()), 
+    da = DimArray(zeros(5, 4), (Y((10, 20); mode=Sampled()), 
                                         X(1:4; mode=Sampled())))
     tda = transpose(da)
     @test tda == transpose(data(da))
@@ -125,7 +125,7 @@ end
     @test dims(tda) == (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                         Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())))
     @test size(tda) == (4, 5)
-    @test typeof(tda) <: DimensionalArray
+    @test typeof(tda) <: DimArray
 
     ada = adjoint(da)
     @test ada == adjoint(data(da))
@@ -140,7 +140,7 @@ end
 
 
 @testset "dimension permuting methods with specified permutation" begin
-    da = DimensionalArray(ones(5, 2, 4), (Y((10, 20); mode=Sampled()), 
+    da = DimArray(ones(5, 2, 4), (Y((10, 20); mode=Sampled()), 
                                           Ti(10:11; mode=Sampled()), 
                                           X(1:4; mode=Sampled())))
     dsp = permutedims(da, [3, 1, 2])
@@ -154,7 +154,7 @@ end
                         Ti(10:11; mode=Sampled(Ordered(), Regular(1), Points())))
     dsp = PermutedDimsArray(da, (3, 1, 2))
     @test dsp == PermutedDimsArray(data(da), (3, 1, 2))
-    @test typeof(dsp) <: DimensionalArray
+    @test typeof(dsp) <: DimArray
 end
 
 @testset "reversing methods" begin
@@ -163,7 +163,7 @@ end
     @test order(revdim) == Ordered(Reverse(), Forward(), Reverse())
 
     A = [1 2 3; 4 5 6]
-    da = DimensionalArray(A, (X(10:10:20), Y(300:-100:100)))
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)))
     rev = reverse(da; dims=Y);
     @test rev == [3 2 1; 6 5 4]
     @test val(dims(rev, X)) == 10:10:20
@@ -209,7 +209,7 @@ end
 
 @testset "dimension mirroring methods" begin
     a = rand(5, 4)
-    da = DimensionalArray(a, (Y((10, 20); mode=Sampled()), 
+    da = DimArray(a, (Y((10, 20); mode=Sampled()), 
                               X(1:4; mode=Sampled())))
 
     cvda = cov(da; dims=X)
@@ -226,7 +226,7 @@ end
     a = [1 2 3 4
          3 4 5 6
          5 6 7 8]
-    da = DimensionalArray(a, (Y((10, 30); mode=Sampled(sampling=Intervals())), 
+    da = DimArray(a, (Y((10, 30); mode=Sampled(sampling=Intervals())), 
                               Ti(1:4; mode=Sampled(sampling=Intervals()))))
     ms = mapslices(sum, da; dims=Y)
     @test ms == [9 12 15 18]
@@ -239,7 +239,7 @@ end
 end
 
 @testset "array info" begin
-    da = DimensionalArray(zeros(5, 4), (Y((10, 20)), X(1:4)))
+    da = DimArray(zeros(5, 4), (Y((10, 20)), X(1:4)))
     @test size(da, Y) == 5
     @test size(da, X()) == 4
     @test axes(da, Y()) == Base.OneTo(5)
@@ -252,9 +252,9 @@ end
 
 @testset "cat" begin
     a = [1 2 3; 4 5 6]
-    da = DimensionalArray(a, (X(1:2), Y(1:3)))
+    da = DimArray(a, (X(1:2), Y(1:3)))
     b = [7 8 9; 10 11 12]
-    db = DimensionalArray(b, (X(3:4), Y(1:3)))
+    db = DimArray(b, (X(3:4), Y(1:3)))
     @test cat(da, db; dims=X()) == [1 2 3; 4 5 6; 7 8 9; 10 11 12]
     testdims = (X([1, 2, 3, 4]; mode=Sampled(Ordered(), Regular(1), Points())),
                 Y(1:3; mode=Sampled(Ordered(), Regular(1), Points())))
@@ -273,7 +273,7 @@ end
 
 @testset "unique" begin
     a = [1 1 6; 1 1 6]
-    da = DimensionalArray(a, (X(1:2), Y(1:3)))
+    da = DimArray(a, (X(1:2), Y(1:3)))
     @test unique(da; dims=X()) == [1 1 6]
     @test unique(da; dims=Y) == [1 6; 1 6]
 end

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -3,7 +3,7 @@ using DimensionalData, Test, Plots, Dates, StatsPlots
 import Distributions
 
 A1 = rand(Distributions.Normal(), 100)
-da1 = DimensionalArray(A1, X(1:10:1000), "Normal"; refdims=(Ti(1),))
+da1 = DimArray(A1, X(1:10:1000), "Normal"; refdims=(Ti(1),))
 
 # Plots
 plot(da1)
@@ -32,7 +32,7 @@ ea_histogram(da1)
 density(da1)
 
 A2 = rand(Distributions.Normal(), 40, 20)
-da2 = DimensionalArray(A2, (X(1:10:400), Y(1:5:100)), "Normal")
+da2 = DimArray(A2, (X(1:10:400), Y(1:5:100)), "Normal")
 
 # Plots
 plot(da2)
@@ -83,5 +83,5 @@ ea_histogram(da2)
 #
 # Crashes GR for some reason
 # im2 = RGB24.(rand(10, 10))
-# da_im2 = DimensionalArray(im2, (X(10:10:100), Y(10:10:100)), "Image")
+# da_im2 = DimArray(im2, (X(10:10:100), Y(10:10:100)), "Image")
 # da_im2 |> plot

--- a/test/prettyprinting.jl
+++ b/test/prettyprinting.jl
@@ -13,22 +13,22 @@ using DimensionalData, Test, Dates
     z = Z('a':'d')
     d = (x, y, z, t)
 
-    A = DimensionalArray(rand(length.(d)...), d)
-    a = DimensionalArray(rand(length(x), length(y)), (x,y))
-    B = DimensionalArray(rand(length(x)), (x,))
+    A = DimArray(rand(length.(d)...), d)
+    a = DimArray(rand(length(x), length(y)), (x,y))
+    B = DimArray(rand(length(x)), (x,))
 
     s1 = sprint(show, A)
     s2 = sprint(show, x)
     s3 = sprint(show, MIME("text/plain"), x)
 
-    @test occursin("DimensionalArray", s1)
+    @test occursin("DimArray", s1)
     for s in (s1, s2, s3)
         @test occursin("Lon", s)
         @test occursin("Longitude", s)
     end
 
     # Test again but now with labelled array A
-    A = DimensionalArray(rand(length.(d)...), d, "test")
+    A = DimArray(rand(length.(d)...), d, "test")
     s1 = sprint(show, A)
     @test occursin("test", s1)
 
@@ -43,13 +43,13 @@ using DimensionalData, Test, Dates
     @test occursin("test", s3)
 
     # It should NOT propagate after binary operations
-    B = DimensionalArray(rand(length.(d)...), d, "test2")
+    B = DimArray(rand(length.(d)...), d, "test2")
     C = A .+ B
     s4 = sprint(show, C)
     @test !occursin("test", s4)
 
     # Test that broadcasted setindex! retains name
-    D = DimensionalArray(ones(length.(d)...), d, "olo")
+    D = DimArray(ones(length.(d)...), d, "olo")
     @. D = A + B
     s5 = sprint(show, D)
     @test occursin("olo", s5)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -19,7 +19,7 @@ dimz = (X(), Y())
 end
 
 a = [1 2 3; 4 5 6]
-da = DimensionalArray(a, (X((143, 145)), Y((-38, -36))))
+da = DimArray(a, (X((143, 145)), Y((-38, -36))))
 dimz = dims(da)
 
 @testset "slicedims" begin
@@ -33,7 +33,7 @@ dimz = dims(da)
         @test slicedims((), (1:2, 3)) == ((), ())
     end
     @testset "Irregular" begin
-        irreg = DimensionalArray(a, (X([140.0, 142.0]; mode=Sampled(Ordered(), Irregular(140.0, 144.0), Intervals(Start()))), 
+        irreg = DimArray(a, (X([140.0, 142.0]; mode=Sampled(Ordered(), Irregular(140.0, 144.0), Intervals(Start()))), 
                                      Y([10.0, 20.0, 40.0]; mode=Sampled(Ordered(), Irregular(0.0, 60.0), Intervals(Center()))), ))
         irreg_dimz = dims(irreg)
         @test slicedims(irreg, (1:2, 3)) == 
@@ -45,7 +45,7 @@ dimz = dims(da)
         @test slicedims((), (1:2, 3)) == ((), ())
     end
     @testset "Val index" begin
-        da = DimensionalArray(a, (X(Val((143, 145))), Y(Val((:x, :y, :z)))))
+        da = DimArray(a, (X(Val((143, 145))), Y(Val((:x, :y, :z)))))
         dimz = dims(da)
         @test slicedims(dimz, (1:2, 3)) == 
             ((X(Val((143,145)), Categorical(), nothing),),

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -8,7 +8,7 @@ a = [1 2  3  4
 
 dims_ = X(10:10:20; mode=Sampled(sampling=Intervals())),
         Y(5:7; mode=Sampled(sampling=Intervals()))
-A = DimensionalArray([1 2 3; 4 5 6], dims_)
+A = DimArray([1 2 3; 4 5 6], dims_)
 
 
 @testset "selector primitives" begin
@@ -281,7 +281,7 @@ end
 
 
 @testset "Selectors on Sampled" begin
-    da = DimensionalArray(a, (Y((10, 30); mode=Sampled()),
+    da = DimArray(a, (Y((10, 30); mode=Sampled()),
                               Ti((1:4)u"s"; mode=Sampled())))
 
     @test At(10.0) == At(10.0, nothing, nothing)
@@ -355,10 +355,10 @@ end
         for idx in indices
             from2d = da[idx]
             @test from2d == data(da)[idx]
-            @test !(from2d isa AbstractDimensionalArray)
+            @test !(from2d isa AbstractDimArray)
             from1d = da[Y <| At(10)][idx]
             @test from1d == data(da)[1, :][idx]
-            @test from1d isa AbstractDimensionalArray
+            @test from1d isa AbstractDimArray
         end
     end
 
@@ -375,7 +375,7 @@ end
             @test from2d isa SubArray
             from1d = view(da[Y(At(10))], idx)
             @test from1d == view(data(da)[1, :], idx)
-            @test from1d isa AbstractDimensionalArray
+            @test from1d isa AbstractDimArray
         end
     end
 
@@ -404,7 +404,7 @@ end
     @testset "more Unitful dims" begin
         dimz = Ti(1.0u"s":1.0u"s":3.0u"s"; mode=Sampled()),
                Y((1u"km", 4u"km"); mode=Sampled())
-        db = DimensionalArray(a, dimz)
+        db = DimArray(a, dimz)
         @test db[Y<|Between(2u"km", 3.9u"km"), Ti<|At<|3.0u"s"] == [10, 11]
     end
 
@@ -414,7 +414,7 @@ end
              9 10 11 12]
 
         @testset "forward index with reverse relation" begin
-            da_ffr = DimensionalArray(a, (Y(10:10:30; mode=Sampled(order=Ordered(Forward(), Forward(), Reverse()))),
+            da_ffr = DimArray(a, (Y(10:10:30; mode=Sampled(order=Ordered(Forward(), Forward(), Reverse()))),
                                          Ti((1:1:4)u"s"; mode=Sampled(order=Ordered(Forward(), Forward(), Reverse())))))
             @test indexorder(dims(da_ffr, Ti)) == Forward()
             @test arrayorder(dims(da_ffr, Ti)) == Forward()
@@ -428,7 +428,7 @@ end
         end
 
         @testset "reverse index with forward relation" begin
-            da_rff = DimensionalArray(a, (Y(30:-10:10; mode=Sampled(order=Ordered(Reverse(), Forward(), Forward()))),
+            da_rff = DimArray(a, (Y(30:-10:10; mode=Sampled(order=Ordered(Reverse(), Forward(), Forward()))),
                                          Ti((4:-1:1)u"s"; mode=Sampled(order=Ordered(Reverse(), Forward(), Forward())))))
             @test da_rff[Y<|At(20), Ti<|At((3.0:4.0)u"s")] == [6, 5]
             @test da_rff[Y<|At([20, 30]), Ti<|At((3.0:4.0)u"s")] == [6 5; 2 1]
@@ -439,7 +439,7 @@ end
         end
 
         @testset "forward index with forward relation" begin
-            da_fff = DimensionalArray(a, (Y(10:10:30; mode=Sampled(order=Ordered(Forward(), Forward(), Forward()))),
+            da_fff = DimArray(a, (Y(10:10:30; mode=Sampled(order=Ordered(Forward(), Forward(), Forward()))),
                                          Ti((1:4)u"s"; mode=Sampled(order=Ordered(Forward(), Forward(), Forward())))))
             @test da_fff[Y<|At(20), Ti<|At((3.0:4.0)u"s")] == [7, 8]
             @test da_fff[Y<|At([20, 30]), Ti<|At((3.0:4.0)u"s")] == [7 8; 11 12]
@@ -449,7 +449,7 @@ end
         end
 
         @testset "reverse index with reverse relation" begin
-            da_rfr = DimensionalArray(a, (Y(30:-10:10; mode=Sampled(order=Ordered(Reverse(), Forward(), Reverse()))),
+            da_rfr = DimArray(a, (Y(30:-10:10; mode=Sampled(order=Ordered(Reverse(), Forward(), Reverse()))),
                                          Ti((4:-1:1)u"s"; mode=Sampled(order=Ordered(Reverse(), Forward(), Reverse())))))
             @test da_rfr[Y<|At(20), Ti<|At((3.0:4.0)u"s")] == [7, 8]
             @test da_rfr[Y<|At([20, 30]), Ti<|At((3.0:4.0)u"s")] == [7 8; 11 12]
@@ -462,7 +462,7 @@ end
 
     @testset "setindex! with selectors" begin
         c = deepcopy(a)
-        dc = DimensionalArray(c, (Y((10, 30)), Ti((1:4)u"s")))
+        dc = DimArray(c, (Y((10, 30)), Ti((1:4)u"s")))
         dc[Near(11), At(3u"s")] = 100
         @test c[1, 3] == 100
         dc[Ti<|Near(2.2u"s"), Y<|Between(10, 30)] = [200, 201, 202]
@@ -472,7 +472,7 @@ end
 end
 
 @testset "Selectors on Sampled and Intervals" begin
-    da = DimensionalArray(a, (Y((10, 30); mode=Sampled(sampling=Intervals())),
+    da = DimArray(a, (Y((10, 30); mode=Sampled(sampling=Intervals())),
                               Ti((1:4)u"s"; mode=Sampled(sampling=Intervals()))))
 
     @testset "selectors with dim wrappers" begin
@@ -499,7 +499,7 @@ end
 
 @testset "Selectors on NoIndex" begin
     dimz = Ti(), Y()
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test da[Ti(At([1, 2])), Y(Contains(2))] == [2, 6]
     @test da[Near(2), Between(2, 4)] == [6, 7, 8]
     @test da[Contains([1, 3]), Near([2, 3, 4])] == [2 3 4; 10 11 12]
@@ -512,7 +512,7 @@ end
 
     dimz = Ti([:one, :two, :three]; mode=Categorical(Ordered())),
         Y([:a, :b, :c, :d]; mode=Categorical(Ordered()))
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test da[Ti(At([:one, :two])), Y(Contains(:b))] == [2, 6]
     @test da[At(:two), Between(:b, :d)] == [6, 7, 8]
     @test da[:two, :b] == 6
@@ -521,7 +521,7 @@ end
    
     dimz = Ti([:one, :two, :three]; mode=Categorical(Unordered())),
         Y([:a, :b, :c, :d]; mode=Categorical(Unordered()))
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test_throws ArgumentError da[At(:two), Between(:b, :d)] == [6, 7, 8]
 
     a = [1 2  3  4
@@ -530,14 +530,14 @@ end
 
     valdimz = Ti(Val((2.4, 2.5, 2.6)); mode=Categorical(Ordered())),
         Y(Val((:a, :b, :c, :d)); mode=Categorical(Ordered()))
-    da = DimensionalArray(a, valdimz)
+    da = DimArray(a, valdimz)
     @test da[Val(2.5), Val(:c)] == 7
     @test da[2.4, :a] == 1
 end
 
 @testset "Where " begin
     dimz = Ti((1:1:3)u"s"), Y(10:10:40)
-    da = DimensionalArray(a, dimz)
+    da = DimArray(a, dimz)
     @test da[Y(Where(x -> x >= 30)), Ti(Where(x -> x in([1u"s", 3u"s"])))] == [3 4; 11 12]
 end
 
@@ -554,7 +554,7 @@ end
         @test permutedims((Y(), Z(), X()), dimz) == (X(), Y(), Z())
     end
 
-    da = DimensionalArray(reshape(a, 3, 4, 1), dimz)
+    da = DimArray(reshape(a, 3, 4, 1), dimz)
 
     @testset "Indexing with array dims indexes the array as usual" begin
         @test da[Dim{:trans1}(3), Dim{:trans2}(1), Z(1)] == 9

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,7 +11,7 @@ using DimensionalData: reversearray, reverseindex, reorderarray, reorderindex,
     @test order(revdimi) == Ordered(Reverse(), Forward(), Reverse())
 
     A = [1 2 3; 4 5 6]
-    da = DimensionalArray(A, (X(10:10:20), Y(300:-100:100)))
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)))
 
     reva = reversearray(da; dims=Y);
     @test reva == [3 2 1; 6 5 4]
@@ -60,7 +60,7 @@ end
 
 @testset "modify" begin
     A = [1 2 3; 4 5 6]
-    da = DimensionalArray(A, (X(10:10:20), Y(300:-100:100)))
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)))
     mda = modify(A -> A .> 3, da)
     @test dims(mda) === dims(da)
     @test mda == [false false false; true true true]


### PR DESCRIPTION
Use `DimArray` and `AbstractDimArray` everywhere. It's just easier to write. 

Keep `const`  `AbstractDimentionalArray` and `DimensionalArray` for legacy support.