### PR TITLE
Add `diff` method for `DimArray`s

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,8 +80,8 @@ function _diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
 
     return view(a, r1...) .- view(a, r0...)
 end
-Base.diff(A::AbstractDimArray; dims) = _diff(A; dims = dimnum(A, dims))
-Base.diff(A::AbstractDimVector) = diff(A; dims = 1)
+Base.diff(A::AbstractDimArray; dims) = _diff(A; dims=dimnum(A, dims))
+Base.diff(A::AbstractDimVector) = diff(A; dims=1)
 
 """
     reorder(::order, A::AbstractDimArray) => AbstractDimArray

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -70,6 +70,18 @@ flip(ot::Type{<:SubOrder}, dim::Dimension) = _set(dim, flip(ot, mode(dim)))
 flip(ot::Type{<:SubOrder}, mode::IndexMode) = _set(mode, flip(ot, order(mode)))
 flip(ot::Type{<:SubOrder}, o::Order) = _set(o, reverse(ot, o))
 
+function _diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
+    Base.require_one_based_indexing(a)
+    1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+
+    r = axes(a)
+    r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
+    r1 = ntuple(i -> i == dims ? UnitRange(2, last(r[i])) : UnitRange(r[i]), N)
+
+    return view(a, r1...) .- view(a, r0...)
+end
+Base.diff(A::AbstractDimArray; dims) = _diff(A; dims = dimnum(A, dims))
+Base.diff(A::AbstractDimVector) = diff(A, dims = 1)
 
 """
     reorder(::order, A::AbstractDimArray) => AbstractDimArray

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -81,7 +81,7 @@ function _diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
     return view(a, r1...) .- view(a, r0...)
 end
 Base.diff(A::AbstractDimArray; dims) = _diff(A; dims = dimnum(A, dims))
