### PR TITLE
Refactor: @generated, selectors and docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.11.2"
+version = "0.12.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ syntax, and additional functionality found in NamedDimensions.jl. It has similar
 goals to pythons [xarray](http://xarray.pydata.org/en/stable/), and is primarily
 written for use with spatial data in [GeoData.jl](https://github.com/rafaqz/GeoData.jl).
 
-:exclamation: | Status
-:-----------: | :-------
-
-    This is a work in progress under active development, it may be a while before
-    the interface stabilises and things are fully documented.
-
 
 ## Dimensions
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Base and Statistics methods:
 - `mean`, `median`, `extrema`, `std`, `var`, `cor`, `cov`
 - `permutedims`, `adjoint`, `transpose`, `Transpose`
 - `mapslices`, `eachslice`
+- `fill`
 
 _Example usage:_
 

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -11,6 +11,8 @@
 - Minimal interface: implementing a dimension-aware type should be easy.
 - Functional style: structs are always rebuilt, and other than the array data,
   fields are not mutated in place.
+- Laziness. Label data correctly, and manipulate them when needed - 
+  instead of standardising eagerly.
 - Least surprise: everything works the same as in Base, but with named dims. If
   a method accepts numeric indices or `dims=X` in base, you should be able to
   use DimensionalData.jl dims.
@@ -45,22 +47,27 @@ packages and scripts.
 ### Syntax
 
 AxisArrays.jl is verbose by default: `a[Axis{:y}(1)]` vs `a[Y(1)]` used here.
-NamedDims.jl has concise syntax, but the dimensions are no longer types.
+NamedDims.jl has concise syntax, but the dimensions are no longer types,
+NamedDims.jl syntax can now be replicated using `Dim{:X}`: 
 
+```julia
+A = Dimarray(rand(4, 5), (:a, :b)
+A[:b=5, :a=3] = 25.0
+```
 
 ## Data types and the interface
 
-DimensionalData.jl provides the concrete `DimenstionalArray` type. But it's
+DimensionalData.jl provides the concrete `DimArray` type. But it's
 core purpose is to be easily used with other array types.
 
 Some of the functionality in DimensionalData.jl will work without inheriting
 from `AbstractDimArray`. The main requirement define a `dims` method
-that returns a `Tuple` of `AbstractDimension` that matches the dimension order
+that returns a `Tuple` of `Dimension` that matches the dimension order
 and axis values of your data. Define `rebuild`, and base methods for `similar`
 and `parent` if you want the metadata to persist through transformations (see
 the `DimArray` and `AbstractDimArray` types). A `refdims` method
 returns the lost dimensions of a previous transformation, passed in to the
 `rebuild` method. `refdims` can be discarded, the main loss being plot labels.
 
-Inheriting from `AbstractDimArray` will give all the functionality
+Inheriting from `AbstractDimArray` will give nearly all the functionality
 of using `DimArray`.

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -42,18 +42,17 @@ export Unaligned, Transformed
 
 export AbstractDimArray, DimArray, AbstractDimensionalArray, DimensionalArray
 
-export data, dims, refdims, mode, metadata, name, shortname,
-       val, label, units, order, bounds, locus, mode, <|
+export data, dims, refdims, mode, metadata, name, shortname, label, units,
+       val, index, order, sampling, span, bounds, locus, relation, <|
 
-export dimnum, hasdim, otherdims, commondims, setdims, swapdims, rebuild, 
-       modify, dimwise, dimwise!
+export dimnum, hasdim, otherdims, commondims, setdims, swapdims, sortdims, 
+       rebuild, modify, dimwise, dimwise!
 
 export order, indexorder, arrayorder, 
        reverseindex, reversearray, reorderindex, 
        reorderarray, reorderrelation
 
 export @dim
-
 
 include("interface.jl")
 include("mode.jl")
@@ -71,5 +70,7 @@ include("prettyprint.jl")
 # For compat with old versions
 const AbstractDimensionalArray = AbstractDimArray
 const DimensionalArray = DimArray
+
+const DD = DimensionalData
 
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -56,7 +56,7 @@ function Base.copyto!(dest::AbstractArray, bc::Broadcasted{DimensionalStyle{S}})
     return if A isa Nothing || _dims isa Nothing
         dest
     else
-        rebuild(A, data(dest), _dims, refdims(A), "")
+        rebuild(A, parent(dest), _dims, refdims(A), "")
     end
 end
 
@@ -67,7 +67,7 @@ function Base.copyto!(dest::AbstractDimArray, bc::Broadcasted{DimensionalStyle{S
     return if A isa Nothing || _dims isa Nothing
         dest
     else
-        rebuild(A, data(dest), _dims, refdims(A), "")
+        rebuild(A, parent(dest), _dims, refdims(A), "")
     end
 end
 
@@ -84,7 +84,7 @@ _unwrap_broadcasted(bc::Broadcasted{DimensionalStyle{S}}) where S = begin
     return Broadcasted{S}(bc.f, innerargs)
 end
 _unwrap_broadcasted(x) = x
-_unwrap_broadcasted(nda::AbstractDimArray) = data(nda)
+_unwrap_broadcasted(nda::AbstractDimArray) = parent(nda)
 
 # Get the first dimensional array inthe broadcast
 _firstdimarray(x::Broadcasted) = _firstdimarray(x.args)

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -25,24 +25,24 @@ contexts, like geospatial data in GeoData.jl. By default it is `nothing`.
 Example:
 
 ```jldoctest Dimension
-using Dates
+using DimensionalData, Dates
 x = X(2:2:10)
 y = Y(['a', 'b', 'c'])
 ti = Ti(DateTime(2021, 1):Month(1):DateTime(2021, 12))
 
-A = DimArray(rand(3, 5, 12), (y, x, ti))
+A = DimArray(zeros(3, 5, 12), (y, x, ti))
 
 # output
 
 DimArray with dimensions:
- Y: Char[a, b, c]
- X: 2:2:10
- Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
+ Y: Char[a, b, c] (Categorical: Unordered)
+ X: 2:2:10 (Sampled: Ordered Regular Points)
+ Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
 and data: 3×5×12 Array{Float64,3}
 [:, :, 1]
- 0.590845  0.460085  0.200586  0.579672   0.066423
- 0.766797  0.794026  0.298614  0.648882   0.956753
- 0.566237  0.854147  0.246837  0.0109059  0.646691
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
 [and 11 more slices...]
 ```
 
@@ -55,12 +55,12 @@ x = A[X(2), Y(3)]
 # output
 
 DimArray with dimensions:
- Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
+ Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
 and referenced dimensions:
- Y: c
- X: 4
+ Y: c (Categorical: Unordered)
+ X: 4 (Sampled: Ordered Regular Points)
 and data: 12-element Array{Float64,1}
-[0.854147, 0.950498, 0.496169, 0.658815, 0.082207, 0.431188, 0.0878598, 0.468079, 0.0677996, 0.836482, 0.0813266, 0.661835]
+[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 ```
 
 A `Dimension` can also wrap [`Selector`](@ref).
@@ -71,12 +71,12 @@ x = A[X(Between(3, 4)), Y(At('b'))]
 # output
 
 DimArray with dimensions:
- X: 4:2:4
- Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00")
+ X: 4:2:4 (Sampled: Ordered Regular Points)
+ Time (type Ti): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
 and referenced dimensions:
- Y: b
+ Y: b (Categorical: Unordered)
 and data: 1×12 Array{Float64,2}
- 0.794026  0.842714  0.0460428  0.499531  …  0.182757  0.140473  0.52376
+ 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 ```
 
 `Dimension` objects may have [`mode`](@ref) and [`metadata`](@ref) fields
@@ -219,13 +219,15 @@ ie `Dim{:lat}(1:9)` rather than `Lat(1:9)`. This is the main reason
 they are not the only type of dimension availabile.
 
 ```jldoctest
+using DimensionalData
+
 dim = Dim{:custom}(['a', 'b', 'c'])
 
 # output
 
-dimension Dim custom (type Dim):
+dimension Dim{:custom} (type Dim):
 val: Char[a, b, c]
-mode: AutoMode{AutoOrder}(AutoOrder())
+mode: AutoMode
 metadata: nothing
 type: Dim{:custom,Array{Char,1},AutoMode{AutoOrder},Nothing}
 ```
@@ -382,9 +384,7 @@ const Time = Ti # For some backwards compat
 Format the passed-in dimension(s) `dims` to match the array `A`.
 
 This means converting indexes of `Tuple` to `LinRange`, and running
-`identify` on . 
-Errors are also thrown if
-dims don't match the array dims or size.
+`identify`. Errors are also thrown if dims don't match the array dims or size.
 
 If a [`IndexMode`](@ref) hasn't been specified, an mode is chosen
 based on the type and element type of the index:

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,20 +1,23 @@
 # Key methods to add for a new dimensional data type
 
 """
-    data(x)
+    rebuild(x, args...)
+    rebuild(x; kwargs...)
 
-Return the data wrapped by the dimentional array. This may not be
-the same as `Base.parent`, as it should never include data outside the
-bounds of the dimensions.
+Rebuild an object struct with updated field values. 
 
-In a disk based [`AbstractDimArray`](@ref), `data` may need to
-load data from disk.
+This is an abstraction that alows inbuilt and custom types to be rebuilt 
+functionally to update them, as most objects in DimensionalData are immutable.
+
+`x` can be a `AbstractDimArray`, a `Dimension`, `IndexMode` or other custom types.
+
+The arguments reuired are defined for the abstract type that has a `rebuild` method.
 """
-function data end
-data(x) = x
+function rebuild end
+rebuild(x; kwargs...) = ConstructionBase.setproperties(x, (;kwargs...))
 
 """
-    dims(x)
+    dims(x) => Tuple{Vararg{<:Dimension}}
 
 Return a tuple of `Dimension`s for an object, in the order that matches 
 the axes or columns etc. of the underlying data.
@@ -23,7 +26,7 @@ function dims end
 dims(x) = nothing
 
 """
-    refdims(x)
+    refdims(x) => Tuple{Vararg{<:Dimension}}
 
 Reference dimensions for an array that is a slice or view of another
 array with more dimensions.
@@ -35,14 +38,6 @@ captions empty.
 """
 function refdims end
 refdims(x) = ()
-"""
-    rebuild(x, args...)
-    rebuild(x; kwargs...)
-
-Rebuild an object struct with updated values.
-"""
-function rebuild end
-rebuild(x; kwargs...) = ConstructionBase.setproperties(x, (;kwargs...))
 
 """
     val(x)
@@ -59,24 +54,28 @@ Return the metadata of a dimension or data object.
 function metadata end
 
 """
-    mode(x)
+    mode(x) => IndexMode 
 
-Return the `IndexMode` of a dimension.
+Returns the [`IndexMode`](@ref) of a dimension. This dictates
+properties of the dimension such as array axis and index order, 
+and sampling properties.
 """
 function mode end
 
 """
-    bounds(x, [dims])
+    bounds(x, [dims]) => Union{Tuple{T,T},Tuple{Vararg{<:Tuple{T,T}}}
 
 Return the bounds of all dimensions of an object, of a specific dimension,
 or of a tuple of dimensions.
 
-Returns a length 2 `Tuple` in ascending order.
+Returns a `Tuple` of length 2 `Tuple` in ascending order for each dimension.
+
+A single value for `dims` will return a single bounds `Tuple`.
 """
 function bounds end
 
 """
-    name(x)
+    name(x) => String
 
 Get the name of data or a dimension.
 """
@@ -86,7 +85,7 @@ name(x::Type) = ""
 name(xs::Tuple) = map(name, xs)
 
 """
-    shortname(x)
+    shortname(x) => String
 
 Get the short name of array data or a dimension.
 
@@ -99,9 +98,9 @@ shortname(xs::Tuple) = map(shortname, xs)
 shortname(x::Type) = ""
 
 """
-    units(x)
+    units(x) => Union{Nothing,Any}
 
-Return the units of a dimension. This could be a string, a unitful unit, or nothing.
+Return the units of a dimension. This could be a string, a unitful unit, or `nothing`.
 
 Units do not have a field, and may or may not be included in `metadata`.
 This method is to facilitate use in labels and plots when units are available, 
@@ -112,7 +111,7 @@ units(x) = nothing
 units(xs::Tuple) = map(units, xs)
 
 """
-    label(x)
+    label(x) => String
 
 Get a plot label for data or a dimension. This will include the name and units
 if they exist, and anything else that should be shown on a plot.

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -18,9 +18,15 @@ rebuild(x; kwargs...) = ConstructionBase.setproperties(x, (;kwargs...))
 
 """
     dims(x) => Tuple{Vararg{<:Dimension}}
+    dims(x, dims::Tuple) => Tuple{Vararg{<:Dimension}}
+    dims(x, dim) => Dimension
 
 Return a tuple of `Dimension`s for an object, in the order that matches 
 the axes or columns etc. of the underlying data.
+
+`dims` can be `Dimension`, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+
+The default is to return `nothing`.
 """
 function dims end
 dims(x) = nothing
@@ -35,87 +41,215 @@ array with more dimensions.
 and the new reference dimensions. Refdims can be stored in a field or disgarded,
 as it is mostly to give context to plots. Ignoring refdims will simply leave some 
 captions empty.
+
+The default is to return an empty `Tuple` `()`.
 """
 function refdims end
 refdims(x) = ()
 
 """
     val(x)
+    val(dims::Tuple) => Tuple
+    val(A::AbstractDimArray, dims::Tuple)  => Tuple
 
-Return the contained value of a wrapper object, otherwise just returns the object.
+Return the contained value of a wrapper object.
+
+`dims` can be `Dimension`, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+
+Objects that don't define a `val` method are returned unaltered.
 """
 function val end
 
 """
-    metadata(x)
+    index(dim::Dimension{<:Val}) => Tuple
+    index(dim::Dimension{<:AbstractArray}) => AbstractArray
+    index(dims::NTuple{N}) => Tuple{Vararg{Union{AbstractArray,Tuple},N}}
 
-Return the metadata of a dimension or data object.
+Return the contained index of a `Dimension`. 
+
+Only valid when a `Dimension` contains an `AbstractArray` 
+or a Val tuple like `Val{(:a, :b)}()`. The `Val` is unwrapped
+to return just the `Tuple`
+
+`dims` can be a `Dimension`, or a tuple of `Dimension`.
 """
-function metadata end
+function index end
 
 """
-    mode(x) => IndexMode 
+    mode(dim:Dimension) => IndexMode 
+    mode(dims::Tuple) => Tuple{Vararg{<:IndexMode,N}}
+    mode(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
 Returns the [`IndexMode`](@ref) of a dimension. This dictates
 properties of the dimension such as array axis and index order, 
 and sampling properties.
+
+`dims` can be a `Dimension`, a dimension type, or a tuple of either.
 """
 function mode end
 
 """
-    bounds(x, [dims]) => Union{Tuple{T,T},Tuple{Vararg{<:Tuple{T,T}}}
+    metadata(dim::Dimension)
+    metadata(dims::Tuple{<:Dimension,Vararg})
+    metadata(A::AbstractDimArray, dims::Tuple)  => (Dim metadata)
+    metadata(A::AbstractDimArray) => (Array metadata)
+
+Returns the metadata for an array or the specified dimension(s).
+`dims` can be a `Symbol` (with `Dim{X}`, a `Dimension`, a `Dimension` type, 
+or a mixed tuple.
+
+`dims` can be a `Dimension`, a dimension type, or a tuple of either.
+"""
+function metadata end
+
+"""
+    bounds(dim::Dimension) => Tuple{T,T}}
+    bounds(dims::Tuple{<:Dimension,Vararg}) => Tuple{Vararg{<:Tuple{T,T}}}
+    bounds(A::AbstractArray, [dims]) => Tuple{Vararg{Tuple{T,T},N}}
+    bounds(A::AbstractArray, dim) => Tuple{T,T}
 
 Return the bounds of all dimensions of an object, of a specific dimension,
 or of a tuple of dimensions.
 
-Returns a `Tuple` of length 2 `Tuple` in ascending order for each dimension.
-
-A single value for `dims` will return a single bounds `Tuple`.
+`dims` can be a `Dimension`, a dimension type, or a tuple of either.
 """
 function bounds end
 
 """
     name(x) => String
+    name(xs::NTuple{N,<:Dimension}) => NTuple{N,String}
+    name(A::AbstractDimArray, dims::NTuple{N}) => NTuple{N,String}
 
-Get the name of data or a dimension.
+Get the name of an array or Dimension, or a tuple of of either.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function name end
 name(x) = name(typeof(x))
 name(x::Type) = ""
-name(xs::Tuple) = map(name, xs)
 
 """
     shortname(x) => String
+    shortname(xs::NTuple{N}) => NTuple{N,String}
+    shortname(A::AbstractDimArray, dims::NTuple{N}) => NTuple{N,String}
 
-Get the short name of array data or a dimension.
+Get the shortname of an array or Dimension, or a tuple of of either.
 
 This may be a shorter version more suitable for small labels than 
 `name`, but it may also be identical to `name`.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function shortname end
 shortname(x) = shortname(typeof(x))
-shortname(xs::Tuple) = map(shortname, xs)
 shortname(x::Type) = ""
 
 """
     units(x) => Union{Nothing,Any}
+    units(::NTuple{N}) => NTuple{N}
+    unit(A::AbstractDimArray, dims::NTuple{N}) => NTuple{N,String}
 
-Return the units of a dimension. This could be a string, a unitful unit, or `nothing`.
+Get the units of an array or `Dimension`, or a tuple of of either.
 
-Units do not have a field, and may or may not be included in `metadata`.
+Units do not have a set field, and may or may not be included in `metadata`.
 This method is to facilitate use in labels and plots when units are available, 
-not a guarantee that they will be.
+not a guarantee that they will be. If not available, `nothing` is returned.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function units end
 units(x) = nothing
-units(xs::Tuple) = map(units, xs)
 
 """
     label(x) => String
+    label(dims::NTuple{N,<:Dimension}) => NTuple{N,String}
+    label(A::AbstractDimArray, dims::NTuple{N,<:Dimension}) => NTuple{N,String}
 
 Get a plot label for data or a dimension. This will include the name and units
 if they exist, and anything else that should be shown on a plot.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function label end
 label(x) = string(name(x), (units(x) === nothing ? "" : string(" ", units(x))))
-label(xs::Tuple) = join(map(label, xs), ", ")
+
+
+"""
+    order(dim:Dimension) => Order 
+    order(dims::Tuple) => Tuple{Vararg{<:Order,N}}
+    order(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Order`](@ref) for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function order end
+
+"""
+    sampling(dim:Dimension) => Sampling 
+    sampling(dims::Tuple) => Tuple{Vararg{<:Sampling,N}}
+    sampling(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Sampling`](@ref) for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function sampling end
+
+"""
+    span(dim:Dimension) => Span 
+    span(dims::Tuple) => Tuple{Vararg{<:Span,N}}
+    span(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Span`](@ref) for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function span end
+
+"""
+    locus(dim:Dimension) => Locus 
+    locus(dims::Tuple) => Tuple{Vararg{<:Locus,N}}
+    locus(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Locus`](@ref) for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function locus end
+
+"""
+    arrayorder(dim:Dimension) => Union{Forward,Reverse}
+    arrayorder(dims::Tuple) => Tuple{Vararg{<:Union{Forward,Reverse},N}}
+    arrayorder(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Order`](@ref) (`Forward` or `Reverse`) of the array, 
+for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function arrayorder end
+
+"""
+    indexorder(dim:Dimension) => Union{Forward,Reverse}
+    indexorder(dims::Tuple) => Tuple{Vararg{<:Union{Forward,Reverse},N}}
+    indexorder(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the [`Order`](@ref) (`Forward` or `Reverse`) of the dimension index, 
+for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function indexorder end
+
+"""
+    relation(dim:Dimension) => Union{Forward,Reverse}
+    relation(dims::Tuple) => Tuple{Vararg{<:Union{Forward,Reverse},N}}
+    relation(A::AbstractDimArray, [dims::Tuple]) => Tuple
+
+Return the relation (`Forward` or `Reverse`) between the dimension index
+and the array axis, for each dimension.
+
+`dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
+"""
+function relation end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -55,15 +55,15 @@ Base.:*(A::Adjoint{<:Any,<:RealHermSymComplexHerm}, B::AbstractDimVector) = rebu
 
 rebuildmul(A::AbstractDimVector, B::AbstractDimMatrix) = begin
     # Vector has no dim 2 to compare
-    rebuild(A, data(A) * data(B), (first(dims(A)), last(dims(B)),))
+    rebuild(A, parent(A) * parent(B), (first(dims(A)), last(dims(B)),))
 end
 rebuildmul(A::AbstractDimMatrix, B::AbstractDimVector) = begin
     comparedims(last(dims(A)), first(dims(B)))
-    rebuild(A, data(A) * data(B), (first(dims(A)),))
+    rebuild(A, parent(A) * parent(B), (first(dims(A)),))
 end
 rebuildmul(A::AbstractDimMatrix, B::AbstractDimMatrix) = begin
     comparedims(last(dims(A)), first(dims(B)))
-    rebuild(A, data(A) * data(B), (first(dims(A)), last(dims(B))))
+    rebuild(A, parent(A) * parent(B), (first(dims(A)), last(dims(B))))
 end
 rebuildmul(A::AbstractDimVector, B::AbstractMatrix) =
     rebuild(A, parent(A) * B, (first(dims(A)), AnonDim(Base.OneTo(size(B, 2)))))

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -170,7 +170,7 @@ end
 for fname in [:permutedims, :PermutedDimsArray]
     @eval begin
         @inline Base.$fname(A::AbstractDimArray{T,N}, perm) where {T,N} =
-            rebuild(A, $fname(parent(A), dimnum(A, perm)), permutedims(dims(A), perm))
+            rebuild(A, $fname(parent(A), dimnum(A, perm)), sortdims(dims(A), perm))
     end
 end
 
@@ -206,7 +206,7 @@ _catifcatdim(catdims::Tuple, ds) =
 _catifcatdim(catdim, ds) = basetypeof(catdim) <: basetypeof(ds[1]) ? vcat(ds...) : ds[1]
 
 Base.vcat(dims::Dimension...) =
-    rebuild(dims[1], vcat(map(val, dims)...), vcat(map(mode, dims)...))
+    rebuild(dims[1], vcat(val(dims)...), vcat(mode(dims)...))
 
 Base.vcat(modes::IndexMode...) = first(modes)
 Base.vcat(modes::AbstractSampled...) =

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -276,24 +276,26 @@ An [`IndexMode`](@ref) that is identical to the array axis.
 Defining a [`DimArray`](@ref) without passing an index
 to the dimension, the IndexMode will be `NoIndex`:
 
-```jldoctest
+```jldoctest NoIndex
+using DimensionalData
+
 A = DimArray(rand(3, 3), (X, Y))
 map(mode, dims(A))
 
 # output
 
-(NoIndex(), NoIndex())
+(NoIndex, NoIndex)
 ```
 
 Is identical to:
 
-```jldoctest
+```jldoctest NoIndex
 A = DimArray(rand(3, 3), (X(; mode=NoIndex()), Y(; mode=NoIndex())))
 map(mode, dims(A))
 
 # output
 
-(NoIndex(), NoIndex())
+(NoIndex, NoIndex)
 ```
 """
 struct NoIndex <: Aligned{Ordered{Forward,Forward,Forward}} end
@@ -389,7 +391,9 @@ The `Sampled` mode is assigned for all indexes of `AbstractRange` not assigned t
 
 Create an array with [`Interval`] sampling.
 
-```jldoctest
+```jldoctest Sampled
+using DimensionalData
+
 dims_ = (X(100:-10:10; mode=Sampled(sampling=Intervals())),
          Y([1, 4, 7, 10]; mode=Sampled(span=Regular(2), sampling=Intervals())))
 A = DimArray(rand(10, 4), dims_)
@@ -397,7 +401,7 @@ map(mode, dims(A))
 
 # output
 
-(Sampled{Ordered{DimensionalData.Reverse,DimensionalData.Forward,DimensionalData.Forward},Regular{Int64},Intervals{Center}}(Ordered{DimensionalData.Reverse,DimensionalData.Forward,DimensionalData.Forward}(DimensionalData.Reverse(), DimensionalData.Forward(), DimensionalData.Forward()), Regular{Int64}(-10), Intervals{Center}(Center())), Sampled{Ordered{DimensionalData.Forward,DimensionalData.Forward,DimensionalData.Forward},Regular{Int64},Intervals{Center}}(Ordered{DimensionalData.Forward,DimensionalData.Forward,DimensionalData.Forward}(DimensionalData.Forward(), DimensionalData.Forward(), DimensionalData.Forward()), Regular{Int64}(2), Intervals{Center}(Center())))
+(Sampled: Ordered Regular Intervals, Sampled: Ordered Regular Intervals)
 ```
 """
 struct Sampled{O,Sp,Sa} <: AbstractSampled{O,Sp,Sa}
@@ -440,14 +444,16 @@ it instead defaults to [`Unordered`].
 
 Create an array with [`Interval`] sampling.
 
-```jldoctest
+```jldoctest Categorical
+using DimensionalData
+
 dims_ = X(["one", "two", "thee"]), Y([:a, :b, :c, :d])
 A = DimArray(rand(3, 4), dims_)
 map(mode, dims(A))
 
 # output
 
-(Categorical{Unordered{DimensionalData.Forward}}(Unordered{DimensionalData.Forward}(DimensionalData.Forward())), Categorical{Unordered{DimensionalData.Forward}}(Unordered{DimensionalData.Forward}(DimensionalData.Forward())))
+(Categorical: Unordered, Categorical: Unordered)
 ```
 """
 struct Categorical{O<:Order} <: AbstractCategorical{O}
@@ -487,7 +493,7 @@ from CoordinateTransformations.jl may be useful.
 ## Example
 
 ```jldoctest
-using CoordinateTransformations
+using DimensionalData, CoordinateTransformations
 
 m = LinearMap([0.5 0.0; 0.0 0.5])
 A = [1 2  3  4

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -578,17 +578,17 @@ struct Transformed{F,D} <: Unaligned
 end
 Transformed(f, D::UnionAll) = Transformed(f, D())
 
-transform(mode::Transformed) = mode.f
+transformfunc(mode::Transformed) = mode.f
 dims(mode::Transformed) = mode.dim
 dims(::Type{<:Transformed{<:Any,D}}) where D = D
 
 """
     rebuild(mode::Transformed, f, dim)
-    rebuild(mode::Transformed, f=transform(mode), dim=dims(mode))
+    rebuild(mode::Transformed, f=transformfunct(mode), dim=dims(mode))
 
 Rebuild the `Transformed` `IndexMode`.
 """
-rebuild(mode::Transformed, f=transform(mode), dim=dims(mode)) =
+rebuild(mode::Transformed, f=transformfunct(mode), dim=dims(mode)) =
     Transformed(f, dim)
 
 # TODO bounds

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -105,6 +105,11 @@ isrev(::Reverse) = true
 """
 Locii indicate the position of index values in cells.
 
+These allow for values array cells to align with the [`Start`](@ref), 
+[`Center`](@ref), or [`End`](@ref) of the index. 
+This means they can be plotted correctly, and allows automatic converrsions 
+to between formats with different standards (such as NetCDF and GeoTiff).
+
 Locii are often `Start` for time series, but often `Center`
 for spatial data.
 """

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -42,7 +42,7 @@ end
     dim = dims(A, 1)
     :xguide --> label(dim)
     :yguide --> label(A)
-    unwrap(index(dim)), parent(A)
+    index(dim), parent(A)
 end
 @recipe function f(::SeriesLike, A::AbstractArray{T,2}) where T
     A = maybe_permute(A, (IndependentDim, DependentDim))
@@ -50,7 +50,7 @@ end
     :xguide --> label(ind)
     :yguide --> label(A)
     :legendtitle --> label(dep)
-    :label --> permutedims(index(dep))
+    :label --> permutedims(val(dep))
     index(ind), parent(A)
 end
 
@@ -110,14 +110,15 @@ forwardorder(A::AbstractArray) =
     reorderindex(A, Forward()) |> a -> reorderrelation(a, Forward())
 
 refdims_title(A::AbstractArray) = join(map(refdims_title, refdims(A)), ", ")
-refdims_title(dim::Dimension) = string(name(dim), ": ", refdims_title(mode(dim), dim))
-refdims_title(mode::AbstractSampled, dim::Dimension) = begin
-    start, stop = map(string, bounds(dim))
+refdims_title(refdim::Dimension) = 
+    string(name(refdim), ": ", refdims_title(mode(refdim), refdim))
+refdims_title(mode::AbstractSampled, refdim::Dimension) = begin
+    start, stop = map(string, bounds(refdim))
     if start == stop
         start
     else
          "$start to $stop"
     end
 end
-refdims_title(mode::IndexMode, dim::Dimension) = string(index(dim))
+refdims_title(mode::IndexMode, refdim::Dimension) = string(val(refdim))
 

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -24,17 +24,17 @@ end
         HistogramLike(), Afwd
     elseif sertype in [:hline]
         :yguide --> label(Afwd)
-        data(Afwd)
+        parent(Afwd)
     elseif sertype in [:vline, :andrews]
         :xguide --> label(Afwd)
-        data(Afwd)
+        parent(Afwd)
     elseif sertype in [:violin, :dotplot, :boxplot]
         ViolinLike(), Afwd
     elseif sertype in [:plot, :histogram2d, :none, :line, :path, :steppre, :steppost, :sticks, :scatter, 
                        :hexbin, :barbins, :scatterbins, :stepbins, :bins2d, :bar]
         SeriesLike(), Afwd
     else
-        data(Afwd)
+        parent(Afwd)
     end
 end
 
@@ -51,13 +51,13 @@ end
     :yguide --> label(A)
     :legendtitle --> label(dep)
     :label --> permutedims(index(dep))
-    index(ind), data(A)
+    index(ind), parent(A)
 end
 
 @recipe function f(::HistogramLike, A::AbstractArray{T,1}) where T
     dim = dims(A, 1)
     :xguide --> label(A)
-    index(dim), data(A)
+    index(dim), parent(A)
 end
 @recipe function f(::HistogramLike, A::AbstractArray{T,2}) where T
     A = maybe_permute(A, (IndependentDim, DependentDim))
@@ -65,13 +65,13 @@ end
     :xguide --> label(A)
     :legendtitle --> label(dep)
     :label --> permutedims(index(dep))
-    index(ind), data(A)
+    index(ind), parent(A)
 end
 
 @recipe function f(::ViolinLike, A::AbstractArray{T,1}) where T
     dim = dims(A, 1)
     :yguide --> label(A)
-    data(A)
+    parent(A)
 end
 @recipe function f(::ViolinLike, A::AbstractArray{T,2}) where T
     A = maybe_permute(A, (IndependentDim, DependentDim))
@@ -80,14 +80,14 @@ end
     :yguide --> label(A)
     :legendtitle --> label(dep)
     :label --> permutedims(index(dep))
-    data(A)
+    parent(A)
 end
 
 @recipe function f(::HeatMapLike, A::AbstractArray{T,1}) where T
     dim = dims(A, 1)
     :xguide --> label(dim)
     :yguide --> label(A)
-    index(dim), data(A)
+    index(dim), parent(A)
 end
 
 @recipe function f(::HeatMapLike, A::AbstractArray{T,2}) where T
@@ -97,11 +97,11 @@ end
     :yguide --> label(y)
     :zguide --> label(A)
     :colorbar_title --> label(A)
-    reverse(map(index, dims(A)))..., data(A)
+    reverse(map(index, dims(A)))..., parent(A)
 end
 
 @recipe function f(::ImageLike, A::AbstractArray{T,2}) where T
-    data(A)
+    parent(A)
 end
 
 maybe_permute(A, dims) = all(hasdim(A, dims)) ? permutedims(A, dims) : A

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -54,9 +54,17 @@ Base.show(io::IO, dim::Dimension) = begin
         printstyled(io, nameof(typeof(dim)); color=:red)
         print(io, ")")
     end
-    print(io, ": ")
+    printdimproperties(io, dim)
+end
+Base.show(io::IO, dim::Dim) = begin
+    printstyled(io, name(dim); color=:red)
+    printdimproperties(io, dim)
+end
 
+printdimproperties(io, dim) = begin
+    print(io, ": ")
     _printdimval(io, val(dim))
+    print(io, " (", mode(dim), ")")
 end
 
 _printdimval(io, A::AbstractArray) = printlimited(io, A)
@@ -72,6 +80,22 @@ function printlimited(io, v::AbstractVector)
     end
     print(io, s*svals*"]")
 end
+
+Base.show(io::IO, mode::IndexMode) = _printmode(io, mode)
+Base.show(io::IO, mode::AbstractSampled) = begin
+    _printmode(io, mode)
+    _printorder(io, mode)
+    print(io, " ", nameof(typeof(span(mode))))
+    print(io, " ", nameof(typeof(sampling(mode))))
+end
+Base.show(io::IO, mode::AbstractCategorical) = begin
+    _printmode(io, mode)
+    _printorder(io, mode)
+end
+
+_printmode(io, mode) = printstyled(io, nameof(typeof(mode)); color=:green)
+
+_printorder(io, mode) = print(io, ": ", nameof(typeof(order(mode))))
 
 # Thanks to Michael Abbott for the following function
 custom_show(io::IO, A::AbstractArray{T,0}) where T =

--- a/src/prettyprint.jl
+++ b/src/prettyprint.jl
@@ -20,9 +20,9 @@ Base.show(io::IO, A::AbstractDimArray) = begin
     end
     print(io, "and")
     printstyled(io, " data: "; color=:green)
-    dataA = data(A)
+    dataA = parent(A)
     print(io, summary(dataA), "\n")
-    custom_show(io, data(A))
+    custom_show(io, parent(A))
 end
 # Short printing for DimArray
 Base.show(io::IO, ::MIME"text/plain", A::AbstractDimArray) = show(io, A)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -325,7 +325,8 @@ val(dims(B, Y))
 'a':1:'j'
 ```
 """
-@inline setdims(A, newdims::Union{Dimension,DimTuple}) = rebuild(A, data(A), setdims(dims(A), newdims))
+@inline setdims(A, newdims::Union{Dimension,DimTuple}) = 
+    rebuild(A, data(A), setdims(dims(A), newdims))
 @inline setdims(dims::DimTuple, newdims::DimTuple) = map(nd -> setdims(dims, nd), newdims)
 # TODO handle the multiples of the same dim.
 @inline setdims(dims::DimTuple, newdim::Dimension) = map(d -> setdims(d, newdim), dims)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -210,12 +210,12 @@ The return type will be a Tuple of `Int` or a single `Int`,
 depending on wether `lookup` is a `Tuple` or single `Dimension`.
 
 ## Example
+
 ```jldoctest
+julia> using DimensionalData
+
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
-
-julia> dimnum(A, Z)
-3
 ```
 """
 @inline dimnum(A, lookup) = dimnum(dims(A), lookup)
@@ -252,13 +252,10 @@ Check if an object or tuple contains an `Dimension`, or a tuple of dimensions.
 
 ## Example
 ```jldoctest
+julia> using DimensionalData
+
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
-julia> hasdim(A, X)
-true
-
-julia> hasdim(A, Ti)
-false
 ```
 """
 @inline hasdim(A::AbstractArray, lookup) = hasdim(dims(A), lookup)
@@ -283,13 +280,10 @@ A tuple holding the unmatched dimensions is always returned.
 
 ## Example
 ```jldoctest
+julia> using DimensionalData
+
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
-julia> otherdims(A, X)
-(Y: Base.OneTo(10), Z: Base.OneTo(10))
-
-julia> otherdims(A, Ti)
-(X: Base.OneTo(10), Y: Base.OneTo(10), Z: Base.OneTo(10))
 ```
 """
 @inline otherdims(A::AbstractArray, lookup) = otherdims(dims(A), lookup)
@@ -320,6 +314,8 @@ and returns a new object or tuple with the dimension updated.
 
 # Example
 ```jldoctest
+using DimensionalData
+
 A = DimArray(ones(10, 10), (X, Y(10:10:100)))
 B = setdims(A, Y('a':'j'))
 val(dims(B, Y))
@@ -353,14 +349,10 @@ dimension as-is.
 
 # Example
 ```jldoctest
+julia> using DimensionalData
+
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
-
-julia> B = swapdims(A, (Z, Dim{:custom}, Ti));
-
-
-julia> dimnum(B, Ti)
-3
 ```
 """
 @inline swapdims(A::AbstractArray, newdims::Tuple) =
@@ -458,15 +450,10 @@ any combination of either.
 
 ## Example
 ```jldoctest
+julia> using DimensionalData
+
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
-
-julia> dims(A, Z)
-dimension Z:
-val: Base.OneTo(10)
-mode: NoIndex()
-metadata: nothing
-type: Z{Base.OneTo{Int64},NoIndex,Nothing}
 ```
 """
 @inline dims(A::AbstractArray, lookup) = dims(dims(A), lookup)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -366,7 +366,7 @@ julia> dimnum(B, Ti)
 @inline swapdims(A::AbstractArray, newdims::Tuple) =
     rebuild(A, data(A), formatdims(A, swapdims(dims(A), newdims)))
 @inline swapdims(dims::DimTuple, newdims::Tuple) =
-    map((d, nd) -> _swapdims(d, nd), dims, symbol2dim(newdims))
+    map((d, nd) -> _swapdims(d, nd), dims, newdims)
 
 @inline _swapdims(dim::Dimension, newdim::DimType) =
     basetypeof(newdim)(val(dim), mode(dim), metadata(dim))
@@ -537,3 +537,4 @@ symbol2dim(s::Symbol) = Dim{s}()
 symbol2dim(dim::Dimension) = dim
 symbol2dim(dimtype::Type{<:Dimension}) = dimtype
 symbol2dim(dims::Tuple) = map(symbol2dim, dims)
+symbol2dim(dim) = dim

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -36,6 +36,8 @@ and wont be used.
 ## Example
 
 ```jldoctest
+using DimensionalData
+
 A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(At(20)), Y(At(6))]
 
@@ -67,6 +69,8 @@ index value for [`Start`](@ref) and [`End`](@ref) loci.
 ## Example
 
 ```jldoctest
+using DimensionalData
+
 A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(Near(23)), Y(Near(5.1))] 
 
@@ -90,6 +94,8 @@ Can only be used for [`Intervals`](@ref) or [`Categorical`](@ref).
 ## Example
 
 ```jldoctest
+using DimensionalData
+
 dims_ = X(10:10:20; mode=Sampled(sampling=Intervals())),
         Y(5:7; mode=Sampled(sampling=Intervals()))
 A = DimArray([1 2 3; 4 5 6], dims_)
@@ -117,14 +123,16 @@ results with the same index and values - this is the intended behaviour.
 ## Example
 
 ```jldoctest
+using DimensionalData
+
 A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(5:7)))
 A[X(Between(15, 25)), Y(Between(4, 6.5))] 
 
 # output
 
 DimArray with dimensions:
- X: 20:10:20
- Y: 5:6
+ X: 20:10:20 (Sampled: Ordered Regular Points)
+ Y: 5:6 (Sampled: Ordered Regular Points)
 and data: 1×2 Array{Int64,2}
  4  5
 ```
@@ -144,14 +152,16 @@ a single value from the index and returns a `Bool`.
 ## Example
 
 ```jldoctest
+using DimensionalData
+
 A = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(19:21)))
 A[X(Where(x -> x > 15)), Y(Where(x -> x in (19, 21)))]
 
 # output
 
 DimArray with dimensions:
- X: Int64[20]
- Y: Int64[19, 21]
+ X: Int64[20] (Sampled: Ordered Regular Points)
+ Y: Int64[19, 21] (Sampled: Ordered Regular Points)
 and data: 1×2 Array{Int64,2}
  4  6
 ```

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -1,7 +1,16 @@
 """
 Selectors are wrappers that indicate that passed values are not the array indices,
 but values to be selected from the dimension index, such as `DateTime` objects for
-a `Ti` dimension.
+a `Ti` dimension. 
+
+Selectors provided in DimensionalData are:
+
+- [`At`](@ref) 
+- [`Between`](@ref) 
+- [`Near`](@ref)
+- [`Where`](@ref)
+- [`Contains`](@ref)
+
 """
 abstract type Selector{T} end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -128,13 +128,14 @@ function reorderrelation end
 
 
 for target in (:index, :array, :relation)
-    local order = Symbol(target, :order)
     reorder = Symbol(:reorder, target)
-    reverse = if target == :relation 
+    if target == :relation 
         # Revsersing the relation reverses the array, not the index
-        :reversearray
+        reverse = :reversearray
+        ord = relation
     else
-        Symbol(:reverse, target)
+        reverse = Symbol(:reverse, target)
+        ord = Symbol(target, :order)
     end
     @eval begin
 
@@ -154,7 +155,7 @@ for target in (:index, :array, :relation)
             A
         end
         ($reorder)(A::AbstractDimArray, dim::DimOrDimType, order::Order) =
-            if order == ($order)(dims(A, dim))
+            if order == ($ord)(dims(A, dim))
                 A
             else
                 ($reverse)(A; dims=dim)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,16 +1,57 @@
+"""
+    reversearray(A; dims) => AbstractDimArray
+    reversearray(dim::Dimension) => Dimension
+
+Reverse the array order, and update the dim to match.
+"""
+function reversearray end
+
+"""
+    reverseindex(A; dims) => AbstractDimArray
+    reverseindex(dim::Dimension) => Dimension
+
+Reverse the dimension index.
+"""
+function reverseindex end
+
+"""
+    fliparray(A; dims) => AbstractDimArray
+    fliparray(dim::Dimension) => Dimension
+
+`Flip` the array order without changing any data.
+"""
+function fliparray end
+
+"""
+    flipindex(A; dims) => AbstractDimArray
+    flipindex(dim::Dimension) => Dimension
+
+`Flip` the index order without changing any data.
+"""
+function flipindex end
+
+"""
+    fliprelation(A; dims) => AbstractDimArray
+    fliprelation(dim::Dimension) => Dimension
+
+`Flip` the relation between the dimension order and the array axis,
+without actually changing any data.
+"""
+function fliprelation end
 
 for func in (:reversearray, :reverseindex, :fliparray, :flipindex, :fliprelation)
     if func != :reversearray
         @eval begin
-            ($func)(A::AbstractDimArray{T,N}; dims=1) where {T,N} = begin
+            ($func)(A::AbstractDimArray{T,N}; dims) where {T,N} = begin
                 dnum = dimnum(A, dims)
                 # Reverse the dimension. TODO: make this type stable
                 newdims = $func(DimensionalData.dims(A), dnum)
-                rebuild(A, data(A), newdims)
+                rebuild(A, parent(A), newdims)
             end
         end
     end
     @eval begin
+        # TODO rewrite this it's awful and not type-stable
         @inline ($func)(dimstorev::Tuple, dnum) = begin
             dim = if length(dimstorev) == dnum
                 ($func)(dimstorev[end])
@@ -29,7 +70,7 @@ reversearray(A::AbstractDimArray{T,N}; dims=1) where {T,N} = begin
     # Reverse the dimension. TODO: make this type stable
     newdims = reversearray(DimensionalData.dims(A), dnum)
     # Reverse the data
-    newdata = reverse(data(A); dims=dnum)
+    newdata = reverse(parent(A); dims=dnum)
     rebuild(A, newdata, newdims)
 end
 @inline reversearray(dim::Dimension) =
@@ -53,8 +94,8 @@ end
 """
     reorderindex(A, order::Union{Order,Dimension{<:Order},Tuple})
 
-Reorder index to `order`, or reorder index for the the given 
-dimension(s) to the `Order` they wrap.
+Reorder every dims index to `order`, or reorder index for 
+the the given dimension(s) to the `Order` they wrap.
 
 `order` can be an [`Order`](@ref), a single [`Dimension`](@ref) 
 or a `Tuple` of `Dimension`.
@@ -64,8 +105,8 @@ function reorderindex end
 """
     reorderarray(A, order::Union{Order,Dimension{<:Order},Tuple})
 
-Reorder array to `order`, or reorder array for the the given 
-dimension(s) to the `Order` they wrap.
+Reorder the array to `order` for every axis, or reorder array 
+for the the given dimension(s) to the `Order` they wrap.
 
 `order` can be an [`Order`](@ref), a single [`Dimension`](@ref) 
 or a `Tuple` of `Dimension`.
@@ -75,8 +116,10 @@ function reorderarray end
 """
     reorderrelation(A, order::Union{Order,Dimension{<:Order},Tuple})
 
-Reorder relation to `order`, or reorder relation for the the given 
-dimension(s) to the `Order` they wrap.
+Reorder relation to `order` for every dimension, or reorder relation 
+for the the given dimension(s) to the `Order` they wrap.
+
+This will reverse the array, not the dimension index.
 
 `order` can be an [`Order`](@ref), a single [`Dimension`](@ref) 
 or a `Tuple` of `Dimension`.
@@ -122,28 +165,27 @@ end
 
 
 """
-    modify(f, A::AbstractDimArray)
+    modify(f, A::AbstractDimArray) => AbstractDimArray
 
-Modify the parent data, rebuilding the `AbstractDimArray` wrapper.
-`f` must return a `AbstractArray` of the same size as the original.
+Modify the parent data, rebuilding the `AbstractDimArray` wrapper without
+change. `f` must return a `AbstractArray` of the same size as the original.
 """
 modify(f, A::AbstractDimArray) = begin
-    newdata = f(data(A))
+    newdata = f(parent(A))
     size(newdata) == size(A) || error("$f returns an array with a different size")
     rebuild(A, newdata)
 end
 
 
 """
-    dimwise!(f, A::AbstractDimArray, B::AbstractDimArray)
+    dimwise(f, A::AbstractDimArray{T,N}, B::AbstractDimArray{T2,M) => AbstractDimArray{T3,N}
 
-Dimension-wise application of function `f`. 
+Dimension-wise application of function `f` to `A` and `B`. 
 
 ## Arguments
 
 -`a`: `AbstractDimArray` to broacast from, along dimensions not in `b`.
--`b`: `AbstractDimArray` to broadcast from all diensions. 
-  Dimensions must be a subset of a.
+-`b`: `AbstractDimArray` to broadcast from all diensions. Dimensions must be a subset of a.
 
 This is like broadcasting over every slice of `A` if it is 
 sliced by the dimensions of `B`, and storing the value in `dest`.
@@ -152,7 +194,7 @@ dimwise(f, A::AbstractDimArray, B::AbstractDimArray) =
     dimwise!(f, similar(A, promote_type(eltype(A), eltype(B))), A, B)
 
 """
-    dimwise!(f, dest::AbstractDimArray, A::AbstractDimArray, B::AbstractDimArray)
+    dimwise!(f, dest::AbstractDimArray{T1,N}, A::AbstractDimArray{T2,N}, B::AbstractDimArray) => dest
 
 Dimension-wise application of function `f`. 
 
@@ -160,8 +202,7 @@ Dimension-wise application of function `f`.
 
 -`dest`: `AbstractDimArray` to update
 -`a`: `AbstractDimArray` to broacast from, along dimensions not in `b`.
--`b`: `AbstractDimArray` to broadcast from all diensions. 
-  Dimensions must be a subset of a.
+-`b`: `AbstractDimArray` to broadcast from all diensions. Dimensions must be a subset of a.
 
 This is like broadcasting over every slice of `A` if it is 
 sliced by the dimensions of `B`, and storing the value in `dest`.
@@ -195,14 +236,14 @@ dimwise_generators(dims::Tuple) = begin
 end
 
 """
-    basetypeof(x)
+    basetypeof(x) => Type
 
-Get the base type of an object - the minimum required to
+Get the "base" type of an object - the minimum required to
 define the object without it's fields. By default this is the full
 `UnionAll` for the type. But custom `basetypeof` methods can be
 defined for types with free type parameters.
 
-In DimensionalData this is primariliy used for comparing dimensions,
+In DimensionalData this is primariliy used for comparing `Dimension`s,
 where `Dim{:x}` is different from `Dim{:y}`.
 """
 basetypeof(x) = basetypeof(typeof(x))

--- a/test/array.jl
+++ b/test/array.jl
@@ -232,23 +232,6 @@ end
     @test ac == a2
 end
 
-@testset "copy" begin
-    rebuild(da2, copy(data(da2)))
-
-    dac = copy(da2)
-    @test dac == da2
-    @test dims(dac) == dims(da2)
-    @test refdims(dac) == refdims(da2) == (Ti(1:1),)
-    @test name(dac) == name(da2) == "test2"
-    @test metadata(dac) == metadata(da2)
-    dadc = deepcopy(da2)
-    @test dadc == da2
-    @test dims(dadc) == dims(da2)
-    @test refdims(dadc) == refdims(da2) == (Ti(1:1),)
-    @test name(dadc) == name(da2) == "test2"
-    @test metadata(dadc) == metadata(da2)
-end
-
 if VERSION > v"1.1-"
     dimz = (X(LinRange(143.0, 145.0, 3); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "X")),
             Y(LinRange(-38.0, -36.0, 4); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "Y")))
@@ -273,3 +256,11 @@ end
     @test_throws DimensionMismatch DimArray(1:5, (X(1:5), Y(1:2)))
 end
 
+
+@testset "fill constructor" begin
+    da = fill(5.0, (X(4), Y(40.0:10.0:80.0)))
+    @test da == fill(5.0, (4, 5))
+    @test dims(da) == 
+        (X(Base.OneTo(4), NoIndex(), nothing), 
+         Y(40.0:10.0:80.0, Sampled(Ordered(), Regular(10.0), Points()), nothing))
+end

--- a/test/array.jl
+++ b/test/array.jl
@@ -134,8 +134,14 @@ da2 = DimArray(a2, dimz2, "test2"; refdims=refdimz)
 @testset "arbitrary dimension names also work for indexing" begin
     @test da2[Dim{:row}(2)] == [3, 4, 5, 6]
     @test da2[Dim{:column}(4)] == [4, 6, 7]
+    @test da2[column=4] == [4, 6, 7]
     @test da2[Dim{:column}(1), Dim{:row}(3)] == 4
+    @test da2[column=1, Dim{:row}(3)] == 4
+    @test da2[Dim{:column}(1), row=3] == 4
+    @test da2[column=1, row=3] == 4
     @inferred getindex(da2, Dim{:column}(1), Dim{:row}(3))
+    # We can also construct without using `Dim{X}`
+    @test dims(DimArray(a2, (:a, :b))) == dims(DimArray(a2, (Dim{:a}, Dim{:b})))
 end
 
 @testset "size and axes" begin
@@ -264,6 +270,6 @@ end
 @testset "constructor" begin
     da = DimArray(rand(5, 4), (X, Y))
     @test_throws DimensionMismatch DimArray(1:5, X(1:6))
-    @test_throws MethodError DimArray(1:5, (X(1:5), Y(1:2)))
+    @test_throws DimensionMismatch DimArray(1:5, (X(1:5), Y(1:2)))
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -38,7 +38,7 @@ end
     a = da[X(1), Y(1:2)]
     @test a == [1, 2]
     @test typeof(a) <: DimArray{Int,1}
-    @test typeof(data(a)) <: Array{Int,1}
+    @test typeof(parent(a)) <: Array{Int,1}
     @test dims(a) == 
         (Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), Dict(:meta => "Y")),)
     @test refdims(a) == 
@@ -51,7 +51,7 @@ end
     a = da[X(:), Y(:)]
     @test a == [1 2; 3 4]
     @test typeof(a) <: DimArray{Int,2}
-    @test typeof(data(a)) <: Array{Int,2}
+    @test typeof(parent(a)) <: Array{Int,2}
     @test typeof(dims(a)) <: Tuple{<:X,<:Y}
     @test dims(a) == (X(LinRange(143.0, 145.0, 2),
                         Sampled(Ordered(), Regular(2.0), Points()), Dict(:meta => "X")),
@@ -67,7 +67,7 @@ end
     v = @inferred view(da, Y(1), X(1))
     @test v[] == 1
     @test typeof(v) <: DimArray{Int,0}
-    @test typeof(data(v)) <:SubArray{Int,0}
+    @test typeof(parent(v)) <:SubArray{Int,0}
     @test typeof(dims(v)) == Tuple{}
     @test dims(v) == ()
     @test refdims(v) == 
@@ -80,7 +80,7 @@ end
     v = @inferred view(da, Y(1), X(1:2))
     @test v == [1, 3]
     @test typeof(v) <: DimArray{Int,1}
-    @test typeof(data(v)) <: SubArray{Int,1}
+    @test typeof(parent(v)) <: SubArray{Int,1}
     @test typeof(dims(v)) <: Tuple{<:X}
     @test dims(v) == 
         (X(LinRange(143.0, 145.0, 2), 
@@ -94,7 +94,7 @@ end
     v = @inferred view(da, Y(1:2), X(1:1))
     @test v == [1 2]
     @test typeof(v) <: DimArray{Int,2}
-    @test typeof(data(v)) <: SubArray{Int,2}
+    @test typeof(parent(v)) <: SubArray{Int,2}
     @test typeof(dims(v)) <: Tuple{<:X,<:Y}
     @test dims(v) == 
         (X(LinRange(143.0, 143.0, 1),
@@ -105,7 +105,7 @@ end
 
     v = @inferred view(da, Y(Base.OneTo(2)), X(1))
     @test v == [1, 2]
-    @test typeof(data(v)) <: SubArray{Int,1}
+    @test typeof(parent(v)) <: SubArray{Int,1}
     @test typeof(dims(v)) <: Tuple{<:Y}
     @test dims(v) == 
         (Y(LinRange(-38.0, -36.0, 2),
@@ -139,6 +139,12 @@ da2 = DimArray(a2, dimz2, "test2"; refdims=refdimz)
     @test da2[column=1, Dim{:row}(3)] == 4
     @test da2[Dim{:column}(1), row=3] == 4
     @test da2[column=1, row=3] == 4
+    @test view(da2, column=1, row=3) == fill(4)
+    @test view(da2, column=1, Dim{:row}(1)) == fill(1)
+    da2_set = deepcopy(da2)
+    da2_set[column=1, Dim{:row}(1)] = 99
+    @test da2_set[1, 1] == 99
+
     @inferred getindex(da2, Dim{:column}(1), Dim{:row}(3))
     # We can also construct without using `Dim{X}`
     @test dims(DimArray(a2, (:a, :b))) == dims(DimArray(a2, (Dim{:a}, Dim{:b})))
@@ -150,6 +156,35 @@ end
     @test axes(da2, Dim{:row}()) == 1:3
     @test axes(da2, Dim{:column}) == 1:4
     @inferred axes(da2, Dim{:column})
+end
+
+@testset "copy and friends" begin
+    rebuild(da2, copy(parent(da2)))
+
+    dac = copy(da2)
+    @test dac == da2
+    @test dims(dac) == dims(da2)
+    @test refdims(dac) == refdims(da2) == (Ti(1:1),)
+    @test name(dac) == name(da2) == "test2"
+    @test metadata(dac) == metadata(da2)
+    dadc = deepcopy(da2)
+    @test dadc == da2
+    @test dims(dadc) == dims(da2)
+    @test refdims(dadc) == refdims(da2) == (Ti(1:1),)
+    @test name(dadc) == name(da2) == "test2"
+    @test metadata(dadc) == metadata(da2)
+
+    o = one(da)
+    @test o == [1 0; 0 1]
+    @test dims(o) == dims(da) 
+
+    ou = oneunit(da)
+    @test ou == [1 0; 0 1]
+    @test dims(ou) == dims(da) 
+
+    z = zero(da)
+    @test z == [0 0; 0 0]
+    @test dims(z) == dims(da) 
 end
 
 @testset "OffsetArray" begin
@@ -220,10 +255,10 @@ end
 @testset "eachindex" begin
     # Should have linear index
     da = DimArray(ones(5, 2, 4), (Y(10:2:18), Ti(10:11), X(1:4)))
-    @test eachindex(da) == eachindex(data(da))
+    @test eachindex(da) == eachindex(parent(da))
     # Should have cartesian index
     sda = DimArray(sprand(10, 10, .1), (Y(1:10), X(1:10)))
-    @test eachindex(sda) == eachindex(data(sda))
+    @test eachindex(sda) == eachindex(parent(sda))
 end
 
 @testset "convert" begin

--- a/test/array.jl
+++ b/test/array.jl
@@ -160,11 +160,14 @@ da2 = DimArray(a2, dimz2, "test2"; refdims=refdimz)
     @inferred view(da2, column=1, row=3)
     @inferred setindex!(da2_set, 77, Dim{:row}(1), column=2)
     # With a large type
-    da4 = DimArray(zeros(1, 2, 3, 4, 5, 6, 7, 8), (:a, :b, :c, :d, :d, :f, :g, :h))
-    @inferred getindex(da2, a=1, b=2, c=3, d=4, e=5)
-    # Type inference breaks with 6 arguments.
-    # @inferred getindex(da2, a=1, b=2, c=3, d=4, e=5, f=6)
-    # @code_warntype getindex(da2, a=1, b=2, c=3, d=4, e=5, f=6)
+
+    if VERSION >= v"1.5"
+        da4 = DimArray(zeros(1, 2, 3, 4, 5, 6, 7, 8), (:a, :b, :c, :d, :d, :f, :g, :h))
+        @inferred getindex(da2, a=1, b=2, c=3, d=4, e=5)
+        # Type inference breaks with 6 arguments.
+        # @inferred getindex(da2, a=1, b=2, c=3, d=4, e=5, f=6)
+        # @code_warntype getindex(da2, a=1, b=2, c=3, d=4, e=5, f=6)
+    end
 end
 
 @testset "size and axes" begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -14,7 +14,7 @@ using DimensionalData, Test
     end
 
     @testset "in place" begin
-        @test data(da .= 1 .* da .+ 7) == 8 * ones(3)
+        @test parent(da .= 1 .* da .+ 7) == 8 * ones(3)
         @test dims(da .= 1 .* da .+ 7) == dims(da)
     end
 
@@ -61,8 +61,8 @@ using DimensionalData, Test
         a = DimArray(reshape(1:12, (4, 3)), (X, Y))
         b = DimArray(1:3, Y)
         @test_throws DimensionMismatch a .* b
-        @test_throws DimensionMismatch data(a) .* data(b)
-        @test data(a) .* data(b)' == data(a .* b')
+        @test_throws DimensionMismatch parent(a) .* parent(b)
+        @test parent(a) .* parent(b)' == parent(a .* b')
         @test dims(a .* b') == dims(a)
     end
 

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful
-using DimensionalData: Forward, slicedims, basetypeof
+using DimensionalData: Forward, slicedims, basetypeof, formatdims
 
 @dim TestDim "Test dimension"
 
@@ -33,22 +33,40 @@ using DimensionalData: Forward, slicedims, basetypeof
     @test iterate(TestDim(10:20)) == iterate(10:20)
 end
 
-# Basic dim and array initialisation
-a = ones(5, 4)
-# Must construct with a tuple for dims/refdims
+@testset "formatdims" begin
+    A = [1 2 3; 4 5 6]
+    @test formatdims(A, (X, Y)) == (X(Base.OneTo(2), NoIndex(), nothing),
+                                    Y(Base.OneTo(3), NoIndex(), nothing))
+    @test formatdims(zeros(3), Ti) == (Ti(Base.OneTo(3), NoIndex(), nothing),)
+    @test formatdims(A, (:a, :b)) == (Dim{:a}(Base.OneTo(2), NoIndex(), nothing),
+                                      Dim{:b}(Base.OneTo(3), NoIndex(), nothing))
+    @test formatdims(51:100, :c) == (Dim{:c}(Base.OneTo(50), NoIndex(), nothing),)
+    @test formatdims(A, (a=[:A, :B], b=(10.0:10.0:30.0))) == 
+        (Dim{:a}([:A, :B], Categorical(Unordered()), nothing), 
+         Dim{:b}(10.0:10:30.0, Sampled(Ordered(), Regular(10.0), Points()), nothing))
+    @test formatdims(A, (X([:A, :B]; metadata=5), 
+                   Y(10.0:10.0:30.0, Categorical(Ordered()), Dict("metadata"=>1)))) == 
+          (X([:A, :B], Categorical(Unordered()), 5), 
+          Y(10.0:10:30.0, Categorical(Ordered()), Dict("metadata"=>1)))
+end
 
-@test_throws MethodError DimArray(a, X((140, 148)))
-@test_throws MethodError DimArray(a, (X((140, 148)), Y((2, 11))), Z(1))
-da = DimArray(a, (X((140, 148)), Y((2, 11))))
+@testset "Basic dim and array initialisation" begin
+    a = ones(5, 4)
+    # Must construct with a tuple for dims/refdims
 
-dimz = dims(da)
-@test d = typeof(slicedims(dimz, (2:4, 3))) == 
-    typeof(((X(LinRange(142,146,3); mode=Sampled(order=Ordered(), span=Regular(2.0))),),
-        (Y(8.0, mode=Sampled(order=Ordered(), span=Regular(3.0))),)))
-@test name(dimz) == ("X", "Y")
-@test shortname(dimz) == ("X", "Y")
-@test units(dimz) == (nothing, nothing)
-@test label(dimz) == ("X, Y")
+    @test_throws DimensionMismatch DimArray(a, X)
+    @test_throws DimensionMismatch DimArray(a, (X, Y, Z))
+
+    da = DimArray(a, (X((140, 148)), Y((2, 11))))
+    dimz = dims(da)
+    @test d = typeof(slicedims(dimz, (2:4, 3))) == 
+        typeof(((X(LinRange(142,146,3); mode=Sampled(order=Ordered(), span=Regular(2.0))),),
+            (Y(8.0, mode=Sampled(order=Ordered(), span=Regular(3.0))),)))
+    @test name(dimz) == ("X", "Y")
+    @test shortname(dimz) == ("X", "Y")
+    @test units(dimz) == (nothing, nothing)
+    @test label(dimz) == ("X, Y")
+end
 
 a = [1 2 3 4
      2 3 4 5
@@ -68,9 +86,9 @@ end
 
 @testset "arbitrary dim names" begin
     dimz = (Dim{:row}((10, 30)), Dim{:column}((-20, 10)))
-    @test name(dimz) == ("Dim row", "Dim column")
+    @test name(dimz) == ("Dim{:row}", "Dim{:column}")
     @test shortname(dimz) == ("row", "column")
-    @test label(dimz) == ("Dim row, Dim column")
+    @test label(dimz) == ("Dim{:row}, Dim{:column}")
     @test basetypeof(dimz[1]) == Dim{:row}
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -12,6 +12,36 @@ using DimensionalData: Forward, Reverse, Rot90, Rot180, Rot270, Rot360, rotdims,
     @test map(x -> 2x, da) isa DimArray{Int64,2}
 end
 
+@testset "copy and friends" begin
+    rebuild(da2, copy(data(da2)))
+
+    dac = copy(da2)
+    @test dac == da2
+    @test dims(dac) == dims(da2)
+    @test refdims(dac) == refdims(da2) == (Ti(1:1),)
+    @test name(dac) == name(da2) == "test2"
+    @test metadata(dac) == metadata(da2)
+    dadc = deepcopy(da2)
+    @test dadc == da2
+    @test dims(dadc) == dims(da2)
+    @test refdims(dadc) == refdims(da2) == (Ti(1:1),)
+    @test name(dadc) == name(da2) == "test2"
+    @test metadata(dadc) == metadata(da2)
+
+    o = one(da)
+    @test o == [1 0; 0 1]
+    @test dims(o) == dims(da) 
+
+    ou = oneunit(da)
+    @test ou == [1 0; 0 1]
+    @test dims(ou) == dims(da) 
+
+    da1 = DimArray(zeros(5), :a)
+    e = empty!(da1)
+    @test e == [1 0; 0 1]
+    @test dims(ou) == dims(da) 
+end
+
 @testset "dimension reducing methods" begin
     a = [1 2; 3 4]
     dimz = X((143, 145); mode=Sampled()), Y((-38, -36); mode=Sampled())

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -8,7 +8,7 @@ using DimensionalData: Forward, Reverse, Rot90, Rot180, Rot270, Rot360, rotdims,
     a = [1 2; 3 4]
     dimz = (X((143, 145)), Y((-38, -36)))
     da = DimArray(a, dimz)
-    @test map(x -> 2x, da) == [2 4; 6 8]
+    @test @inferred map(x -> 2x, da) == [2 4; 6 8]
     @test map(x -> 2x, da) isa DimArray{Int64,2}
 end
 
@@ -16,55 +16,66 @@ end
     a = [1 2; 3 4]
     dimz = X((143, 145); mode=Sampled()), Y((-38, -36); mode=Sampled())
     da = DimArray(a, dimz)
-    @test sum(da; dims=X()) == sum(a; dims=1)
-    @test sum(da; dims=Y()) == sum(a; dims=2)
+
+    @test @inferred sum(da; dims=X()) == sum(a; dims=1)
+    @test @inferred sum(da; dims=Y()) == sum(a; dims=2)
     @test dims(sum(da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
          Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
-    @test prod(da; dims=X) == [3 8]
-    @test prod(da; dims=2) == [2 12]'
+
+    @test @inferred prod(da; dims=X) == [3 8]
+    @test @inferred prod(da; dims=2) == [2 12]'
     resultdimz =
         (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), nothing),
          Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing))
     @test typeof(dims(prod(da; dims=X()))) == typeof(resultdimz)
-    @test bounds(dims(prod(da; dims=X()))) == bounds(resultdimz)
-    @test maximum(x -> 2x, da; dims=X) == [6 8]
-    @test maximum(x -> 2x, da; dims=2) == [4 8]'
-    @test maximum(da; dims=X) == [3 4]
-    @test maximum(da; dims=2) == [2 4]'
-    @test minimum(da; dims=1) == [1 2]
-    @test minimum(da; dims=Y()) == [1 3]'
+    @test @inferred bounds(dims(prod(da; dims=X()))) == bounds(resultdimz)
+
+    @test @inferred maximum(x -> 2x, da; dims=X) == [6 8]
+    @test @inferred maximum(x -> 2x, da; dims=2) == [4 8]'
+    @test @inferred maximum(da; dims=X) == [3 4]
+    @test @inferred maximum(da; dims=2) == [2 4]'
+
+    @test @inferred minimum(da; dims=1) == [1 2]
+    @test @inferred minimum(da; dims=Y()) == [1 3]'
     @test dims(minimum(da; dims=X())) ==
         (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), nothing),
          Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing))
+
     @test mean(da; dims=1) == [2.0 3.0]
     @test mean(da; dims=Y()) == [1.5 3.5]'
     @test dims(mean(da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
          Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+
     @test mapreduce(x -> x > 3, +, da; dims=X) == [0 1]
     @test mapreduce(x -> x > 3, +, da; dims=2) == [0 1]'
     @test dims(mapreduce(x-> x > 3, +, da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
          Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+
     @test reduce(+, da) == reduce(+, a)
     @test reduce(+, da; dims=X) == [4 6]
     @test reduce(+, da; dims=Y()) == [3 7]'
     @test dims(reduce(+, da; dims=Y())) ==
         (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
          Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+
     @test std(da) === std(a)
     @test std(da; dims=1) == [1.4142135623730951 1.4142135623730951]
     @test std(da; dims=Y()) == [0.7071067811865476 0.7071067811865476]'
+
     @test var(da; dims=1) == [2.0 2.0]
     @test var(da; dims=Y()) == [0.5 0.5]'
+    @test dims(var(da; dims=Y())) ==
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+
     if VERSION > v"1.1-"
         @test extrema(da; dims=Y) == permutedims([(1, 2) (3, 4)])
         @test extrema(da; dims=X) == [(1, 3) (2, 4)]
     end
-    @test dims(var(da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+
     a = [1 2 3; 4 5 6]
     da = DimArray(a, dimz)
     @test median(da) == 3.5
@@ -88,20 +99,20 @@ end
 end
 
 if VERSION > v"1.1-"
-    @testset "iteration methods" begin
+    @testset "eachslice" begin
         a = [1 2 3 4
              3 4 5 6
              5 6 7 8]
-        # eachslice
         da = DimArray(a, (Y((10, 30)), Ti(1:4)))
         @test [mean(s) for s in eachslice(da; dims=Ti)] == [3.0, 4.0, 5.0, 6.0]
         @test [mean(s) for s in eachslice(da; dims=2)] == [3.0, 4.0, 5.0, 6.0]
+
         slices = [s .* 2 for s in eachslice(da; dims=Y)]
-        @test map(sin, da) == map(sin, a)
         @test slices[1] == [2, 4, 6, 8]
         @test slices[2] == [6, 8, 10, 12]
         @test slices[3] == [10, 12, 14, 16]
         dims(slices[1]) == (Ti(1.0:1.0:4.0),)
+
         slices = [s .* 2 for s in eachslice(da; dims=Ti)]
         @test slices[1] == [2, 6, 10]
         dims(slices[1]) == (Y(10.0:10.0:30.0),)
@@ -144,7 +155,6 @@ end
                                           Ti(10:11; mode=Sampled()), 
                                           X(1:4; mode=Sampled())))
     dsp = permutedims(da, [3, 1, 2])
-
     @test permutedims(da, [X, Y, Ti]) == permutedims(da, (X, Y, Ti))
     @test permutedims(da, [X(), Y(), Ti()]) == permutedims(da, (X(), Y(), Ti()))
     dsp = permutedims(da, (X(), Y(), Ti()))
@@ -152,6 +162,7 @@ end
     @test dims(dsp) == (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                         Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())),
                         Ti(10:11; mode=Sampled(Ordered(), Regular(1), Points())))
+
     dsp = PermutedDimsArray(da, (3, 1, 2))
     @test dsp == PermutedDimsArray(parent(da), (3, 1, 2))
     @test typeof(dsp) <: DimArray
@@ -255,6 +266,7 @@ end
     da = DimArray(a, (X(1:2), Y(1:3)))
     b = [7 8 9; 10 11 12]
     db = DimArray(b, (X(3:4), Y(1:3)))
+
     @test cat(da, db; dims=X()) == [1 2 3; 4 5 6; 7 8 9; 10 11 12]
     testdims = (X([1, 2, 3, 4]; mode=Sampled(Ordered(), Regular(1), Points())),
                 Y(1:3; mode=Sampled(Ordered(), Regular(1), Points())))
@@ -277,9 +289,3 @@ end
     @test unique(da; dims=X()) == [1 1 6]
     @test unique(da; dims=Y) == [1 6; 1 6]
 end
-
-# These need fixes in base. kwargs are ::Integer so we can't add methods
-# or dispatch on AbstractDimension in underscore _methods
-# accumulate
-# cumsum
-# cumprod

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -12,36 +12,6 @@ using DimensionalData: Forward, Reverse, Rot90, Rot180, Rot270, Rot360, rotdims,
     @test map(x -> 2x, da) isa DimArray{Int64,2}
 end
 
-@testset "copy and friends" begin
-    rebuild(da2, copy(data(da2)))
-
-    dac = copy(da2)
-    @test dac == da2
-    @test dims(dac) == dims(da2)
-    @test refdims(dac) == refdims(da2) == (Ti(1:1),)
-    @test name(dac) == name(da2) == "test2"
-    @test metadata(dac) == metadata(da2)
-    dadc = deepcopy(da2)
-    @test dadc == da2
-    @test dims(dadc) == dims(da2)
-    @test refdims(dadc) == refdims(da2) == (Ti(1:1),)
-    @test name(dadc) == name(da2) == "test2"
-    @test metadata(dadc) == metadata(da2)
-
-    o = one(da)
-    @test o == [1 0; 0 1]
-    @test dims(o) == dims(da) 
-
-    ou = oneunit(da)
-    @test ou == [1 0; 0 1]
-    @test dims(ou) == dims(da) 
-
-    da1 = DimArray(zeros(5), :a)
-    e = empty!(da1)
-    @test e == [1 0; 0 1]
-    @test dims(ou) == dims(da) 
-end
-
 @testset "dimension reducing methods" begin
     a = [1 2; 3 4]
     dimz = X((143, 145); mode=Sampled()), Y((-38, -36); mode=Sampled())
@@ -143,7 +113,7 @@ end
     da = DimArray(zeros(5, 4), (Y((10, 20); mode=Sampled()), 
                                         X(1:4; mode=Sampled())))
     tda = transpose(da)
-    @test tda == transpose(data(da))
+    @test tda == transpose(parent(da))
     resultdims = (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                   Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())))
     @test typeof(dims(tda)) == typeof(resultdims) 
@@ -151,20 +121,20 @@ end
     @test size(tda) == (4, 5)
 
     tda = Transpose(da)
-    @test tda == Transpose(data(da))
+    @test tda == Transpose(parent(da))
     @test dims(tda) == (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                         Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())))
     @test size(tda) == (4, 5)
     @test typeof(tda) <: DimArray
 
     ada = adjoint(da)
-    @test ada == adjoint(data(da))
+    @test ada == adjoint(parent(da))
     @test dims(ada) == (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                         Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())))
     @test size(ada) == (4, 5)
 
     dsp = permutedims(da)
-    @test permutedims(data(da)) == data(dsp)
+    @test permutedims(parent(da)) == parent(dsp)
     @test dims(dsp) == reverse(dims(da))
 end
 
@@ -178,12 +148,12 @@ end
     @test permutedims(da, [X, Y, Ti]) == permutedims(da, (X, Y, Ti))
     @test permutedims(da, [X(), Y(), Ti()]) == permutedims(da, (X(), Y(), Ti()))
     dsp = permutedims(da, (X(), Y(), Ti()))
-    @test dsp == permutedims(data(da), (3, 1, 2))
+    @test dsp == permutedims(parent(da), (3, 1, 2))
     @test dims(dsp) == (X(1:4; mode=Sampled(Ordered(), Regular(1), Points())),
                         Y(LinRange(10.0, 20.0, 5); mode=Sampled(Ordered(), Regular(2.5), Points())),
                         Ti(10:11; mode=Sampled(Ordered(), Regular(1), Points())))
     dsp = PermutedDimsArray(da, (3, 1, 2))
-    @test dsp == PermutedDimsArray(data(da), (3, 1, 2))
+    @test dsp == PermutedDimsArray(parent(da), (3, 1, 2))
     @test typeof(dsp) <: DimArray
 end
 
@@ -265,7 +235,7 @@ end
             Ti(1:4; mode=Sampled(Ordered(), Regular(1), Intervals(Start())))))
     @test refdims(ms) == ()
     ms = mapslices(sum, da; dims=Ti)
-    @test data(ms) == [10 18 26]'
+    @test parent(ms) == [10 18 26]'
 end
 
 @testset "array info" begin

--- a/test/mode.jl
+++ b/test/mode.jl
@@ -1,7 +1,7 @@
 using DimensionalData, Test, Unitful
 using DimensionalData: Forward, Reverse,
       reversearray, reverseindex, slicebounds, slicemode, identify,
-      indexorder, arrayorder, relationorder
+      indexorder, arrayorder, relation
 
 @testset "identify IndexMode" begin
    @testset "identify Categorical from Auto" begin
@@ -34,6 +34,7 @@ using DimensionalData: Forward, Reverse,
             @test identify(Auto(), X, 10:-2:1) ==
                 Sampled(Ordered(Reverse(), Forward(), Forward()), Regular(-2), Points())
         end
+
     end
 
     @testset "identify Sampled" begin
@@ -68,10 +69,10 @@ end
 @testset "order" begin
     @test indexorder(Ordered()) == Forward()
     @test arrayorder(Ordered()) == Forward()
-    @test relationorder(Ordered()) == Forward()
+    @test relation(Ordered()) == Forward()
     @test indexorder(Unordered()) == Unordered()
     @test arrayorder(Unordered()) == Unordered()
-    @test relationorder(Unordered()) == Forward()
+    @test relation(Unordered()) == Forward()
 end
 
 @testset "reverse" begin
@@ -205,7 +206,7 @@ end
         last(dim), first(dim)
         @test bounds(dim) == (10, 15)
         dim = X(index; mode=Sampled(order=Unordered(), sampling=Points()))
-        @test_throws ErrorException bounds(dim)
+        @test bounds(dim) == (nothing, nothing)
     end
 
     @testset "Categorical" begin
@@ -215,7 +216,7 @@ end
         dim = X(index; mode=Categorical(; order=Ordered(;index=Reverse())))
         @test bounds(dim) == (:d, :a)
         dim = X(index; mode=Categorical(; order=Unordered()))
-        @test_throws ErrorException bounds(dim)
+        @test bounds(dim) == (nothing, nothing)
     end
 
 end

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -44,7 +44,7 @@ histogram(da2)
 stephist(da2)
 barhist(da2)
 scatterhist(da2)
-histogram2d(data(da2))
+histogram2d(parent(da2))
 histogram2d(da2)
 hline(da2)
 vline(da2)
@@ -65,20 +65,20 @@ ea_histogram(da2)
 
 # TODO handle everything
 
-# These don't seem to work for plot(data(da2))
+# These don't seem to work for plot(parent(da2))
 # path3d(da2)
-# hexbin(data(da1))
+# hexbin(parent(da1))
 # plot(da2; seriestype=:histogram3d)
 
 # Crashes GR
-# groupedbar(data(da2))
+# groupedbar(parent(da2))
 
 # surface(da2)
 # plot(da2; seriestype=:bins2d)
 # plot(da2; seriestype=:volume)
 # plot(da2; seriestype=:stepbins)
-# plot(data(da2); seriestype=:barbins)
-# plot(data(da2); seriestype=:contour3d)
+# plot(parent(da2); seriestype=:barbins)
+# plot(parent(da2); seriestype=:contour3d)
 # pie(da2)
 #
 # Crashes GR for some reason

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -60,6 +60,8 @@ boxplot(da2)
 violin(da2)
 ea_histogram(da2)
 
+nothing
+
 # Not sure how recipes work for this
 # andrewsplot(da2)
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -65,10 +65,9 @@ end
 
 @testset "dims2indices" begin
     emptyval = Colon()
-    @test DimensionalData._dims2indices(mode(dimz[1]), dimz[1], Y, Nothing) == Colon()
+    @test DimensionalData._dims2indices(dimz[1], Y, Nothing) == Colon()
     @test dims2indices(dimz, (Y(),), emptyval) == (Colon(), Colon())
     @test dims2indices(dimz, (Y(1),), emptyval) == (Colon(), 1)
-    # Time is just ignored if it's not in dims. Should this be an error?
     @test dims2indices(dimz, (Ti(4), X(2))) == (2, Colon())
     @test dims2indices(dimz, (Y(2), X(3:7)), emptyval) == (3:7, 2)
     @test dims2indices(dimz, (X(2), Y([1, 3, 4])), emptyval) == (2, [1, 3, 4])

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -147,8 +147,7 @@ end
         @test dims(A) == 
             (Dim{:one}(Base.OneTo(4), NoIndex(), nothing), 
              Dim{:two}(Base.OneTo(5), NoIndex(), nothing))
-        @test dims(A, :two) == (Dim{:two}(),)
-             (Dim{:two}(Base.OneTo(5), NoIndex(), nothing),)
+        @test dims(A, :two) == Dim{:two}(Base.OneTo(5), NoIndex(), nothing)
     end
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -3,19 +3,19 @@ using DimensionalData, Test
 using DimensionalData: val, basetypeof, slicedims, dims2indices, mode,
       @dim, reducedims, XDim, YDim, ZDim, Forward, commondims
 
-dimz = (X(), Y())
+dimz = (X(), Y(), Z(), Ti())
 
 @testset "permutedims" begin
-    @test permutedims((Y(1:2), X(1)), dimz) == (X(1), Y(1:2))
-    @test permutedims((X(1),), dimz) == (X(1), nothing)
-    @test permutedims((Y(), X()), dimz) == (X(:), Y(:))
-    @test permutedims([Y(), X()], dimz) == (X(:), Y(:))
-    @test permutedims((Y, X),     dimz) == (X, Y)
-    @test permutedims([Y, X],     dimz) == (X, Y)
-    @test permutedims(dimz, (Y(), X())) == (Y(:), X(:))
-    @test permutedims(dimz, [Y(), X()]) == (Y(:), X(:))
-    @test permutedims(dimz, (Y, X)    ) == (Y(:), X(:))
-    @test permutedims(dimz, [Y, X]    ) == (Y(:), X(:))
+    @test @inferred permutedims((Y(1:2), X(1)), dimz) == (X(1), Y(1:2), nothing, nothing)
+    @test @inferred permutedims((Ti(1),), dimz) == (nothing, nothing, nothing, Ti(1))
+    @test @inferred permutedims((Y, X, Z, Ti), dimz) == (X(), Y(), Z(), Ti())
+    @test @inferred permutedims((Y(), X(), Z(), Ti()), dimz) == (X(), Y(), Z(), Ti())
+    @test @inferred permutedims([Y(), X(), Z(), Ti()], dimz) == (X(), Y(), Z(), Ti())
+    @test @inferred permutedims((Z(), Y(), X()),     dimz) == (X(), Y(), Z(), nothing)
+    @test @inferred permutedims(dimz, (Y(), Z())) == (Y(), Z())
+    @test @inferred permutedims(dimz, [Ti(), X(), Z()]) == (Ti(), X(), Z())
+    @test @inferred permutedims(dimz, (Y, Ti)    ) == (Y(), Ti())
+    @test @inferred permutedims(dimz, [Ti, Z, X, Y]    ) == (Ti(), Z(), X(), Y())
 end
 
 a = [1 2 3; 4 5 6]

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -354,10 +354,10 @@ end
         ]
         for idx in indices
             from2d = da[idx]
