### PR TITLE
reverse reverses array and index, not relation

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,7 +5,9 @@
 
 Reverse the array order, and update the dim to match.
 """
-Base.reverse(A::AbstractDimArray; dims=1) = reverse(ArrayOrder, A, dims)
+Base.reverse(A::AbstractDimArray; dims=1) =
+    reverse(IndexOrder, reverse(ArrayOrder, A, dims), dims)
+
 Base.reverse(ds::AbstractDimDataset; dims=1) = reverse(ArrayOrder, ds, dims)
 Base.reverse(ot::Type{<:SubOrder}, x; dims) = reverse(ot, x, dims)
 Base.reverse(ot::Type{<:SubOrder}, x, lookup) = set(x, reverse(ot, dims(x, lookup)))
@@ -16,7 +18,7 @@ Base.reverse(ot::Type{<:ArrayOrder}, x, lookup) = begin
 end
 
 _reversedata(A::AbstractDimArray, dimnum) = reverse(parent(A); dims=dimnum)
-_reversedata(ds::AbstractDimDataset, dimnum) = 
+_reversedata(ds::AbstractDimDataset, dimnum) =
     map(a -> reverse(parent(a); dims=dimnum), data(ds))
 
 # Dimension
@@ -30,9 +32,9 @@ Base.reverse(ot::Type{<:IndexOrder}, dim::Dimension{<:Val{Keys}}) where Keys =
 Base.reverse(dim::Dimension) = reverse(IndexOrder, dim)
 
 # Mode
-Base.reverse(ot::Type{<:SubOrder}, mode::IndexMode) = 
+Base.reverse(ot::Type{<:SubOrder}, mode::IndexMode) =
     rebuild(mode; order=reverse(ot, order(mode)))
-Base.reverse(ot::Type{<:SubOrder}, mode::AbstractSampled) = 
+Base.reverse(ot::Type{<:SubOrder}, mode::AbstractSampled) =
     rebuild(mode; order=reverse(ot, order(mode)), span=reverse(ot, span(mode)))
 
 # Order
@@ -50,7 +52,7 @@ Base.reverse(::ForwardArray) = ReverseArray()
 Base.reverse(::ReverseRelation) = ForwardRelation()
 Base.reverse(::ForwardRelation) = ReverseRelation()
 
-# Span 
+# Span
 Base.reverse(::Type{<:IndexOrder}, span::Regular) = reverse(span)
 Base.reverse(::Type{<:SubOrder}, span::Span) = span
 Base.reverse(span::Regular) = Regular(-step(span))
@@ -126,7 +128,7 @@ _reorder(ot::Type{<:IndexOrder}, x, dim::DimOrDimType) =
     ot == basetypeof(order(ot, dim)) ? x : set(x, reverse(ot, dim))
 # If either ArrayOrder or Relation are reversed, we reverse the array
 _reorder(ot::Type{<:Union{ArrayOrder,Relation}}, x, dim::DimOrDimType) =
-    ot == basetypeof(order(ot, dim)) ? x : reverse(x; dims=dim)
+    ot == basetypeof(order(ot, dim)) ? x : reverse(ArrayOrder, x; dims=dim)
 
 
 """

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -194,22 +194,6 @@ end
     @test typeof(dsp) <: DimArray
 end
 
-@testset "reversing methods" begin
-    revdim = reverse(X(10:10:20; mode=Sampled(order=Ordered())))
-    @test val(revdim) == 20:-10:10
-    @test order(revdim) == Ordered(ReverseIndex(), ForwardArray(), ReverseRelation())
-
-    A = [1 2 3; 4 5 6]
-    da = DimArray(A, (X(10:10:20), Y(300:-100:100)))
-    rev = reverse(ArrayOrder, da, Y)
-    @test rev == [3 2 1; 6 5 4] 
-    @test val(rev, X) == 10:10:20
-    @test val(rev, Y) == 300:-100:100
-    @test order(rev, X) == Ordered(ForwardIndex(), ForwardArray(), ForwardRelation())
-    @test order(da, Y) == Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())
-    @test order(rev, Y) == Ordered(ReverseIndex(), ReverseArray(), ReverseRelation())
-end
-
 
 @testset "dimension rotating methods" begin
     @test rottype(-100) == Rot360()

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,21 @@
-using DimensionalData, Test
+using DimensionalData, Test, Dates
 using DimensionalData: flip
 
-@testset "reversing methods" begin
+@testset "reverse" begin
+    revdim = reverse(X(10:10:20; mode=Sampled(order=Ordered())))
+    @test val(revdim) == 20:-10:10
+    @test order(revdim) == Ordered(ReverseIndex(), ForwardArray(), ReverseRelation())
+
+    A = [1 2 3; 4 5 6]
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)))
+    rev = reverse(da; dims=Y)
+    @test rev == [3 2 1; 6 5 4] 
+    @test val(rev, X) == 10:10:20
+    @test val(rev, Y) == 100:100:300
+    @test order(rev, X) == Ordered(ForwardIndex(), ForwardArray(), ForwardRelation())
+    @test order(da, Y)  == Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())
+    @test order(rev, Y) == Ordered(ForwardIndex(), ReverseArray(), ForwardRelation())
+
     revdima = reverse(ArrayOrder, X(10:10:20; mode=Sampled(order=Ordered(), span=Regular(10))))
     @test val(revdima) == 10:10:20
     @test order(revdima) == Ordered(ForwardIndex(), ReverseArray(), ReverseRelation())
@@ -11,7 +25,6 @@ using DimensionalData: flip
     @test order(revdimi) == Ordered(ReverseIndex(), ForwardArray(), ReverseRelation())
     @test span(revdimi) == Regular(-10)
 
-    A = [1 2 3; 4 5 6]
     da = DimArray(A, (X(10:10:20), Y(300:-100:100)), :test)
     ds = DimDataset(da)
 
@@ -42,7 +55,11 @@ using DimensionalData: flip
     @test val(dims(revids, X)) == 10:10:20
     @test val(dims(revids, Y)) == 100:100:300
     @test order(dims(revids, X)) == Ordered(ForwardIndex(), ForwardArray(), ForwardRelation())
+end
 
+@testset "reorder" begin
+    A = [1 2 3; 4 5 6]
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)), :test)
 
     reoa = reorder(da, ReverseArray())
     @test reoa == [6 5 4; 3 2 1]


### PR DESCRIPTION
closes #190

This is a minor breaking change. Indexing etc will still work the same way - but the index will be reversed whenever the array is reversed, instead of just having the `Relation` trait flipped.

`reverse(ArrayOrder, A, dims)` is available for the previous behaviour.