-Base.diff(A::AbstractDimVector) = diff(A, dims = 1)
+Base.diff(A::AbstractDimVector) = diff(A; dims = 1)
 
 """
     reorder(::order, A::AbstractDimArray) => AbstractDimArray

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -94,21 +94,22 @@ end
 end
 
 @testset "diff" begin
-    @testset "Array 3D" begin
-        x = X(2:2:10)
+    @testset "Array 2D" begin
         y = Y(['a', 'b', 'c'])
-        ti = Ti(DateTime(2021, 1):Month(1):DateTime(2021, 12))
-        A = DimArray(zeros(3, 5, 12), (y, x, ti))
-        @test diff(A; dims=1) == diff(A; dims=Y) == diff(A; dims=:Y) == diff(A; dims=y) == DimArray(zeros(2, 5, 12), (Y(['b', 'c']), x, ti))
-        @test diff(A; dims=2) == diff(A; dims=X) == diff(A; dims=:X) == diff(A; dims=x) == DimArray(zeros(3, 4, 12), (y, X(4:2:10), ti))
-        @test diff(A; dims=3) == diff(A; dims=Ti) == diff(A; dims=:Ti) == diff(A; dims=ti) == DimArray(zeros(3, 5, 11), (y, x, Ti(DateTime(2021, 2):Month(1):DateTime(2021, 12))))
+        ti = Ti(DateTime(2021, 1):Month(1):DateTime(2021, 4))
+        data = [-87  -49  107  -18
+                24   44  -62  124
+                122  -11   48   -7]
+        A = DimArray(data, (y, ti))
+        @test diff(A; dims=1) == diff(A; dims=Y) == diff(A; dims=:Y) == diff(A; dims=y) == DimArray([111 93 -169 142; 98 -55 110 -131], (Y(['b', 'c']), ti))
+        @test diff(A; dims=2) == diff(A; dims=Ti) == diff(A; dims=:Ti) == diff(A; dims=ti) == DimArray([38 156 -125; 20 -106 186; -133 59 -55], (y, Ti(DateTime(2021, 2):Month(1):DateTime(2021, 4))))
         @test_throws MethodError diff(A; dims='X')
         @test_throws ArgumentError diff(A; dims=Z)
-        @test_throws ArgumentError diff(A; dims=4)
+        @test_throws ArgumentError diff(A; dims=3)
     end
     @testset "Vector" begin
-        x = DimArray(1:10, X(2:2:20))
-        @test diff(x) == diff(x; dims=1) == diff(x; dims=X) == DimArray(ones(9), X(4:2:20))
+        x = DimArray([56, -123, -60, -44, -64, 70, 52, -48, -74, 86], X(2:2:20))
+        @test diff(x) == diff(x; dims=1) == diff(x; dims=X) == DimArray([-179, 63, 16, -20, 134, -18, -100, -26, 160], X(4:2:20))
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -93,6 +93,25 @@ end
     @test relation(fda, Y) == ReverseRelation()
 end
 
+@testset "diff" begin
+    @testset "Array 3D" begin
+        x = X(2:2:10)
+        y = Y(['a', 'b', 'c'])
+        ti = Ti(DateTime(2021, 1):Month(1):DateTime(2021, 12))
+        A = DimArray(zeros(3, 5, 12), (y, x, ti))
+        @test diff(A; dims = 1) == diff(A; dims = Y) == diff(A; dims = :Y) == diff(A; dims = y) == DimArray(zeros(2, 5, 12), (Y(['b', 'c']), x, ti))
+        @test diff(A; dims = 2) == diff(A; dims = X) == diff(A; dims = :X) == diff(A; dims = x) == DimArray(zeros(3, 4, 12), (y, X(4:2:10), ti))
+        @test diff(A; dims = 3) == diff(A; dims = Ti) == diff(A; dims = :Ti) == diff(A; dims = ti) == DimArray(zeros(3, 5, 11), (y, x, Ti(DateTime(2021, 2):Month(1):DateTime(2021, 12))))
+        @test_throws MethodError diff(A; dims = 'X')
+        @test_throws ArgumentError diff(A; dims = Z)
+        @test_throws ArgumentError diff(A; dims = 4)
+    end
+    @testset "Vector" begin
+        x = DimArray(1:10, X(2:2:20))
+        @test diff(x) == diff(x; dims = 1) == diff(x; dims = X) == DimArray(ones(9), X(4:2:20))
+    end
+end
+
 @testset "modify" begin
     A = [1 2 3; 4 5 6]
     dimz = (X(10:10:20), Y(300:-100:100))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -99,16 +99,16 @@ end
         y = Y(['a', 'b', 'c'])
         ti = Ti(DateTime(2021, 1):Month(1):DateTime(2021, 12))
         A = DimArray(zeros(3, 5, 12), (y, x, ti))
-        @test diff(A; dims = 1) == diff(A; dims = Y) == diff(A; dims = :Y) == diff(A; dims = y) == DimArray(zeros(2, 5, 12), (Y(['b', 'c']), x, ti))
-        @test diff(A; dims = 2) == diff(A; dims = X) == diff(A; dims = :X) == diff(A; dims = x) == DimArray(zeros(3, 4, 12), (y, X(4:2:10), ti))
-        @test diff(A; dims = 3) == diff(A; dims = Ti) == diff(A; dims = :Ti) == diff(A; dims = ti) == DimArray(zeros(3, 5, 11), (y, x, Ti(DateTime(2021, 2):Month(1):DateTime(2021, 12))))
-        @test_throws MethodError diff(A; dims = 'X')
-        @test_throws ArgumentError diff(A; dims = Z)
-        @test_throws ArgumentError diff(A; dims = 4)
+        @test diff(A; dims=1) == diff(A; dims=Y) == diff(A; dims=:Y) == diff(A; dims=y) == DimArray(zeros(2, 5, 12), (Y(['b', 'c']), x, ti))
+        @test diff(A; dims=2) == diff(A; dims=X) == diff(A; dims=:X) == diff(A; dims=x) == DimArray(zeros(3, 4, 12), (y, X(4:2:10), ti))
+        @test diff(A; dims=3) == diff(A; dims=Ti) == diff(A; dims=:Ti) == diff(A; dims=ti) == DimArray(zeros(3, 5, 11), (y, x, Ti(DateTime(2021, 2):Month(1):DateTime(2021, 12))))
+        @test_throws MethodError diff(A; dims='X')
+        @test_throws ArgumentError diff(A; dims=Z)
+        @test_throws ArgumentError diff(A; dims=4)
     end
     @testset "Vector" begin
         x = DimArray(1:10, X(2:2:20))
-        @test diff(x) == diff(x; dims = 1) == diff(x; dims = X) == DimArray(ones(9), X(4:2:20))
+        @test diff(x) == diff(x; dims=1) == diff(x; dims=X) == DimArray(ones(9), X(4:2:20))
     end
 end
 


### PR DESCRIPTION
This one is tricky: Julia does not allow dispatching on keyword args, so if I define `diff(A::AbstractDimArray; dims::DimOrDimType)`, it overwrites the default `diff(A::AbstractArray; dims::Integer)`. So I have to copy its definition [from base](https://github.com/JuliaLang/julia/blob/539f3ce943f59dec8aff3f2238b083f1b27f41e5/base/multidimensional.jl#L841-L850). Not the most ideal solution but it works.