-            @test from2d == data(da)[idx]
+            @test from2d == parent(da)[idx]
             @test !(from2d isa AbstractDimArray)
-            from1d = da[Y <| At(10)][idx]
-            @test from1d == data(da)[1, :][idx]
+            from1d = da[Y(At(10))][idx]
+            @test from1d == parent(da)[1, :][idx]
             @test from1d isa AbstractDimArray
         end
     end
@@ -371,10 +371,10 @@ end
         ]
         for idx in indices
             from2d = view(da, idx)
-            @test from2d == view(data(da), idx)
+            @test from2d == view(parent(da), idx)
             @test from2d isa SubArray
             from1d = view(da[Y(At(10))], idx)
-            @test from1d == view(data(da)[1, :], idx)
+            @test from1d == view(parent(da)[1, :], idx)
             @test from1d isa AbstractDimArray
         end
     end
@@ -389,13 +389,13 @@ end
         for idx in indices
             # 2D case
             da2d = copy(da)
-            a2d = copy(data(da2d))
+            a2d = copy(parent(da2d))
             replacement = zero(a2d[idx])
             @test setindex!(da2d, replacement, idx) == setindex!(a2d, replacement, idx)
             @test da2d == a2d
             # 1D array
-            da1d = da[Y <| At(10)]
-            a1d = copy(data(da1d))
+            da1d = da[Y(At(10))]
+            a1d = copy(parent(da1d))
             @test setindex!(da1d, replacement, idx) == setindex!(a1d, replacement, idx)
             @test da1d == a1d
         end

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1,6 +1,6 @@
 using DimensionalData, Test, Unitful, Combinatorics
 using DimensionalData: Forward, Reverse, Ordered,
