### PR TITLE
Metadata

### DIFF
--- a/docs/src/course.md
+++ b/docs/src/course.md
@@ -71,8 +71,7 @@ with the simple `Ti(range)` syntax like so:
 A[X(1:3:11), Ti(1:2:11)]
 ```
 
-Of course, wh
-specifying only one dimension, all elements of the other
+Of course, when specifying only one dimension, all elements of the other
 dimensions are assumed to be included:
 
 ```@example main

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -51,6 +51,11 @@ export AbstractDimTable, DimTable
 
 export AbstractDimDataset, DimDataset
 
+export Metadata, AbstractArrayMetadata, AbstractDimMetadata, AbstractStackMetadata, 
+       ArrayMetadata, DimMetadata, StackMetadata 
+
+export AbstractName, Name, NoName 
+
 export data, dims, refdims, mode, metadata, name, label, units,
        val, index, order, sampling, span, bounds, locus, <|
 
@@ -65,6 +70,8 @@ const DD = DimensionalData
 
 include("interface.jl")
 include("mode.jl")
+include("metadata.jl")
+include("name.jl")
 include("identify.jl")
 include("dimension.jl")
 include("array.jl")

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -52,7 +52,7 @@ export AbstractDimTable, DimTable
 export AbstractDimDataset, DimDataset
 
 export Metadata, AbstractArrayMetadata, AbstractDimMetadata, AbstractStackMetadata, 
-       ArrayMetadata, DimMetadata, StackMetadata 
+       ArrayMetadata, DimMetadata, StackMetadata, NoMetadata
 
 export AbstractName, Name, NoName 
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -227,11 +227,6 @@ struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDi
     name::Na
     metadata::Me
 end
-# Warn string conversion for compatibility
-DimArray(A::AbstractArray, dims, refdims, name::String, metadata) = begin
-    @warn "The AbstractDimArray name field is now a Symbol"
-    DimArray(A, dims, refdims, Symbol(name), metadata)
-end
 # 2 or 3 arg version
 DimArray(data::AbstractArray, dims, name=NoName(); refdims=(), metadata=nothing) =
     DimArray(data, formatdims(data, dims), refdims, name, metadata)

--- a/src/array.jl
+++ b/src/array.jl
@@ -23,8 +23,6 @@ const AbstractDimMatrix = AbstractDimArray{T,2} where T
 
 const StandardIndices = Union{AbstractVector{<:Integer},Colon,Integer}
 
-
-
 # DimensionalData.jl interface methods ############################################################
 
 # Standard fields
@@ -222,7 +220,7 @@ julia> A[X(Near([12, 35])), Ti(At(DateTime(2001,5)))];
 julia> A[Near(DateTime(2001, 5, 4)), Between(20, 50)];
 ```
 """
-struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na<:Symbol,Me} <: AbstractDimArray{T,N,D,A}
+struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDimArray{T,N,D,A}
     data::A
     dims::D
     refdims::R
@@ -235,10 +233,10 @@ DimArray(A::AbstractArray, dims, refdims, name::String, metadata) = begin
     DimArray(A, dims, refdims, Symbol(name), metadata)
 end
 # 2 or 3 arg version
-DimArray(data::AbstractArray, dims, name=Symbol(""); refdims=(), metadata=nothing) =
+DimArray(data::AbstractArray, dims, name=NoName(); refdims=(), metadata=nothing) =
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
 # All kwargs version
-DimArray(; data, dims, refdims=(), name=Symbol(""), metadata=nothing) =
+DimArray(; data, dims, refdims=(), name=NoName(), metadata=nothing) =
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
 # Construct from another AbstractDimArray
 DimArray(A::AbstractDimArray; dims=dims(A), refdims=refdims(A), 
@@ -253,7 +251,7 @@ Rebuild a `DimArray` with new fields. Handling partial field
 update is dealth with in `rebuild` for `AbstractDimArray`.
 """
 @inline rebuild(A::DimArray, data::AbstractArray, dims::Tuple,
-                refdims::Tuple, name::Symbol, metadata) =
+                refdims::Tuple, name, metadata) =
     DimArray(data, dims, refdims, name, metadata)
 
 """

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -57,13 +57,13 @@ julia> da3 = DimArray(3A, dimz, :three);
 
 
 julia> ds = DimDataset(da1, da2, da3)
-DimDataset{NamedTuple{(:one, :two, :three),Tuple{Array{Float64,2},Array{Float64,2},Array{Float64,2}}},2,Tuple{X{Array{Symbol,1},Categorical{Unordered{ForwardRelation}},Nothing},Y{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},Nothing}},Tuple{},NamedTuple{(:one, :two, :three),Tuple{Nothing,Nothing,Nothing}}}((one = [1.0 2.0 3.0; 4.0 5.0 6.0], two = [2.0 4.0 6.0; 8.0 10.0 12.0], three = [3.0 6.0 9.0; 12.0 15.0 18.0]), (X (type X): Symbol[a, b] (Categorical: Unordered), Y (type Y): 10.0:10.0:30.0 (Sampled: Ordered Regular Points)), (), (one = nothing, two = nothing, three = nothing))
+DimDataset{NamedTuple{(:one, :two, :three),Tuple{Array{Float64,2},Array{Float64,2},Array{Float64,2}}},2,Tuple{X{Array{Symbol,1},Categorical{Unordered{ForwardRelation}},NoMetadata},Y{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},NoMetadata}},Tuple{},NamedTuple{(:one, :two, :three),Tuple{Nothing,Nothing,Nothing}}}((one = [1.0 2.0 3.0; 4.0 5.0 6.0], two = [2.0 4.0 6.0; 8.0 10.0 12.0], three = [3.0 6.0 9.0; 12.0 15.0 18.0]), (X (type X): Symbol[a, b] (Categorical: Unordered), Y (type Y): 10.0:10.0:30.0 (Sampled: Ordered Regular Points)), (), (one = nothing, two = nothing, three = nothing))
 
 julia> ds[:b, 10.0]
 (one = 4.0, two = 8.0, three = 12.0)
 
 julia> ds[X(:a)]
-DimDataset{NamedTuple{(:one, :two, :three),Tuple{Array{Float64,1},Array{Float64,1},Array{Float64,1}}},1,Tuple{Y{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},Nothing}},Tuple{X{Symbol,Categorical{Unordered{ForwardRelation}},Nothing}},NamedTuple{(:one, :two, :three),Tuple{Nothing,Nothing,Nothing}}}((one = [1.0, 2.0, 3.0], two = [2.0, 4.0, 6.0], three = [3.0, 6.0, 9.0]), (Y (type Y): 10.0:10.0:30.0 (Sampled: Ordered Regular Points),), (X (type X): a (Categorical: Unordered),), (one = nothing, two = nothing, three = nothing))
+DimDataset{NamedTuple{(:one, :two, :three),Tuple{Array{Float64,1},Array{Float64,1},Array{Float64,1}}},1,Tuple{Y{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},NoMetadata}},Tuple{X{Symbol,Categorical{Unordered{ForwardRelation}},NoMetadata}},NamedTuple{(:one, :two, :three),Tuple{Nothing,Nothing,Nothing}}}((one = [1.0, 2.0, 3.0], two = [2.0, 4.0, 6.0], three = [3.0, 6.0, 9.0]), (Y (type Y): 10.0:10.0:30.0 (Sampled: Ordered Regular Points),), (X (type X): a (Categorical: Unordered),), (one = nothing, two = nothing, three = nothing))
 ```
 
 """

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -9,12 +9,14 @@ same file type with identical metadata.
 """
 abstract type Metadata{T} end
 
