### PR TITLE
Fix typo in `@dim` example

### DIFF
--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -300,7 +300,7 @@ are plotted on the Y axis, `<: XDim` on the X axis, etc.
 
 Example:
 ```julia
-@dim Lat "Lattitude" "lat"
+@dim Lat YDim "latitude"
 @dim Lon XDim "Longitude"
 ```
 """


### PR DESCRIPTION
The old example seemed a bit wrong but maybe I didn't fully understand the `@dim` docstring?