-      arrayorder, indexorder, relationorder, between, at, near, contains
+      arrayorder, indexorder, relation, between, at, near, contains
 
 a = [1 2  3  4
      5 6  7  8
@@ -13,209 +13,213 @@ A = DimArray([1 2 3; 4 5 6], dims_)
 
 @testset "selector primitives" begin
 
-    @testset "Regular Intervals IndexMode with range" begin
+    @testset "Regular Intervals with range" begin
         # Order: index, array, relation (array order is irrelevent here, it's just for plotting)
-        startfwdfwd = Ti(5.0:30.0;      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(Start())))
-        startfwdrev = Ti(5.0:30.0;      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(Start())))
-        startrevfwd = Ti(30.0:-1.0:5.0; mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(Start())))
-        startrevrev = Ti(30.0:-1.0:5.0; mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(Start())))
+        # Varnames: locusindexorderrelation
+
+        startfwdfwd = Ti(11.0:30.0;      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(Start())))
+        startfwdrev = Ti(11.0:30.0;      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(Start())))
+        startrevfwd = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(Start())))
+        startrevrev = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(Start())))
 
         @testset "Any at" begin
-            @test at(startfwdfwd, At(30)) == 26
+            @test at(startfwdfwd, At(30)) == 20
             @test at(startrevfwd, At(30)) == 1
             @test at(startfwdrev, At(30)) == 1