+# NamedTuple constructor
+(::Type{T})(; kwargs...) where T <: Metadata = T((; kwargs...))
+
 struct NoMetadata <: Metadata{NamedTuple{(),Tuple{}}} end
 Base.keys(::NoMetadata) = ()
 Base.length(::NoMetadata) = 0
 # TODO: what else is needed here
 
-(::Type{T})() where T <: Metadata = T(Dict())
 
 val(metadata::Metadata) = metadata.val
 
@@ -26,7 +28,7 @@ Base.iterate(metadata::Metadata, args...) = iterate(val(metadata), args...)
 Base.IteratorSize(::Metadata) = Base.IteratorSize(m)
 Base.IteratorEltype(m::Metadata) = Base.IteratorEltype(m)
 Base.eltype(m::Metadata) = eltype(m)
-Base.length(metadata::Metadata) = length(val(metadata))
+Base.length(m::Metadata) = length(val(m))
 
 
 """
@@ -45,14 +47,17 @@ Abstract supertype for `Metadata` wrappers to be attached to `AbstractGeoStack`.
 abstract type AbstractStackMetadata{T} <: Metadata{T} end
 
 
-struct DimMetadata{T} <: Metadata{T}
+struct DimMetadata{T<:Union{AbstractDict,NamedTuple}} <: Metadata{T}
     val::T
 end
+DimMetadata(p::Pair, ps::Pair...) = DimMetadata(Dict(p, ps...))
 
-struct ArrayMetadata{T} <: Metadata{T} 
+struct ArrayMetadata{T<:Union{AbstractDict,NamedTuple}} <: Metadata{T} 
     val::T
 end
+ArrayMetadata(p::Pair, ps::Pair...) = ArrayMetadata(Dict(p, ps...))
 
-struct StackMetadata{T} <: Metadata{T} 
+struct StackMetadata{T<:Union{AbstractDict,NamedTuple}} <: Metadata{T} 
     val::T
 end
+StackMetadata(p::Pair, ps::Pair...) = StackMetadata(Dict(p, ps...))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,0 +1,58 @@
+
+"""
+Supertype for all metadata wrappers.
+
+These allow tracking the contents and origin of metadata. 
+This can facilitate conversion between metadata types (for saving 
+a file to a differenet format) or simply saving data back to the 
+same file type with identical metadata.
+"""
+abstract type Metadata{T} end
+
+struct NoMetadata <: Metadata{NamedTuple{(),Tuple{}}} end
+Base.keys(::NoMetadata) = ()
+Base.length(::NoMetadata) = 0
+# TODO: what else is needed here
+
+(::Type{T})() where T <: Metadata = T(Dict())
+
+val(metadata::Metadata) = metadata.val
+
+Base.get(metadata::Metadata, args...) = get(val(metadata), args...)
+Base.getindex(metadata::Metadata, args...) = getindex(val(metadata), args...)
+Base.setindex!(metadata::Metadata, args...) = setindex!(val(metadata), args...)
+Base.keys(metadata::Metadata) = keys(val(metadata))
+Base.iterate(metadata::Metadata, args...) = iterate(val(metadata), args...)
+Base.IteratorSize(::Metadata) = Base.IteratorSize(m)
+Base.IteratorEltype(m::Metadata) = Base.IteratorEltype(m)
+Base.eltype(m::Metadata) = eltype(m)
+Base.length(metadata::Metadata) = length(val(metadata))
+
+
+"""
+Abstract supertype for `Metadata` wrappers to be attached to `Dimension`s.
+"""
+abstract type AbstractDimMetadata{T} <: Metadata{T} end
+
+"""
+Abstract supertype for `Metadata` wrappers to be attached to `AbstractGeoArrays`.
+"""
+abstract type AbstractArrayMetadata{T} <: Metadata{T} end
+
+"""
+Abstract supertype for `Metadata` wrappers to be attached to `AbstractGeoStack`.
+"""
+abstract type AbstractStackMetadata{T} <: Metadata{T} end
+
+
+struct DimMetadata{T} <: Metadata{T}
+    val::T
+end
+
+struct ArrayMetadata{T} <: Metadata{T} 
+    val::T
+end
+
+struct StackMetadata{T} <: Metadata{T} 
+    val::T
+end

--- a/src/name.jl
+++ b/src/name.jl
@@ -1,10 +1,13 @@
 
 abstract type AbstractName end
 
-struct NoName <: AbstractName end
 struct Name{X} <: AbstractName end
+Name(name::Symbol) = Name{name}()
 
-Base.string(::Name{X}) where X = string(X)
-Base.string(::NoName) = ""
 Base.Symbol(::Name{X}) where X = X
+Base.string(::Name{X}) where X = string(X)
+
+struct NoName <: AbstractName end
+
+Base.string(::NoName) = ""
 Base.Symbol(::NoName) = Symbol("")

--- a/src/name.jl
+++ b/src/name.jl
@@ -1,0 +1,10 @@
+
+abstract type AbstractName end
+
+struct NoName <: AbstractName end
+struct Name{X} <: AbstractName end
+
+Base.string(::Name{X}) where X = string(X)
+Base.string(::NoName) = ""
+Base.Symbol(::Name{X}) where X = X
+Base.Symbol(::NoName) = Symbol("")

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -152,7 +152,7 @@ A[X(Between(15, 25)), Y(Between(4, 6.5))]
 
 # output
 
-DimArray with dimensions:
+DimArray (named NoName()) with dimensions:
  X (type X): 20:10:20 (Sampled: Ordered Regular Points)
  Y (type Y): 5:6 (Sampled: Ordered Regular Points)
 and data: 1×2 Array{Int64,2}
@@ -180,7 +180,7 @@ A[X(Where(x -> x > 15)), Y(Where(x -> x in (19, 21)))]
 
 # output
 
-DimArray with dimensions:
+DimArray (named NoName()) with dimensions:
  X (type X): Int64[20] (Sampled: Ordered Regular Points)
  Y (type Y): Int64[19, 21] (Sampled: Ordered Regular Points)
 and data: 1×2 Array{Int64,2}

--- a/src/set.jl
+++ b/src/set.jl
@@ -80,6 +80,9 @@ values. Dimension fields not assigned a value will be ignored, and the orginals 
 set(A::Union{AbstractDimArray,AbstractDimDataset}, args::Union{Dimension,DimTuple,Pair}...; kwargs...) =
     rebuild(A, data(A), _set(dims(A), args...; kwargs...))
 
+
+_set(dim::Union{AbstractDimArray,AbstractDimDataset}, ::Type{T}) where T = _set(dim, T())
+
 # Array
 
 """
