### PR TITLE
Print the length of each dimension

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -67,6 +67,7 @@ printdimproperties(io, dim) = begin
         _printdimval(io, val(dim))
     end
     print(io, " (", mode(dim), ")")
+    print(io, " (length ", length(dim), ")")
 end
 
 _printdimval(io, A::AbstractArray) = printlimited(io, A)


### PR DESCRIPTION
Looks something like this now:

```
julia> A = DimArray(rand(3, 5, 3), (X, Y(5:5:25), Z([1.1, 2.5, 3.9])))
DimArray with dimensions:
 X (type X) (NoIndex) (length 3)
 Y (type Y): 5:5:25 (Sampled: Ordered Regular Points) (length 5)
 Z (type Z): Float64[1.1, 2.5, 3.9] (Sampled: Ordered Irregular Points) (length 3)
and data: 3×5×3 Array{Float64,3}
[:, :, 1]
 0.905982   0.319636  0.909655  0.90895   0.778717
 0.0381998  0.631785  0.450077  0.668797  0.104157
 0.441726   0.719826  0.264105  0.775776  0.566153
[and 2 more slices...]
```

Might be kinda redundant here since it also prints `3×5×3 Array{Float64,3}` but printing dimension lengths would be nice for GeoData.jl.

Resolves #206 