-            @test at(startrevrev, At(30)) == 26
+            @test at(startrevrev, At(30)) == 20
         end
 
         @testset "Start between" begin
-            @test between(startfwdfwd, Between(9.9, 15.1)) === 6:10
-            @test between(startfwdrev, Between(9.9, 15.1)) === 17:1:21
-            @test between(startrevfwd, Between(9.9, 15.1)) === 17:21
-            @test between(startrevrev, Between(9.9, 15.1)) === 6:1:10
-            @test between(startfwdfwd, Between(10, 15)) === 6:10
-            @test between(startfwdrev, Between(10, 15)) === 17:1:21
-            @test between(startrevfwd, Between(10, 15)) === 17:21
-            @test between(startrevrev, Between(10, 15)) === 6:1:10
+            @test between(startfwdfwd, Between(11, 14)) === 1:3
+            @test between(startfwdrev, Between(11, 14)) === 18:1:20
+            @test between(startrevfwd, Between(11, 14)) === 18:20
+            @test between(startrevrev, Between(11, 14)) === 1:1:3
+            @test between(startfwdfwd, Between(11.1, 13.9)) === 2:2
+            @test between(startfwdrev, Between(11.1, 13.9)) === 19:1:19
+            @test between(startrevfwd, Between(11.1, 13.9)) === 19:19
+            @test between(startrevrev, Between(11.1, 13.9)) === 2:1:2
             # Input order doesn't matter