@@ -96,15 +99,15 @@ end
 """
     set(A::AbstractDimArray, metadata::AbstractDict) => AbstractDimArray
 
-AbstractDicts are always metadata, and update the `metadata` field of the array.
+Update the `metadata` field of the array.
 """
-set(A::AbstractDimArray, metadata::AbstractDict) = rebuild(A; metadata=metadata)
+set(A::AbstractDimArray, metadata::ArrayMetadata) = rebuild(A; metadata=metadata)
 """
     set(A::AbstractDimArray, metadata::AbstractDict) => AbstractDimArray
 
 Symbols are always names, and update the `name` field of the array.
 """
-set(A::AbstractDimArray, name::Symbol) = rebuild(A; name=name)
+set(A::AbstractDimArray, name::Union{Symbol,AbstractName}) = rebuild(A; name=name)
 
 # Dataset
 
@@ -228,6 +231,7 @@ _set(mode::IndexMode, newmode::NoIndex) = newmode
 # Order
 _set(mode::IndexMode, neworder::Order) =
     rebuild(mode; order=_set(order(mode), neworder))
+_set(mode::NoIndex, neworder::Order) = mode
 
 _set(order::Union{Ordered,Unordered}, neworder::Ordered) = begin
     index = _set(indexorder(order), indexorder(neworder)) 
@@ -285,10 +289,9 @@ _set(sampling::Intervals, locus::Locus) = Intervals(locus)
 _set(sampling::Intervals, locus::AutoLocus) = sampling
 
 
-# Metadata: TODO: implement metadata types
-_set(dim::Dimension, newmetadata::AbstractDict) = 
+_set(dim::Dimension, newmetadata::Metadata) = 
     rebuild(dim, val(dim), mode(dim), _set(metadata(dim), newmetadata))
-_set(metadata::AbstractDict, newmetadata::AbstractDict) = newmetadata
+_set(metadata::Metadata, newmetadata::Metadata) = newmetadata
 
 _set(x, ::Nothing) = x
 _set(::Nothing, x) = x

--- a/src/set.jl
+++ b/src/set.jl
@@ -5,19 +5,19 @@ Set the field matching the supertypes of values in xs and return a new object.
 As DimensionalData is so strongly typed you do not need to specify what field
 to `set` - there is no ambiguity.
 
-To set fields of dimensions you need to specify the dimension. This can be done using 
-`Dimension => x` pairs, `X = x` keyword arguments, `Dimension` wrapped arguments, 
+To set fields of dimensions you need to specify the dimension. This can be done using
+`Dimension => x` pairs, `X = x` keyword arguments, `Dimension` wrapped arguments,
 or a `NamedTuple`.
 
-When dimensions or IndexModes are passed to `set` to replace the existing ones, 
+When dimensions or IndexModes are passed to `set` to replace the existing ones,
 fields that are not set will keep their original values.
 
 ## Notes:
 
-Changing the dimension index range will set the `Sampled` mode 
-component `Regular` with a new step size, and set the dimension order. 
+Changing the dimension index range will set the `Sampled` mode
+component `Regular` with a new step size, and set the dimension order.
 
-Setting [`Order`](@ref) will *not* reverse the array or dimension to match. Use 
+Setting [`Order`](@ref) will *not* reverse the array or dimension to match. Use
 [`reverse`](@ref) and [`reorder`](@ref) to do this.
 
 
@@ -53,43 +53,37 @@ set(da, custom=Ordered(array=Reverse()), Z=Unordered())
 """
 function set end
 
+const DimArrayOrDataset = Union{AbstractDimArray,AbstractDimDataset}
 
-@noinline set(A::Union{AbstractDimArray,AbstractDimDataset}, name::T) where {T<:Union{Mode,ModeComponent}} =  
-    throw(ArgumentError("Can only set $(typeof(T)) for a dimension. Specify which dimension you want to set it for"))
-@noinline set(A, x) = _cantset(A, x)
-@noinline _set(A, x) = _cantset(A, x)
-
-_cantset(a, b) = throw(ArgumentError("Can not set any fields of $a to $b"))
-
-@noinline _axiserr(a, b) = 
-    throw(ArgumentError("passed in axes $(axes(b)) do not match the currect axes $(axes(a))"))
+set(A::DimArrayOrDataset, name::T) where {T<:Union{Mode,ModeComponent}} = _onlydimerror(T)
+set(A, x) = _cantseterror(A, x)
+_set(A, x) = _cantseterror(A, x)
 
 """
     set(x, args::Pairs...) => x with updated field/s
-    set(x, args...; kwargs...) => x with updated field/s
-    set(x, args::Tuple{Vararg{<:Dimension}}; kwargs...) => x with updated field/s
+    set(x, args...; kw...) => x with updated field/s
+    set(x, args::Tuple{Vararg{<:Dimension}}; kw...) => x with updated field/s
 
-Set the dimensions or any properties of the dimensions for `AbstractDimArray` 
+Set the dimensions or any properties of the dimensions for `AbstractDimArray`
 or `AbstractDimDataset`.
 
-Set can be passed Keyword arguments or arguments of Pairs using dimension names, 
+Set can be passed Keyword arguments or arguments of Pairs using dimension names,
 tuples of values wrapped in the intended dimensions. Or fully or partially