-            @test between(startfwdfwd, Between(15, 10)) === 6:10
+            @test between(startfwdfwd, Between(14, 11)) === 1:3
         end
 
         @testset "Start contains" begin
-            @test_throws BoundsError contains(startfwdfwd, Contains(4.9))
+            @test_throws BoundsError contains(startfwdfwd, Contains(10.9))
             @test_throws BoundsError contains(startfwdfwd, Contains(31))
-            @test_throws BoundsError contains(startrevfwd, Contains(4.9))
+            @test_throws BoundsError contains(startrevfwd, Contains(10.9))
             @test_throws BoundsError contains(startrevfwd, Contains(31))
-            @test contains(startfwdfwd, Contains(5)) == 1
-            @test contains(startfwdfwd, Contains(5.9)) == 1
-            @test contains(startfwdfwd, Contains(6.0)) == 2
-            @test contains(startfwdfwd, Contains(30.0)) == 26
-            @test contains(startfwdfwd, Contains(29.9)) == 25
-            @test contains(startrevfwd, Contains(5.9)) == 26
-            @test contains(startrevfwd, Contains(6.0)) == 25
+            @test contains(startfwdfwd, Contains(11)) == 1
+            @test contains(startfwdfwd, Contains(11.9)) == 1
+            @test contains(startfwdfwd, Contains(12.0)) == 2
+            @test contains(startfwdfwd, Contains(30.0)) == 20
+            @test contains(startfwdfwd, Contains(29.9)) == 19
+            @test contains(startrevfwd, Contains(11.9)) == 20
+            @test contains(startrevfwd, Contains(12.0)) == 19
             @test contains(startrevfwd, Contains(30.9)) == 1
             @test contains(startrevfwd, Contains(30.0)) == 1
             @test contains(startrevfwd, Contains(29.0)) == 2