-constructed dimensions with val, mode or metadata fields set to intended 
+constructed dimensions with val, mode or metadata fields set to intended
 values. Dimension fields not assigned a value will be ignored, and the orginals kept.
 """
-set(A::Union{AbstractDimArray,AbstractDimDataset}, args::Union{Dimension,DimTuple,Pair}...; kwargs...) =
-    rebuild(A, data(A), _set(dims(A), args...; kwargs...))
+set(A::DimArrayOrDataset, args::Union{Dimension,DimTuple,Pair}...; kw...) =
+    rebuild(A, data(A), _set(dims(A), args...; kw...))
 
-
-_set(dim::Union{AbstractDimArray,AbstractDimDataset}, ::Type{T}) where T = _set(dim, T())
+_set(dim::DimArrayOrDataset, ::Type{T}) where T = _set(dim, T())
 
 # Array
 
 """
-    set(A::AbstractDimArray, metadata::AbstractDict) => AbstractDimArray
+    set(A::AbstractDimArray, data::AbstractArray) => AbstractDimArray
 
 `AbstractArray` is always data, and update the `data` field of the array.
-This is what is returned by `parent(A)`. It must be the same size as the 
+This is what is returned by `parent(A)`. It must be the same size as the
 original value to match the `Dimension`s in the dims field.
 """
 set(A::AbstractDimArray, newdata::AbstractArray) = begin
@@ -97,13 +91,14 @@ set(A::AbstractDimArray, newdata::AbstractArray) = begin
     rebuild(A; data=newdata)
 end
 """
-    set(A::AbstractDimArray, metadata::AbstractDict) => AbstractDimArray
+    set(A::AbstractDimArray, metadata::ArrayMetadata) => AbstractDimArray
 
 Update the `metadata` field of the array.
 """
-set(A::AbstractDimArray, metadata::ArrayMetadata) = rebuild(A; metadata=metadata)
+set(A::AbstractDimArray, metadata::Union{ArrayMetadata,NoMetadata}) = 
+    rebuild(A; metadata=metadata)
 """
-    set(A::AbstractDimArray, metadata::AbstractDict) => AbstractDimArray
+    set(A::AbstractDimArray, metadata::DimMetadata) => AbstractDimArray
 
 Symbols are always names, and update the `name` field of the array.
 """
@@ -115,7 +110,7 @@ set(A::AbstractDimArray, name::Union{Symbol,AbstractName}) = rebuild(A; name=nam
     set(ds::AbstractDimDataset, data::NamedTuple) => AbstractDimDataset
 
 `NamedTuple`s are always data, and update the `data` field of the dataset.
-The values must be `AbstractArray of the same size as the original data, to 
+The values must be `AbstractArray of the same size as the original data, to
 match the `Dimension`s in the dims field.
 """
 set(ds::AbstractDimDataset, newdata::NamedTuple) = begin
@@ -125,27 +120,29 @@ set(ds::AbstractDimDataset, newdata::NamedTuple) = begin
     rebuild(ds; data=newdata)
 end
 """
-    set(ds::AbstractDimDataset, metadata::AbstractDict) => AbstractDimDataset
+    set(ds::AbstractDimDataset, metadata::Union{StackMetadata,NoMetadata}) => AbstractDimDataset
 
-AbstractDicts are always metadata, and update the `metadata` field of the dataset.
+StackMetadata update the `metadata` field of the dataset.
 """
-set(ds::AbstractDimDataset, metadata::AbstractDict) = rebuild(ds; metadata=metadata)
+set(ds::AbstractDimDataset, metadata::Union{StackMetadata,NoMetadata}) = 
+    rebuild(ds; metadata=metadata)
+
+
+const InDims = Union{DimMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
 
 """
     set(dim::Dimension, index::Unioon{AbstractArray,Val}) => Dimension
     set(dim::Dimension, mode::Mode) => Dimension
     set(dim::Dimension, modecomponent::ModeComponent) => Dimension
-    set(dim::Dimension, metadata::AbstractDict) => Dimension
+    set(dim::Dimension, metadata::DimMetadata) => Dimension
 
 Set fields of the dimension
 """
-set(dim::Dimension, x::Union{AbstractArray,Val,Mode,ModeComponent,AbstractDict}) = 
-    _set(dim, x)
+set(dim::Dimension, x::InDims) = _set(dim, x)
 
 
 # Convert args/kwargs to dims and set
-_set(dims_::DimTuple, args::Dimension...; kwargs...) =
-    _set(dims_, (args..., _kwargdims(kwargs)...))
+_set(dims_::DimTuple, args::Dimension...; kw...) = _set(dims_, (args..., _kwargdims(kw)...))
 # Convert pairs to wrapped dims and set
 _set(dims_::DimTuple, p::Pair, ps::Vararg{<:Pair}) = _set(dims_, (p, ps...))
 _set(dims_::DimTuple, ps::Tuple{Vararg{<:Pair}}) = _set(dims_, _pairdims(ps...))
@@ -153,21 +150,18 @@ _set(dims_::DimTuple, ps::Tuple{Vararg{<:Pair}}) = _set(dims_, _pairdims(ps...))
 # Set dims with (possibly unsorted) wrapper vals
 _set(dims::DimTuple, wrappers::DimTuple) = begin
     # Check the dimension types match
-    map(wrappers) do w 
+    map(wrappers) do w
         hasdim(dims, w) || _wrongdimserr(dims, w)
     end
     # Missing dims return `nothing` from sortdims
     newdims = map(_set, dims, sortdims(wrappers, dims))
-    # Swaps existing dims with non-nothing new dims 
+    # Swaps existing dims with non-nothing new dims
     swapdims(dims, newdims)
 end
 
-@noinline _wrongdimserr(dims, w) = 
-    throw(ArgumentError("dim $(basetypeof(w))) not in $(map(basetypeof, dims))"))
 
 # Set things wrapped in dims
-_set(dim::Dimension, wrapper::Dimension{<:Union{AbstractDict,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}}) = 
-    _set(dim::Dimension, val(wrapper))
+_set(dim::Dimension, wrapper::Dimension{<:InDims}) = _set(dim::Dimension, val(wrapper))
 
 # Set the index
 _set(dim::Dimension, index::Val) = rebuild(dim; val=index)
@@ -181,7 +175,7 @@ _set(dim::Dimension, index::Colon) = dim
 
 _set(mode::IndexMode, dim::Dimension, index::AbstractRange) = rebuild(dim; val=index)
 # Update the Sampling mode of Sampled dims - it must match the range.
-_set(mode::AbstractSampled, dim::Dimension, index::AbstractRange) = 
+_set(mode::AbstractSampled, dim::Dimension, index::AbstractRange) =
     rebuild(dim; val=index, mode=_set(mode, Regular(step(index))))
 
 # Set the dim, checking the mode
@@ -229,14 +223,13 @@ _set(mode::IndexMode, newmode::NoIndex) = newmode
 
 
 # Order
-_set(mode::IndexMode, neworder::Order) =
-    rebuild(mode; order=_set(order(mode), neworder))
+_set(mode::IndexMode, neworder::Order) = rebuild(mode; order=_set(order(mode), neworder))
 _set(mode::NoIndex, neworder::Order) = mode
 
 _set(order::Union{Ordered,Unordered}, neworder::Ordered) = begin
-    index = _set(indexorder(order), indexorder(neworder)) 
-    array = _set(arrayorder(order), arrayorder(neworder)) 
-    rel = _set(relation(order), relation(neworder)) 
+    index = _set(indexorder(order), indexorder(neworder))
+    array = _set(arrayorder(order), arrayorder(neworder))
+    rel = _set(relation(order), relation(neworder))
     Ordered(index, array, rel)
 end
 _set(order::Union{Ordered,Unordered}, neworder::Unordered) =
@@ -283,16 +276,21 @@ _set(sampling::Sampling, newsampling::AutoSampling) = sampling
 _set(mode::AbstractSampled, locus::Locus) =
     rebuild(mode; sampling=_set(sampling(mode), locus))
 _set(sampling::Points, locus::Union{AutoLocus,Center}) = Points()
-@noinline _set(sampling::Points, locus::Locus) =
-    throw(ArgumentError("Can't set a locus for `Points` sampling other than `Center` - the index values are the exact points"))
+_set(sampling::Points, locus::Locus) = _locuserror()
 _set(sampling::Intervals, locus::Locus) = Intervals(locus)
 _set(sampling::Intervals, locus::AutoLocus) = sampling
 
 
-_set(dim::Dimension, newmetadata::Metadata) = 
-    rebuild(dim, val(dim), mode(dim), _set(metadata(dim), newmetadata))
-_set(metadata::Metadata, newmetadata::Metadata) = newmetadata
+_set(dim::Dimension, newmetadata::Union{DimMetadata,NoMetadata}) =
+    rebuild(dim, val(dim), mode(dim), newmetadata)
 
 _set(x, ::Nothing) = x
 _set(::Nothing, x) = x
 _set(::Nothing, ::Nothing) = nothing
+
+
+@noinline _locuserror() = throw(ArgumentError("Can't set a locus for `Points` sampling other than `Center` - the index values are the exact points"))
+@noinline _cantseterror(a, b) = throw(ArgumentError("Can not set any fields of $a to $b"))
+@noinline _onlydimerror(T) = throw(ArgumentError("Can only set $(typeof(T)) for a dimension. Specify which dimension you want to set it for"))
+@noinline _axiserr(a, b) = throw(ArgumentError("passed in axes $(axes(b)) do not match the currect axes $(axes(a))"))
+@noinline _wrongdimserr(dims, w) = throw(ArgumentError("dim $(basetypeof(w))) not in $(map(basetypeof, dims))"))

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -4,8 +4,8 @@ using DimensionalData: slicedims, basetypeof, formatdims, modetype
 @dim TestDim "Testname"
 
 @testset "dims creation macro" begin
-    @test TestDim(1:10, Sampled()) == TestDim(1:10, Sampled(), nothing)
-    @test TestDim(1:10; mode=Categorical()) == TestDim(1:10, Categorical(), nothing)
+    @test TestDim(1:10, Sampled(), NoMetadata()) == TestDim(1:10, Sampled(), NoMetadata())
+    @test TestDim(1:10; mode=Categorical()) == TestDim(1:10, Categorical(), NoMetadata())
     @test DimensionalData.name(TestDim) == :Testname
     @test label(TestDim) == "Testname"
     @test val(TestDim(:testval)) == :testval
@@ -36,26 +36,26 @@ end
 
 @testset "formatdims" begin
     A = [1 2 3; 4 5 6]
-    @test formatdims(A, (X, Y)) == (X(Base.OneTo(2), NoIndex(), nothing),
-                                    Y(Base.OneTo(3), NoIndex(), nothing))
-    @test formatdims(zeros(3), Ti) == (Ti(Base.OneTo(3), NoIndex(), nothing),)
-    @test formatdims(A, (:a, :b)) == (Dim{:a}(Base.OneTo(2), NoIndex(), nothing),
-                                      Dim{:b}(Base.OneTo(3), NoIndex(), nothing))
-    @test formatdims(51:100, :c) == (Dim{:c}(Base.OneTo(50), NoIndex(), nothing),)
+    @test formatdims(A, (X, Y)) == (X(Base.OneTo(2), NoIndex(), NoMetadata()),
+                                    Y(Base.OneTo(3), NoIndex(), NoMetadata()))
+    @test formatdims(zeros(3), Ti) == (Ti(Base.OneTo(3), NoIndex(), NoMetadata()),)
+    @test formatdims(A, (:a, :b)) == (Dim{:a}(Base.OneTo(2), NoIndex(), NoMetadata()),
+                                      Dim{:b}(Base.OneTo(3), NoIndex(), NoMetadata()))
+    @test formatdims(51:100, :c) == (Dim{:c}(Base.OneTo(50), NoIndex(), NoMetadata()),)
     @test formatdims(A, (a=[:A, :B], b=(10.0:10.0:30.0))) ==
-        (Dim{:a}([:A, :B], Categorical(Unordered()), nothing),
-         Dim{:b}(10.0:10:30.0, Sampled(Ordered(), Regular(10.0), Points()), nothing))
+    (Dim{:a}([:A, :B], Categorical(Unordered()), NoMetadata()),
+     Dim{:b}(10.0:10:30.0, Sampled(Ordered(), Regular(10.0), Points()), NoMetadata()))
     @test formatdims(A, (X([:A, :B]; metadata=5),
-                   Y(10.0:10.0:30.0, Categorical(Ordered()), Dict("metadata"=>1)))) ==
+           Y(10.0:10.0:30.0, Categorical(Ordered()), Dict("metadata"=>1)))) ==
           (X([:A, :B], Categorical(Unordered()), 5),
-          Y(10.0:10:30.0, Categorical(Ordered()), Dict("metadata"=>1)))
+           Y(10.0:10:30.0, Categorical(Ordered()), Dict("metadata"=>1)))
     @test formatdims(zeros(3, 4), 
-       (Dim{:row}(Val((:A, :B, :C))), 
-        Dim{:column}(Val((-20, -10, 0, 10)), Sampled(), nothing))) ==
-       (Dim{:row}(Val((:A, :B, :C)), Categorical(), nothing), 
-        Dim{:column}(Val((-20, -10, 0, 10)), Sampled(Ordered(),Irregular(),Points()), nothing))
+        (Dim{:row}(Val((:A, :B, :C))), 
+         Dim{:column}(Val((-20, -10, 0, 10)), Sampled(), NoMetadata()))) ==
+        (Dim{:row}(Val((:A, :B, :C)), Categorical(), NoMetadata()), 
+         Dim{:column}(Val((-20, -10, 0, 10)), Sampled(Ordered(),Irregular(),Points()), NoMetadata()))
     @test formatdims(A, (X(:, Sampled(Ordered(), Regular(), Points())), Y)) == 