-            @test contains(startfwdrev, Contains(5.9)) == 26
-            @test contains(startfwdrev, Contains(6.0)) == 25
+            @test contains(startfwdrev, Contains(11.9)) == 20
+            @test contains(startfwdrev, Contains(12.0)) == 19
             @test contains(startfwdrev, Contains(30.0)) == 1
             @test contains(startfwdrev, Contains(29.9)) == 2
-            @test contains(startrevrev, Contains(5.9)) == 1
-            @test contains(startrevrev, Contains(6.0)) == 2
-            @test contains(startrevrev, Contains(29.9)) == 25
-            @test contains(startrevrev, Contains(30.0)) == 26
+            @test contains(startrevrev, Contains(11.9)) == 1
+            @test contains(startrevrev, Contains(12.0)) == 2
+            @test contains(startrevrev, Contains(29.9)) == 19
+            @test contains(startrevrev, Contains(30.0)) == 20
         end
 
         @testset "Start near" begin
             @test bounds(startfwdfwd) == bounds(startfwdrev) == bounds(startrevrev) == bounds(startrevfwd)
-            @test near(startfwdfwd, Near(50)) == 26
-            @test near(startfwdfwd, Near(0)) == 1
-            @test near(startfwdfwd, Near(5.9)) == 1
-            @test near(startfwdfwd, Near(6.0)) == 2
-            @test near(startfwdfwd, Near(30.0)) == 26
-            @test near(startfwdfwd, Near(29.9)) == 25
-            @test near(startfwdrev, Near(5.9)) == 26
-            @test near(startfwdrev, Near(6.0)) == 25
+            @test near(startfwdfwd, Near(-100)) == 1
+            @test near(startfwdfwd, Near(11.9)) == 1
+            @test near(startfwdfwd, Near(12.0)) == 2
+            @test near(startfwdfwd, Near(30.0)) == 20
+            @test near(startfwdfwd, Near(29.9)) == 19
+            @test near(startfwdrev, Near(11.9)) == 20
+            @test near(startfwdrev, Near(12.0)) == 19
             @test near(startfwdrev, Near(29.9)) == 2
             @test near(startfwdrev, Near(30.0)) == 1
-            @test near(startrevfwd, Near(5.9)) == 26
-            @test near(startrevfwd, Near(6.0)) == 25
+            @test near(startrevfwd, Near(11.9)) == 20
+            @test near(startrevfwd, Near(12.0)) == 19
             @test near(startrevfwd, Near(29.0)) == 2
             @test near(startrevfwd, Near(30.0)) == 1
-            @test near(startrevrev, Near(5.9)) == 1
-            @test near(startrevrev, Near(6.0)) == 2
-            @test near(startrevrev, Near(29.9)) == 25
-            @test near(startrevrev, Near(30.0)) == 26
+            @test near(startrevrev, Near(11.9)) == 1
+            @test near(startrevrev, Near(12.0)) == 2
+            @test near(startrevrev, Near(29.9)) == 19
+            @test near(startrevrev, Near(30.0)) == 20
+            @test near(startfwdfwd, Near(100)) == 20
         end
 
-        centerfwdfwd = Ti((5.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(Center())))
-        centerfwdrev = Ti((5.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(Center())))
-        centerrevfwd = Ti((30.0:-1.0:5.0); mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(Center())))
-        centerrevrev = Ti((30.0:-1.0:5.0); mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(Center())))
+        centerfwdfwd = Ti((11.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(Center())))
+        centerfwdrev = Ti((11.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(Center())))
+        centerrevfwd = Ti((30.0:-1.0:11.0); mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(Center())))
+        centerrevrev = Ti((30.0:-1.0:11.0); mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(Center())))
 
         @testset "Center between" begin
-            @test between(centerfwdfwd, Between(9.9, 15.1)) === 7:10
-            @test between(centerfwdrev, Between(9.9, 15.1)) === 17:1:20
-            @test between(centerrevfwd, Between(9.9, 15.1)) === 17:20
-            @test between(centerrevrev, Between(9.9, 15.1)) === 7:1:10
-            @test between(centerfwdfwd, Between(10, 15)) === 7:10
-            @test between(centerfwdrev, Between(10, 15)) === 17:1:20
-            @test between(centerrevfwd, Between(10, 15)) === 17:20
-            @test between(centerrevrev, Between(10, 15)) === 7:1:10
+            @test between(centerfwdfwd, Between(10.5, 14.6)) === 1:4
+            @test between(centerfwdrev, Between(10.5, 14.6)) === 17:1:20
+            @test between(centerrevfwd, Between(10.5, 14.6)) === 17:20
+            @test between(centerrevrev, Between(10.5, 14.6)) === 1:1:4
+            @test between(centerfwdfwd, Between(10.6, 14.4)) === 2:3
+            @test between(centerfwdrev, Between(10.6, 14.4)) === 18:1:19
+            @test between(centerrevfwd, Between(10.6, 14.4)) === 18:19
+            @test between(centerrevrev, Between(10.6, 14.4)) === 2:1:3
             # Input order doesn't matter
-            @test between(centerfwdfwd, Between(15, 10)) === 7:10
+            @test between(centerfwdfwd, Between(15, 10)) === 1:4
         end
 
         @testset "Center contains" begin
-            @test_throws BoundsError contains(centerfwdfwd, Contains(4.4))
+            @test_throws BoundsError contains(centerfwdfwd, Contains(10.4))
             @test_throws BoundsError contains(centerfwdfwd, Contains(30.5))
-            @test_throws BoundsError contains(centerrevfwd, Contains(4.4))
+            @test_throws BoundsError contains(centerrevfwd, Contains(10.4))
             @test_throws BoundsError contains(centerrevfwd, Contains(30.5))
-            @test contains(centerfwdfwd, Contains(4.5)) == 1
-            @test contains(centerfwdfwd, Contains(30.4)) == 26
-            @test contains(centerfwdfwd, Contains(29.5)) == 26
-            @test contains(centerfwdfwd, Contains(29.4)) == 25
-            @test contains(centerrevfwd, Contains(4.5)) == 26
+            @test contains(centerfwdfwd, Contains(10.5)) == 1
+            @test contains(centerfwdfwd, Contains(30.4)) == 20
+            @test contains(centerfwdfwd, Contains(29.5)) == 20
+            @test contains(centerfwdfwd, Contains(29.4)) == 19
+            @test contains(centerrevfwd, Contains(10.5)) == 20
             @test contains(centerrevfwd, Contains(30.4)) == 1
             @test contains(centerrevfwd, Contains(29.5)) == 1
             @test contains(centerrevfwd, Contains(29.4)) == 2
             @test contains(centerfwdrev, Contains(29.5)) == 1
             @test contains(centerfwdrev, Contains(29.4)) == 2
-            @test contains(centerrevrev, Contains(29.5)) == 26
-            @test contains(centerrevrev, Contains(29.4)) == 25
+            @test contains(centerrevrev, Contains(29.5)) == 20
+            @test contains(centerrevrev, Contains(29.4)) == 19
         end
 
         @testset "Center near" begin
-            @test near(centerfwdfwd, Near(4.4)) == 1
-            @test near(centerfwdfwd, Near(30.5)) == 26
-            @test near(centerrevfwd, Near(4.4)) == 26
+            @test near(centerfwdfwd, Near(10.4)) == 1
+            @test near(centerfwdfwd, Near(30.5)) == 20
+            @test near(centerrevfwd, Near(10.4)) == 20
             @test near(centerrevfwd, Near(30.5)) == 1
-            @test near(centerfwdfwd, Near(4.5)) == 1
-            @test near(centerfwdfwd, Near(30.4)) == 26
-            @test near(centerfwdfwd, Near(29.5)) == 26
-            @test near(centerfwdfwd, Near(29.4)) == 25
-            @test near(centerrevfwd, Near(4.5)) == 26
+            @test near(centerfwdfwd, Near(10.5)) == 1
+            @test near(centerfwdfwd, Near(30.4)) == 20
+            @test near(centerfwdfwd, Near(29.5)) == 20
+            @test near(centerfwdfwd, Near(29.4)) == 19
+            @test near(centerrevfwd, Near(10.5)) == 20
             @test near(centerrevfwd, Near(30.4)) == 1
             @test near(centerrevfwd, Near(29.5)) == 1
             @test near(centerrevfwd, Near(29.4)) == 2
             @test near(centerfwdrev, Near(29.5)) == 1
             @test near(centerfwdrev, Near(29.4)) == 2
-            @test near(centerrevrev, Near(29.5)) == 26
-            @test near(centerrevrev, Near(29.4)) == 25
+            @test near(centerrevrev, Near(29.5)) == 20
+            @test near(centerrevrev, Near(29.4)) == 19
         end
 