-        (X(Base.OneTo(2), Sampled(Ordered(), Regular(1), Points()), nothing), Y(Base.OneTo(3), NoIndex(), nothing))
+        (X(Base.OneTo(2), Sampled(Ordered(), Regular(1), Points()), NoMetadata()), Y(Base.OneTo(3), NoIndex(), NoMetadata()))
 end
 
 @testset "Basic dim and array initialisation and methods" begin
@@ -96,7 +96,7 @@ end
 @testset "arbitrary dim names and Val index" begin
     dimz = formatdims(zeros(3, 4),
            (Dim{:row}(Val((:A, :B, :C))), 
-            Dim{:column}(Val((-20, -10, 0, 10)), Sampled(Ordered(),Regular(10),Points()), nothing))
+            Dim{:column}(Val((-20, -10, 0, 10)), Sampled(Ordered(),Regular(10),Points()), NoMetadata()))
     )
     @test name(dimz) == (:row, :column)
     @test label(dimz) == ("row", "column")

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -35,22 +35,22 @@ end
     @test minimum(da; dims=1) == [1 2]
     @test minimum(da; dims=Y()) == [1 3]'
     @test dims(minimum(da; dims=X())) ==
-        (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), nothing),
-         Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing))
+        (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()),
+         Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()))
 
     @test sum(da; dims=X()) == sum(a; dims=1)
     @test sum(da; dims=Y()) == sum(a; dims=2)
     @test dims(sum(da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()))
     @test sum(da; dims=:) == 10
     @test sum(x -> 2x, da; dims=:) == 20
 
     @test prod(da; dims=X) == [3 8]
     @test prod(da; dims=2) == [2 12]'
     resultdimz =
-        (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), nothing),
-         Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing))
+        (X([144.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()),
+         Y(LinRange(-38.0, -36.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()))
     @test typeof(dims(prod(da; dims=X()))) == typeof(resultdimz)
     @test bounds(dims(prod(da; dims=X()))) == bounds(resultdimz)
 
@@ -63,8 +63,8 @@ end
     @test mean(x -> 2x, da; dims=(1, 2)) == [5.0]'
     @test mean(x -> 2x, da; dims=(:X, :Y)) == [5.0]'
     @test dims(mean(da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()))
 
 
     @test mapreduce(x -> x > 3, +, da; dims=X) == [0 1]
@@ -72,15 +72,15 @@ end
     @test mapreduce(x -> x > 3, +, da; dims=(:X, :Y)) == [1]'
     @test mapreduce(x -> x > 3, +, da; dims=(1, 2)) == [1]'
     @test dims(mapreduce(x-> x > 3, +, da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()))
 
     @test reduce(+, da) == reduce(+, a)
     @test reduce(+, da; dims=X) == [4 6]
     @test reduce(+, da; dims=(X, Y())) == [10]'
     @test dims(reduce(+, da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()))
 
     @test std(da) === std(a)
     @test std(da; dims=1) == [1.4142135623730951 1.4142135623730951]
@@ -89,8 +89,8 @@ end
     @test var(da; dims=1) == [2.0 2.0]
     @test var(da; dims=Y()) == [0.5 0.5]'
     @test dims(var(da; dims=Y())) ==
-        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), nothing),
-         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), nothing))
+        (X(LinRange(143.0, 145.0, 2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),
+         Y([-37.0], Sampled(Ordered(), Regular(4.0), Points()), NoMetadata()))
 
     @test extrema(da; dims=Y) == permutedims([(1, 2) (3, 4)])
     @test extrema(da; dims=X) == [(1, 3) (2, 4)]

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -32,11 +32,11 @@ dimz = dims(da)
 @testset "slicedims" begin
     @testset "Regular" begin
         @test slicedims(dimz, (1:2, 3)) == 
-            ((X(LinRange(143,145,2), Sampled(Ordered(), Regular(2.0), Points()), nothing),),
-             (Y(-36.0, Sampled(Ordered(), Regular(1.0), Points()), nothing),))
+            ((X(LinRange(143,145,2), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()),),
+             (Y(-36.0, Sampled(Ordered(), Regular(1.0), Points()), NoMetadata()),))
         @test slicedims(dimz, (2:2, :)) == 
-            ((X(LinRange(145,145,1), Sampled(Ordered(), Regular(2.0), Points()), nothing), 
-              Y(LinRange(-38.0,-36.0, 3), Sampled(Ordered(), Regular(1.0), Points()), nothing)), ())
+            ((X(LinRange(145,145,1), Sampled(Ordered(), Regular(2.0), Points()), NoMetadata()), 
+              Y(LinRange(-38.0,-36.0, 3), Sampled(Ordered(), Regular(1.0), Points()), NoMetadata())), ())
         @test slicedims((), (1:2, 3)) == ((), ())
     end
     @testset "Irregular" begin
@@ -44,32 +44,32 @@ dimz = dims(da)
                                      Y([10.0, 20.0, 40.0]; mode=Sampled(Ordered(), Irregular(0.0, 60.0), Intervals(Center()))), ))
         irreg_dimz = dims(irreg)
         @test slicedims(irreg, (1:2, 3)) == 
-            ((X([140.0, 142.0], Sampled(Ordered(), Irregular(140.0, 144.0), Intervals(Start())), nothing),),
-                    (Y(40.0, Sampled(Ordered(), Irregular(30.0, 60.0), Intervals(Center())), nothing),))
+            ((X([140.0, 142.0], Sampled(Ordered(), Irregular(140.0, 144.0), Intervals(Start())), NoMetadata()),),
+                    (Y(40.0, Sampled(Ordered(), Irregular(30.0, 60.0), Intervals(Center())), NoMetadata()),))
         @test slicedims(irreg, (2:2, 1:2)) == 
-            ((X([142.0], Sampled(Ordered(), Irregular(142.0, 144.0), Intervals(Start())), nothing), 
-              Y([10.0, 20.0], Sampled(Ordered(), Irregular(0.0, 30.0), Intervals(Center())), nothing)), ())
+            ((X([142.0], Sampled(Ordered(), Irregular(142.0, 144.0), Intervals(Start())), NoMetadata()), 
+              Y([10.0, 20.0], Sampled(Ordered(), Irregular(0.0, 30.0), Intervals(Center())), NoMetadata())), ())
         @test slicedims((), (1:2, 3)) == ((), ())
     end
     @testset "Val index" begin
         da = DimArray(a, (X(Val((143, 145))), Y(Val((:x, :y, :z)))))
         dimz = dims(da)
         @test slicedims(dimz, (1:2, 3)) == 
-            ((X(Val((143,145)), Categorical(), nothing),),
-             (Y(Val(:z), Categorical(), nothing),))
+            ((X(Val((143,145)), Categorical(), NoMetadata()),),
+             (Y(Val(:z), Categorical(), NoMetadata()),))
         @test slicedims(dimz, (2:2, :)) == 
-            ((X(Val((145,)), Categorical(), nothing), 
-              Y(Val((:x, :y, :z)), Categorical(), nothing)), ())
+            ((X(Val((145,)), Categorical(), NoMetadata()), 
+              Y(Val((:x, :y, :z)), Categorical(), NoMetadata())), ())
     end
     @testset "NoIndex" begin
         da = DimArray(a, (X(Val((143, 145))), Y(Val((:x, :y, :z)))))
         dimz = dims(da)
         @test slicedims(dimz, (1:2, 3)) == 
-            ((X(Val((143,145)), Categorical(), nothing),),
-             (Y(Val(:z), Categorical(), nothing),))
+            ((X(Val((143,145)), Categorical(), NoMetadata()),),
+             (Y(Val(:z), Categorical(), NoMetadata()),))
         @test slicedims(dimz, (2:2, :)) == 
-            ((X(Val((145,)), Categorical(), nothing), 
-              Y(Val((:x, :y, :z)), Categorical(), nothing)), ())
+            ((X(Val((145,)), Categorical(), NoMetadata()), 
+              Y(Val((:x, :y, :z)), Categorical(), NoMetadata())), ())
     end
 
     @testset "No slicing" begin
@@ -121,30 +121,30 @@ end
 @testset "reducedims" begin
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Regular(1), Points())), 
                       Y(1:5; mode=Sampled(Ordered(), Regular(1), Points()))), (X, Y)) == 
-                     (X([4], Sampled(Ordered(), Regular(2), Points()), nothing), 
-                      Y([3], Sampled(Ordered(), Regular(5), Points()), nothing))
+                     (X([4], Sampled(Ordered(), Regular(2), Points()), NoMetadata()), 
+                      Y([3], Sampled(Ordered(), Regular(5), Points()), NoMetadata()))
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Regular(1), Intervals(Start()))), 
                       Y(1:5; mode=Sampled(Ordered(), Regular(1), Intervals(End())))), (X, Y)) ==
-        (X([3], Sampled(Ordered(), Regular(2), Intervals(Start())), nothing), 
-         Y([5], Sampled(Ordered(), Regular(5), Intervals(End())), nothing))
+        (X([3], Sampled(Ordered(), Regular(2), Intervals(Start())), NoMetadata()), 
+         Y([5], Sampled(Ordered(), Regular(5), Intervals(End())), NoMetadata()))
 
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Irregular(2.5, 4.5), Intervals(Center()))),
                       Y(1:5; mode=Sampled(Ordered(), Irregular(0.5, 5.5), Intervals(Center())))), (X, Y))[1] ==
-                     (X([4], Sampled(Ordered(), Irregular(2.5, 4.5), Intervals(Center())), nothing),
-                      Y([3], Sampled(Ordered(), Irregular(0.5, 5.5), Intervals(Center())), nothing))[1]
+                     (X([4], Sampled(Ordered(), Irregular(2.5, 4.5), Intervals(Center())), NoMetadata()),
+                      Y([3], Sampled(Ordered(), Irregular(0.5, 5.5), Intervals(Center())), NoMetadata()))[1]
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Irregular(3, 5), Intervals(Start()))),
                       Y(1:5; mode=Sampled(Ordered(), Irregular(0, 5), Intervals(End()  )))), (X, Y))[1] ==
-                     (X([3], Sampled(Ordered(), Irregular(3, 5), Intervals(Start())), nothing),
-                      Y([5], Sampled(Ordered(), Irregular(0, 5), Intervals(End()  )), nothing))[1]
+                     (X([3], Sampled(Ordered(), Irregular(3, 5), Intervals(Start())), NoMetadata()),
+                      Y([5], Sampled(Ordered(), Irregular(0, 5), Intervals(End()  )), NoMetadata()))[1]
 
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Irregular(), Points())), 
                       Y(1:5; mode=Sampled(Ordered(), Irregular(), Points()))), (X, Y)) ==
-        (X([4], Sampled(Ordered(), Irregular(), Points()), nothing), 
-         Y([3], Sampled(Ordered(), Irregular(), Points()), nothing))
+        (X([4], Sampled(Ordered(), Irregular(), Points()), NoMetadata()), 
+         Y([3], Sampled(Ordered(), Irregular(), Points()), NoMetadata()))
     @test reducedims((X(3:4; mode=Sampled(Ordered(), Regular(1), Points())), 
                       Y(1:5; mode=Sampled(Ordered(), Regular(1), Points()))), (X, Y)) ==
-                     (X([4], Sampled(Ordered(), Regular(2), Points()), nothing), 
-                      Y([3], Sampled(Ordered(), Regular(5), Points()), nothing))
+                     (X([4], Sampled(Ordered(), Regular(2), Points()), NoMetadata()), 
+                      Y([3], Sampled(Ordered(), Regular(5), Points()), NoMetadata()))
 
     @test reducedims((X([:a,:b]; mode=Categorical()), 
                       Y(["1","2","3","4","5"]; mode=Categorical())), (X, Y)) ==
@@ -166,9 +166,9 @@ end
     @testset "with Dim{X} and symbols" begin
         A = DimArray(zeros(4, 5), (:one, :two))
         @test dims(A) == 