-        endfwdfwd = Ti((5.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(End())))
-        endfwdrev = Ti((5.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(End())))
-        endrevfwd = Ti((30.0:-1.0:5.0); mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(End())))
-        endrevrev = Ti((30.0:-1.0:5.0); mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(End())))
+        endfwdfwd = Ti((11.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Forward()), Regular(1), Intervals(End())))
+        endfwdrev = Ti((11.0:30.0);      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), Regular(1), Intervals(End())))
+        endrevfwd = Ti((30.0:-1.0:11.0); mode=Sampled(Ordered(Reverse(),Forward(),Forward()), Regular(-1), Intervals(End())))
+        endrevrev = Ti((30.0:-1.0:11.0); mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), Regular(-1), Intervals(End())))
 
         @testset "End between" begin
-            @test between(endfwdfwd, Between(9.9, 15.1)) === 7:11
-            @test between(endfwdrev, Between(9.9, 15.1)) === 16:1:20
-            @test between(endrevfwd, Between(9.9, 15.1)) === 16:20
-            @test between(endrevrev, Between(9.9, 15.1)) === 7:1:11
-            @test between(endfwdfwd, Between(10, 15)) === 7:11
+            @test between(endfwdfwd, Between(10.1, 14.9)) === 2:4
+            @test between(endfwdrev, Between(10.1, 14.9)) === 17:1:19
+            @test between(endrevfwd, Between(10.1, 14.9)) === 17:19
+            @test between(endrevrev, Between(10.1, 14.9)) === 2:1:4
+            @test between(endfwdfwd, Between(10, 15)) === 1:5
             @test between(endfwdrev, Between(10, 15)) === 16:1:20
             @test between(endrevfwd, Between(10, 15)) === 16:20
-            @test between(endrevrev, Between(10, 15)) === 7:1:11
+            @test between(endrevrev, Between(10, 15)) === 1:1:5
             # Input order doesn't matter
-            @test between(endfwdfwd, Between(15, 10)) === 7:11
+            @test between(endfwdfwd, Between(15, 10)) === 1:5
         end
 
         @testset "End contains" begin
-            @test_throws BoundsError contains(endfwdfwd, Contains(4))
+            @test_throws BoundsError contains(endfwdfwd, Contains(10))
             @test_throws BoundsError contains(endfwdfwd, Contains(30.1))
-            @test_throws BoundsError contains(endrevfwd, Contains(4))
+            @test_throws BoundsError contains(endrevfwd, Contains(10))
             @test_throws BoundsError contains(endrevfwd, Contains(30.1))
-            @test contains(endfwdfwd, Contains(4.1)) == 1
-            @test contains(endfwdfwd, Contains(5.0)) == 1
-            @test contains(endfwdfwd, Contains(5.1)) == 2
-            @test contains(endfwdfwd, Contains(29.0)) == 25
-            @test contains(endfwdfwd, Contains(29.1)) == 26
-            @test contains(endfwdfwd, Contains(30.0)) == 26
-            @test contains(endrevfwd, Contains(4.1)) == 26
-            @test contains(endrevfwd, Contains(5.0)) == 26
-            @test contains(endrevfwd, Contains(5.1)) == 25
+            @test contains(endfwdfwd, Contains(10.1)) == 1
+            @test contains(endfwdfwd, Contains(11.0)) == 1
+            @test contains(endfwdfwd, Contains(11.1)) == 2
+            @test contains(endfwdfwd, Contains(29.0)) == 19
+            @test contains(endfwdfwd, Contains(29.1)) == 20
+            @test contains(endfwdfwd, Contains(30.0)) == 20
+            @test contains(endrevfwd, Contains(10.1)) == 20
+            @test contains(endrevfwd, Contains(11.0)) == 20
+            @test contains(endrevfwd, Contains(11.1)) == 19
             @test contains(endrevfwd, Contains(29.0)) == 2
             @test contains(endrevfwd, Contains(29.1)) == 1
             @test contains(endrevfwd, Contains(30.0)) == 1
-            @test contains(endrevrev, Contains(5.0)) == 1
-            @test contains(endrevrev, Contains(5.1)) == 2
-            @test contains(endrevrev, Contains(29.0)) == 25
-            @test contains(endrevrev, Contains(29.1)) == 26
-            @test contains(endrevfwd, Contains(5.0)) == 26
-            @test contains(endrevfwd, Contains(5.1)) == 25
+            @test contains(endrevrev, Contains(11.0)) == 1
+            @test contains(endrevrev, Contains(11.1)) == 2
+            @test contains(endrevrev, Contains(29.0)) == 19
+            @test contains(endrevrev, Contains(29.1)) == 20
+            @test contains(endrevfwd, Contains(11.0)) == 20
+            @test contains(endrevfwd, Contains(11.1)) == 19
             @test contains(endrevfwd, Contains(29.0)) == 2
             @test contains(endrevfwd, Contains(29.1)) == 1
         end
 
         @testset "End near" begin
-            @test near(endfwdfwd, Near(4)) == 1
-            @test near(endfwdfwd, Near(5.0)) == 1
-            @test near(endfwdfwd, Near(5.1)) == 2
-            @test near(endfwdfwd, Near(29.0)) == 25
-            @test near(endfwdfwd, Near(29.1)) == 26
-            @test near(endfwdfwd, Near(30.0)) == 26
-            @test near(endfwdfwd, Near(31.1)) == 26
-            @test near(endrevfwd, Near(4)) == 26
-            @test near(endrevfwd, Near(5.0)) == 26
-            @test near(endrevfwd, Near(5.1)) == 25
+            @test near(endfwdfwd, Near(10)) == 1
+            @test near(endfwdfwd, Near(11.0)) == 1
+            @test near(endfwdfwd, Near(11.1)) == 2
+            @test near(endfwdfwd, Near(29.0)) == 19
+            @test near(endfwdfwd, Near(29.1)) == 20
+            @test near(endfwdfwd, Near(30.0)) == 20
+            @test near(endfwdfwd, Near(31.1)) == 20
+            @test near(endrevfwd, Near(10)) == 20
+            @test near(endrevfwd, Near(11.0)) == 20
+            @test near(endrevfwd, Near(11.1)) == 19
             @test near(endrevfwd, Near(29.0)) == 2
             @test near(endrevfwd, Near(29.1)) == 1
             @test near(endrevfwd, Near(30.0)) == 1
             @test near(endrevfwd, Near(31.1)) == 1
-            @test near(endrevrev, Near(5.0)) == 1
-            @test near(endrevrev, Near(5.1)) == 2
-            @test near(endrevrev, Near(29.0)) == 25
-            @test near(endrevrev, Near(29.1)) == 26
-            @test near(endrevfwd, Near(5.0)) == 26
-            @test near(endrevfwd, Near(5.1)) == 25
+            @test near(endrevrev, Near(11.0)) == 1
+            @test near(endrevrev, Near(11.1)) == 2
+            @test near(endrevrev, Near(29.0)) == 19
+            @test near(endrevrev, Near(29.1)) == 20
+            @test near(endrevfwd, Near(11.0)) == 20
+            @test near(endrevfwd, Near(11.1)) == 19
             @test near(endrevfwd, Near(29.0)) == 2
             @test near(endrevfwd, Near(29.1)) == 1
+            @test near(endfwdfwd, Near(-100)) == 1
+            @test near(endfwdfwd, Near(100)) == 20
         end
 
     end
-    @testset "RegulaSpan Intervals mode with array" begin
-        # Order: index, array, relation (array order is irrelevent here, it's just for plotting)
+
+    @testset "Regular Intervals with array" begin
         startfwd = Ti([1, 3, 4, 5]; mode=Sampled(Ordered(index=Forward()), Regular(1), Intervals(Start())))
         startrev = Ti([5, 4, 3, 1]; mode=Sampled(Ordered(index=Reverse()), Regular(-1), Intervals(Start())))
         @test_throws BoundsError contains(startfwd, Contains(0.9))
@@ -226,7 +230,6 @@ A = DimArray([1 2 3; 4 5 6], dims_)
         @test contains(startfwd, Contains(3)) == 2
         @test contains(startfwd, Contains(5.9)) == 4
         @test_throws BoundsError contains(startfwd, Contains(6))
-
         @test_throws BoundsError contains(startrev, Contains(0.9))
         @test contains(startrev, Contains(1.0)) == 4
         @test contains(startrev, Contains(1.9)) == 4
@@ -235,9 +238,182 @@ A = DimArray([1 2 3; 4 5 6], dims_)
         @test contains(startrev, Contains(3)) == 3
         @test contains(startrev, Contains(5.9)) == 1
         @test_throws BoundsError contains(startrev, Contains(6))
-
     end
 
+    @testset "Irregular Intervals with array" begin
+        # Order: index, array, relation (array order is irrelevent here, it's just for plotting)
+        # Varnames: locusindexorderrelation
+        args = Irregular(1.0, 121.0), Intervals(Start())
+        startfwdfwd = Ti((1:10).^2;    mode=Sampled(Ordered(Forward(),Forward(),Forward()), args...))
+        startfwdrev = Ti((1:10).^2;    mode=Sampled(Ordered(Forward(),Forward(),Reverse()), args...))
+        startrevfwd = Ti((10:-1:1).^2; mode=Sampled(Ordered(Reverse(),Forward(),Forward()), args...))
+        startrevrev = Ti((10:-1:1).^2; mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), args...))
+
+        @testset "Any at" begin
+            @test at(startfwdfwd, At(25)) == 5
+            @test at(startfwdrev, At(25)) == 6
+            @test at(startrevfwd, At(25)) == 6
+            @test at(startrevrev, At(25)) == 5
+            @test at(startfwdfwd, At(100)) == 10
+            @test at(startfwdrev, At(100)) == 1
+            @test at(startrevfwd, At(100)) == 1
+            @test at(startrevrev, At(100)) == 10
+        end
+
+        @testset "Start between" begin
+            @test between(startfwdfwd, Between(9, 36)) === 3:5
+            @test between(startfwdrev, Between(9, 36)) === 6:1:8
+            @test between(startrevfwd, Between(9, 36)) === 6:8
+            @test between(startrevrev, Between(9, 36)) === 3:1:5
+            @test between(startfwdfwd, Between(9.1, 35.0)) === 4:4
+            @test between(startfwdrev, Between(9.1, 35.9)) === 7:1:7
+            @test between(startrevfwd, Between(9.1, 35.9)) === 7:7
+            @test between(startrevrev, Between(9.1, 35.9)) === 4:1:4
+            # Input order doesn't matter
+            @test between(startfwdfwd, Between(36, 9)) === 3:5
+            # Handle searchorted overflow
+            @test between(startfwdfwd, Between(-100, 9)) === 1:2
+            @test between(startfwdfwd, Between(80, 150)) === 9:10
+            @test between(startfwdrev, Between(-100, 9)) === 9:1:10
+            @test between(startfwdrev, Between(80, 150)) === 1:1:2
+            @test between(startrevfwd, Between(-100, 9)) === 9:10
+            @test between(startrevfwd, Between(80, 150)) === 1:2
+            @test between(startrevrev, Between(-100, 9)) === 1:1:2
+            @test between(startrevrev, Between(80, 150)) === 9:1:10
+        end
+
+        @testset "Start contains" begin
+            @test_throws BoundsError contains(startfwdfwd, Contains(0.9))
+            @test_throws BoundsError contains(startfwdfwd, Contains(121.1))
+            @test_throws BoundsError contains(startfwdrev, Contains(0.9))
+            @test_throws BoundsError contains(startfwdrev, Contains(121.1))
+            @test contains(startfwdfwd, Contains(1)) == 1
+            @test contains(startfwdfwd, Contains(3.9)) == 1
+            @test contains(startfwdfwd, Contains(4.0)) == 2
+            @test contains(startfwdfwd, Contains(100.0)) == 10
+            @test contains(startfwdfwd, Contains(99.9)) == 9
+            @test contains(startfwdrev, Contains(3.9)) == 10
+            @test contains(startfwdrev, Contains(4.0)) == 9
+            @test contains(startfwdrev, Contains(100.0)) == 1
+            @test contains(startfwdrev, Contains(99.9)) == 2
+            @test_throws BoundsError contains(startrevrev, Contains(0.9))
+            @test_throws BoundsError contains(startrevrev, Contains(121.1))
+            @test_throws BoundsError contains(startrevfwd, Contains(0.9))
+            @test_throws BoundsError contains(startrevfwd, Contains(121.1))
+            @test contains(startrevfwd, Contains(3.9)) == 10
+            @test contains(startrevfwd, Contains(4.0)) == 9
+            @test contains(startrevfwd, Contains(120.9)) == 1
+            @test contains(startrevfwd, Contains(100.0)) == 1
+            @test contains(startrevfwd, Contains(99.0)) == 2
+            @test contains(startrevrev, Contains(3.9)) == 1
+            @test contains(startrevrev, Contains(4.0)) == 2
+            @test contains(startrevrev, Contains(100.0)) == 10
+            @test contains(startrevrev, Contains(99.9)) == 9
+        end
+
+        args = Irregular(0.5, 111.5), Intervals(Center())
+        centerfwdfwd =Ti((1.0:10.0).^2;      mode=Sampled(Ordered(Forward(),Forward(),Forward()), args...))
+        centerfwdrev =Ti((1.0:10.0).^2;      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), args...))
+        centerrevfwd =Ti((10.0:-1.0:1.0).^2; mode=Sampled(Ordered(Reverse(),Forward(),Forward()), args...))
+        centerrevrev =Ti((10.0:-1.0:1.0).^2; mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), args...))
+
+        @testset "Center between" begin
+            @test between(centerfwdfwd, Between(6.5, 30.5)) === 3:5
+            @test between(centerfwdfwd, Between(6.6, 30.4)) === 4:4
+            @test between(centerfwdrev, Between(6.5, 30.5)) === 6:1:8
+            @test between(centerfwdrev, Between(6.6, 30.4)) === 7:1:7
+            @test between(centerrevfwd, Between(6.5, 30.5)) === 6:8
+            @test between(centerrevfwd, Between(6.6, 30.4)) === 7:7
+            @test between(centerrevrev, Between(6.5, 30.5)) === 3:1:5
+            @test between(centerrevrev, Between(6.6, 30.4)) === 4:1:4
+            # Input order doesn't matter
+            @test between(centerfwdfwd, Between(30.5, 6.5)) === 3:5
+        end
+
+        @testset "Center contains" begin
+            @test_throws BoundsError contains(centerfwdfwd, Contains(0.4))
+            @test_throws BoundsError contains(centerfwdfwd, Contains(111.5))
+            @test contains(centerfwdfwd, Contains(0.5)) == 1
+            @test contains(centerfwdfwd, Contains(111.4)) == 10
+            @test contains(centerfwdfwd, Contains(90.5)) == 10
+            @test contains(centerfwdfwd, Contains(90.4)) == 9
+            @test contains(centerfwdrev, Contains(90.6)) == 1
+            @test contains(centerfwdrev, Contains(90.5)) == 1
+            @test contains(centerfwdrev, Contains(90.4)) == 2
+            @test contains(centerfwdrev, Contains(72.5)) == 2
+            @test contains(centerfwdrev, Contains(72.4)) == 3
+            @test_throws BoundsError contains(centerrevfwd, Contains(0.4))
+            @test_throws BoundsError contains(centerrevfwd, Contains(111.5))
+            @test contains(centerrevfwd, Contains(72.5)) == 2
+            @test contains(centerrevfwd, Contains(72.4)) == 3
+            @test contains(centerrevfwd, Contains(0.5)) == 10
+            @test contains(centerrevfwd, Contains(111.4)) == 1
+            @test contains(centerrevfwd, Contains(90.5)) == 1
+            @test contains(centerrevfwd, Contains(90.4)) == 2
+
+            @test contains(centerrevrev, Contains(90.5)) == 10
+            @test contains(centerrevrev, Contains(90.4)) == 9
+        end
+
+        # @testset "Center near" begi
+
+        args = Irregular(0.0, 100.0), Intervals(End())
+        endfwdfwd = Ti((1.0:10.0).^2;      mode=Sampled(Ordered(Forward(),Forward(),Forward()), args...))
+        endfwdrev = Ti((1.0:10.0).^2;      mode=Sampled(Ordered(Forward(),Forward(),Reverse()), args...))
+        endrevfwd = Ti((10.0:-1.0:1.0).^2; mode=Sampled(Ordered(Reverse(),Forward(),Forward()), args...))
+        endrevrev = Ti((10.0:-1.0:1.0).^2; mode=Sampled(Ordered(Reverse(),Forward(),Reverse()), args...))
+
+        @testset "End between" begin
+            @test between(endfwdfwd, Between(4, 25)) === 3:5
+            @test between(endfwdrev, Between(4, 25)) === 6:1:8
+            @test between(endrevfwd, Between(4, 25)) === 6:8
+            @test between(endrevrev, Between(4, 25)) === 3:1:5
+            @test between(endfwdfwd, Between(4.1, 24.9)) === 4:4
+            @test between(endfwdrev, Between(4.1, 24.9)) === 7:1:7
+            @test between(endrevfwd, Between(4.1, 24.9)) === 7:7
+            @test between(endrevrev, Between(4.1, 24.9)) === 4:1:4
+            # Input order doesn't matter
+            @test between(endfwdfwd, Between(25, 4)) === 3:5
+            # Handle searchorted overflow
+            @test between(endfwdfwd, Between(-100, 4)) === 1:2
+            @test between(endfwdfwd, Between(-100, 4)) === 1:2
+            @test between(endfwdfwd, Between(64, 150)) === 9:10
+            @test between(endfwdrev, Between(-100, 4)) === 9:1:10
+            @test between(endfwdrev, Between(64, 150)) === 1:1:2
+            @test between(endrevfwd, Between(-100, 4)) === 9:10
+            @test between(endrevfwd, Between(64, 150)) === 1:2
+            @test between(endrevrev, Between(-100, 4)) === 1:1:2
+            @test between(endrevrev, Between(64, 150)) === 9:1:10
+        end
+
+        @testset "End contains" begin
+            @test_throws BoundsError contains(endfwdfwd, Contains(-0.1))
+            @test_throws BoundsError contains(endfwdfwd, Contains(100.1))
+            @test_throws BoundsError contains(endrevfwd, Contains(-0.1))
+            @test_throws BoundsError contains(endrevfwd, Contains(100.1))
+            @test contains(endfwdfwd, Contains(0.1)) == 1
+            @test contains(endfwdfwd, Contains(1.0)) == 1
+            @test contains(endfwdfwd, Contains(1.1)) == 2
+            @test contains(endfwdfwd, Contains(81.0)) == 9
+            @test contains(endfwdfwd, Contains(81.1)) == 10
+            @test contains(endfwdfwd, Contains(100.0)) == 10
+            @test contains(endrevfwd, Contains(0.1)) == 10
+            @test contains(endrevfwd, Contains(1.0)) == 10
+            @test contains(endrevfwd, Contains(1.1)) == 9
+            @test contains(endrevfwd, Contains(81.0)) == 2
+            @test contains(endrevfwd, Contains(81.1)) == 1
+            @test contains(endrevfwd, Contains(100.0)) == 1
+            @test contains(endrevrev, Contains(1.0)) == 1
+            @test contains(endrevrev, Contains(1.1)) == 2
+            @test contains(endrevrev, Contains(81.0)) == 9
+            @test contains(endrevrev, Contains(81.1)) == 10
+            @test contains(endrevfwd, Contains(1.0)) == 10
+            @test contains(endrevfwd, Contains(1.1)) == 9
+            @test contains(endrevfwd, Contains(81.0)) == 2
+            @test contains(endrevfwd, Contains(81.1)) == 1
+        end
+
+    end
 
     @testset "Points mode" begin
 