-            (Dim{:one}(Base.OneTo(4), NoIndex(), nothing), 
-             Dim{:two}(Base.OneTo(5), NoIndex(), nothing))
-        @test dims(A, :two) == Dim{:two}(Base.OneTo(5), NoIndex(), nothing)
+            (Dim{:one}(Base.OneTo(4), NoIndex(), NoMetadata()), 
+             Dim{:two}(Base.OneTo(5), NoIndex(), NoMetadata()))
+        @test dims(A, :two) == Dim{:two}(Base.OneTo(5), NoIndex(), NoMetadata())
     end
     @test_throws ArgumentError dims(da, Ti)
     @test_throws ArgumentError dims(dimz, Ti)
@@ -179,8 +179,8 @@ end
     @test dims(dimz, Y) === dimz[2]
     @test dims(dimz, Y) === dimz[2]
     @test typeof(dims(da)) ==
-        Tuple{X{LinRange{Float64},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},Nothing},
-              Y{LinRange{Float64},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},Nothing}}
+        Tuple{X{LinRange{Float64},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},NoMetadata},
+              Y{LinRange{Float64},Sampled{Ordered{ForwardIndex,ForwardArray,ForwardRelation},Regular{Float64},Points},NoMetadata}}
 end
 
 @testset "commondims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,8 +26,6 @@ if Sys.islinux()
     # Maybe ram use of all the plots on the small CI machine? idk
     include("plotrecipes.jl")
 end
-
-# Test documentation
 if VERSION >= v"1.5.0"
     docsetup = quote
         using DimensionalData, Random

--- a/test/set.jl
+++ b/test/set.jl
@@ -16,6 +16,8 @@ ds = DimDataset(da2, DimArray(2a2, dimz2, :test3))
 
 @testset " Array fields" begin
     @test name(set(da2, :newname)) == :newname
+    @test name(set(da2, Name(:newname))) == Name{:newname}()
+    @test name(set(da2, NoName())) == NoName()
     @test metadata(set(da2, ArrayMetadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
     @test parent(set(da2, fill(9, 3, 4))) == fill(9, 3, 4)
     # A differently sized array can't be set

--- a/test/set.jl
+++ b/test/set.jl
@@ -1,8 +1,8 @@
 using DimensionalData, Test
 
 a = [1 2; 3 4]
-dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "X")),
-        Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=Dict(:meta => "Y")))
+dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=DimMetadata(Dict(:meta => "X"))),
+        Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=DimMetadata(Dict(:meta => "Y"))))
 da = DimArray(a, dimz, :test)
 
 a2 = [1 2 3 4
@@ -16,7 +16,7 @@ ds = DimDataset(da2, DimArray(2a2, dimz2, :test3))
 
 @testset " Array fields" begin
     @test name(set(da2, :newname)) == :newname
-    @test metadata(set(da2, Dict(:testa => "test"))) == Dict(:testa => "test")
+    @test metadata(set(da2, ArrayMetadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
     @test parent(set(da2, fill(9, 3, 4))) == fill(9, 3, 4)
     # A differently sized array can't be set
     @test_throws ArgumentError parent( set(da2, [9 9; 9 9])) == [9 9; 9 9]
@@ -26,7 +26,7 @@ end
     ds2 = set(ds, (x=a2, y=3a2))
     @test keys(ds2) == (:x, :y)
     @test values(ds2) == (a2, 3a2)
-    @test metadata(set(ds, Dict(:testa => "test"))) == Dict(:testa => "test")
+    @test metadata(set(ds, StackMetadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
 end
 
 @testset "DimDataset Dimension" begin
@@ -94,27 +94,26 @@ end
 
 
 @testset "metadata" begin
-    @test metadata(set(X(), Dict(:a=>1, :b=>2))) == Dict(:a=>1, :b=>2)
-    dax = set(da, X(Dict(:a=>1, :b=>2)))
-    @test metadata(dims(dax), X) == Dict(:a=>1, :b=>2)
-    @test metadata(dims(dax), Y) == Dict(:meta => "Y") 
-    dax = set(da, X(; metadata=Dict(:a=>1, :b=>2)))
-    @test metadata(dims(dax, X)) == Dict(:a=>1, :b=>2)
-
-    dax = set(da2, row=Dict(:a=>1, :b=>2))
-    @test metadata(dims(dax, :row)) == Dict(:a=>1, :b=>2)
-    dax = set(da2, column=Dict(:a=>1, :b=>2))
-    @test metadata(dims(dax, :column)) == Dict(:a=>1, :b=>2)
+    @test metadata(set(X(), DimMetadata(Dict(:a=>1, :b=>2)))).val == Dict(:a=>1, :b=>2)
+    dax = set(da, X(DimMetadata(Dict(:a=>1, :b=>2))))
+    @test metadata(dims(dax), X).val == Dict(:a=>1, :b=>2)
+    @test metadata(dims(dax), Y).val == Dict(:meta => "Y") 
+    dax = set(da, X(; metadata=DimMetadata(Dict(:a=>1, :b=>2))))
+    @test metadata(dims(dax, X)).val == Dict(:a=>1, :b=>2)
+    dax = set(da2, row=DimMetadata(Dict(:a=>1, :b=>2)))
+    @test metadata(dims(dax, :row)).val == Dict(:a=>1, :b=>2)
+    dax = set(da2, column=DimMetadata(Dict(:a=>1, :b=>2)))
+    @test metadata(dims(dax, :column)).val == Dict(:a=>1, :b=>2)
 end
 
 @testset "all dim fields" begin
-    dax = set(da, X(20:-10:10; mode=Sampled(), metadata=Dict(:a=>1, :b=>2)))
+    dax = set(da, X(20:-10:10; mode=Sampled(), metadata=DimMetadata(Dict(:a=>1, :b=>2))))
     x = dims(dax, X)
     @test val(x) == 20:-10:10
     @test order(x) == Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())
     @test span(x) == Regular(-10)
     @test mode(x) == Sampled(Ordered(ReverseIndex(), ForwardArray(), ForwardRelation()), Regular(-10), Points())
-    @test metadata(x) == Dict(:a=>1, :b=>2) 
+    @test metadata(x).val == Dict(:a=>1, :b=>2) 
 end
 
 @testset "errors with set" begin


### PR DESCRIPTION
Add `Metadata` and `Name` types.

This helps with `set` to remove metadata or names, and will also help with `adapt` for GPU as we can dispatch on the metadata types and replace them with `NoMetadata` as strings aren't allowed, and replace `:name` with `Name{:name}`.