@@ -275,6 +451,10 @@ A = DimArray([1 2 3; 4 5 6], dims_)
             @test near(revrev, Near(30.1)) == 26
         end
 
+        @testset "near" begin
+            @test_throws ArgumentError contains(fwdfwd, Contains(50))
+        end
+
     end
 
 end
@@ -285,31 +465,31 @@ end
                               Ti((1:4)u"s"; mode=Sampled())))
 
     @test At(10.0) == At(10.0, nothing, nothing)
-    @test At(10.0; atol=0.0, rtol=Base.rtoldefault(Float64)) == 
+    @test At(10.0; atol=0.0, rtol=Base.rtoldefault(Float64)) ==
         At(10.0, 0.0, Base.rtoldefault(Float64))
     Near([10, 20])
 
     @test Between(10, 20) == Between((10, 20))
 
     @testset "selectors with dim wrappers" begin
-        @test da[Y(At([10, 30])), Ti(At([1u"s", 4u"s"]))] == [1 4; 9 12]
+        @test @inferred da[Y(At([10, 30])), Ti(At([1u"s", 4u"s"]))] == [1 4; 9 12]
         @test_throws ArgumentError da[Y(At([9, 30])), Ti(At([1u"s", 4u"s"]))]
-        @test view(da, Y(At(20)), Ti(At((3:4)u"s"))) == [7, 8]
-        @test view(da, Y(Near(17)), Ti(Near([1.5u"s", 3.1u"s"]))) == [6, 7]
-        @test view(da, Y(Between(9, 21)), Ti(At((3:4)u"s"))) == [3 4; 7 8]
+        @test @inferred view(da, Y(At(20)), Ti(At((3:4)u"s"))) == [7, 8]
+        @test @inferred view(da, Y(Near(17)), Ti(Near([1.5u"s", 3.1u"s"]))) == [6, 7]
+        @test @inferred view(da, Y(Between(9, 21)), Ti(At((3:4)u"s"))) == [3 4; 7 8]
     end
 
     @testset "selectors without dim wrappers" begin
-        @test da[At(20:10:30), At(1u"s")] == [5, 9]
-        @test view(da, Between(9, 31), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
-        @test view(da, Near(22), At([3.0u"s", 4.0u"s"])) == [7, 8]
-        @test view(da, At(20), At((2:3)u"s")) == [6, 7]
-        @test view(da, Near(13), Near([1.3u"s", 3.3u"s"])) == [1, 3]
+        @test @inferred da[At(20:10:30), At(1u"s")] == [5, 9]
+        @test @inferred view(da, Between(9, 31), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
+        @test @inferred view(da, Near(22), At([3.0u"s", 4.0u"s"])) == [7, 8]
+        @test @inferred view(da, At(20), At((2:3)u"s")) == [6, 7]
+        @test @inferred view(da, Near(13), Near([1.3u"s", 3.3u"s"])) == [1, 3]
         # Near works with a tuple input
-        @test view(da, Near([13]), Near([1.3u"s", 3.3u"s"])) == [1 3]
-        @test view(da, Between(11, 20), At((2:3)u"s")) == [6 7]
+        @test @inferred view(da, Near([13]), Near([1.3u"s", 3.3u"s"])) == [1 3]
+        @test @inferred view(da, Between(11, 20), At((2:3)u"s")) == [6 7]
         # Between also accepts a tuple input
-        @test view(da, Between((11, 20)), Between((2u"s", 3u"s"))) == [6 7]
+        @test @inferred view(da, Between((11, 20)), Between((2u"s", 3u"s"))) == [6 7]
     end
 
     @testset "mixed selectors and standard" begin
@@ -418,7 +598,7 @@ end
                                          Ti((1:1:4)u"s"; mode=Sampled(order=Ordered(Forward(), Forward(), Reverse())))))
             @test indexorder(dims(da_ffr, Ti)) == Forward()
             @test arrayorder(dims(da_ffr, Ti)) == Forward()
-            @test relationorder(dims(da_ffr, Ti)) == Reverse()
+            @test relation(dims(da_ffr, Ti)) == Reverse()
             @test da_ffr[Y<|At(20), Ti<|At((3.0:4.0)u"s")] == [6, 5]
             @test da_ffr[Y<|At([20, 30]), Ti<|At((3.0:4.0)u"s")] == [6 5; 2 1]
             @test da_ffr[Y<|Near(22), Ti<|Near([3.3u"s", 4.3u"s"])] == [6, 5]
@@ -465,7 +645,7 @@ end
         dc = DimArray(c, (Y((10, 30)), Ti((1:4)u"s")))
         dc[Near(11), At(3u"s")] = 100
         @test c[1, 3] == 100
-        dc[Ti<|Near(2.2u"s"), Y<|Between(10, 30)] = [200, 201, 202]
+        @inferred setindex!(dc, [200, 201, 202], Ti<|Near(2.2u"s"), Y<|Between(10, 30))
         @test c[1:3, 2] == [200, 201, 202]
     end
 
@@ -476,23 +656,23 @@ end
                               Ti((1:4)u"s"; mode=Sampled(sampling=Intervals()))))
 
     @testset "selectors with dim wrappers" begin
-        @test da[Y(At([10, 30])), Ti(At([1u"s", 4u"s"]))] == [1 4; 9 12]
+        @test @inferred da[Y(At([10, 30])), Ti(At([1u"s", 4u"s"]))] == [1 4; 9 12]
         @test_throws ArgumentError da[Y(At([9, 30])), Ti(At([1u"s", 4u"s"]))]
-        @test view(da, Y(At(20)), Ti(At((3:4)u"s"))) == [7, 8]
-        @test view(da, Y(Contains(17)), Ti(Contains([1.9u"s", 3.1u"s"]))) == [5, 7]
-        @test view(da, Y(Between(4, 26)), Ti(At((3:4)u"s"))) == [3 4; 7 8]
+        @test @inferred view(da, Y(At(20)), Ti(At((3:4)u"s"))) == [7, 8]
+        @test @inferred view(da, Y(Contains(17)), Ti(Contains([1.9u"s", 3.1u"s"]))) == [5, 7]
+        @test @inferred view(da, Y(Between(4, 26)), Ti(At((3:4)u"s"))) == [3 4; 7 8]
     end
 
     @testset "selectors without dim wrappers" begin
-        @test da[At(20:10:30), At(1u"s")] == [5, 9]
-        @test view(da, Between(4, 36), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
-        @test view(da, Near(22), At([3.0u"s", 4.0u"s"])) == [7, 8]
-        @test view(da, At(20), At((2:3)u"s")) == [6, 7]
-        @test view(da, Near(13), Near([1.3u"s", 3.3u"s"])) == [1, 3]
-        @test view(da, Near([13]), Near([1.3u"s", 3.3u"s"])) == [1 3]
-        @test view(da, Between(11, 26), At((2:3)u"s")) == [6 7]
+        @test @inferred da[At(20:10:30), At(1u"s")] == [5, 9]
+        @test @inferred view(da, Between(4, 36), Near((3:4)u"s")) == [3 4; 7 8; 11 12]
+        @test @inferred view(da, Near(22), At([3.0u"s", 4.0u"s"])) == [7, 8]
+        @test @inferred view(da, At(20), At((2:3)u"s")) == [6, 7]
+        @test @inferred view(da, Near(13), Near([1.3u"s", 3.3u"s"])) == [1, 3]
+        @test @inferred view(da, Near([13]), Near([1.3u"s", 3.3u"s"])) == [1 3]
+        @test @inferred view(da, Between(11, 26), At((2:3)u"s")) == [6 7]
         # Between also accepts a tuple input
-        @test view(da, Between((11, 26)), Between((2u"s", 4u"s"))) == [6 7]
+        @test @inferred view(da, Between((11, 26)), Between((2u"s", 4u"s"))) == [6 7]
     end
 end
 
@@ -500,9 +680,9 @@ end
 @testset "Selectors on NoIndex" begin
     dimz = Ti(), Y()
     da = DimArray(a, dimz)
-    @test da[Ti(At([1, 2])), Y(Contains(2))] == [2, 6]
-    @test da[Near(2), Between(2, 4)] == [6, 7, 8]
-    @test da[Contains([1, 3]), Near([2, 3, 4])] == [2 3 4; 10 11 12]
+    @test @inferred da[Ti(At([1, 2])), Y(Contains(2))] == [2, 6]
+    @test @inferred da[Near(2), Between(2, 4)] == [6, 7, 8]
+    @test @inferred da[Contains([1, 3]), Near([2, 3, 4])] == [2 3 4; 10 11 12]
 end
 
 @testset "Selectors on Categorical" begin
@@ -513,12 +693,12 @@ end
     dimz = Ti([:one, :two, :three]; mode=Categorical(Ordered())),
         Y([:a, :b, :c, :d]; mode=Categorical(Ordered()))
     da = DimArray(a, dimz)
-    @test da[Ti(At([:one, :two])), Y(Contains(:b))] == [2, 6]
-    @test da[At(:two), Between(:b, :d)] == [6, 7, 8]
-    @test da[:two, :b] == 6
+    @test @inferred da[Ti(At([:one, :two])), Y(Contains(:b))] == [2, 6]
+    @test @inferred da[At(:two), Between(:b, :d)] == [6, 7, 8]
+    @test @inferred da[:two, :b] == 6
     # Near and contains are just At
-    @test da[Contains([:one, :three]), Near([:b, :c, :d])] == [2 3 4; 10 11 12]
-   
+    @test @inferred da[Contains([:one, :three]), Near([:b, :c, :d])] == [2 3 4; 10 11 12]
+
     dimz = Ti([:one, :two, :three]; mode=Categorical(Unordered())),
         Y([:a, :b, :c, :d]; mode=Categorical(Unordered()))
     da = DimArray(a, dimz)
@@ -531,14 +711,14 @@ end
     valdimz = Ti(Val((2.4, 2.5, 2.6)); mode=Categorical(Ordered())),
         Y(Val((:a, :b, :c, :d)); mode=Categorical(Ordered()))
     da = DimArray(a, valdimz)
-    @test da[Val(2.5), Val(:c)] == 7
-    @test da[2.4, :a] == 1
+    @test @inferred da[Val(2.5), Val(:c)] == 7
+    @test @inferred da[2.4, :a] == 1
 end
 
 @testset "Where " begin
     dimz = Ti((1:1:3)u"s"), Y(10:10:40)
     da = DimArray(a, dimz)
-    @test da[Y(Where(x -> x >= 30)), Ti(Where(x -> x in([1u"s", 3u"s"])))] == [3 4; 11 12]
+    @test @inferred da[Y(Where(x -> x >= 30)), Ti(Where(x -> x in([1u"s", 3u"s"])))] == [3 4; 11 12]
 end
 
 @testset "TranformedIndex" begin
@@ -551,25 +731,26 @@ end
            Z()
 
     @testset "permutedims works on mode dimensions" begin
-        @test permutedims((Y(), Z(), X()), dimz) == (X(), Y(), Z())
+        DimensionalData.modetype(typeof(dimz[1]))
+        @test @inferred sortdims((Y(), Z(), X()), dimz) == (X(), Y(), Z())
     end
 
     da = DimArray(reshape(a, 3, 4, 1), dimz)
 
     @testset "Indexing with array dims indexes the array as usual" begin
-        @test da[Dim{:trans1}(3), Dim{:trans2}(1), Z(1)] == 9
+        @test @inferred da[Dim{:trans1}(3), Dim{:trans2}(1), Z(1)] == 9
         # Using selectors works the same as indexing with mode
         # dims - it applies the transform function.
         # It's not clear this should be allowed or makes sense,
         # but it works anyway because the permutation is correct either way.
-        @test da[Dim{:trans1}(At(6)), Dim{:trans2}(At(2)), Z(1)] == 9
+        @test @inferred da[Dim{:trans1}(At(6)), Dim{:trans2}(At(2)), Z(1)] == 9
     end
 
     @testset "Indexing with mode dims uses the transformation" begin
-        @test da[X(Near(6.1)), Y(Near(8.5)), Z(1)] == 12
-        @test da[X(At(4.0)), Y(At(2.0)), Z(1)] == 5
+        @test @inferred da[X(Near(6.1)), Y(Near(8.5)), Z(1)] == 12
+        @test @inferred da[X(At(4.0)), Y(At(2.0)), Z(1)] == 5
         @test_throws InexactError da[X(At(6.1)), Y(At(8)), Z(1)]
         # Indexing directly with mode dims also just works, but maybe shouldn't?
-        @test da[X(2), Y(2), Z(1)] == 6
+        @test @inferred da[X(2), Y(2), Z(1)] == 6
     end
 end


### PR DESCRIPTION
This i includes generated dims2indices to guarantee compile time performance.

It also includes a massive refactor to selectors to reduce and simplify the code, and more thoroughly test it.`
`Contains` and `Between` should now work properly on `Irregular` grids.

Indexing with kwargs also now works for `Dim{:x}` dims, and has no runtime cost.

There are some minor changes to the interface, and `AbstractDimensionalArray` and `DimensionalArray` are now
`DimensionalArray` and `DimArray`. But constants replace the old names so they still work.