### PR TITLE
add Adapt.jl and adapt_stucture methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
 version = "0.15.1"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+Adapt = "2"
 ConstructionBase = "1"
 RecipesBase = "0.7, 0.8, 1"
 Tables = "1"

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -10,7 +10,8 @@ end DimensionalData
 using Base.Broadcast: Broadcasted, BroadcastStyle, DefaultArrayStyle, AbstractArrayStyle, 
       Unknown
 
-using ConstructionBase, 
+using Adapt,
+      ConstructionBase, 
       Dates,
       LinearAlgebra, 
       RecipesBase, 

--- a/src/array.jl
+++ b/src/array.jl
@@ -110,6 +110,12 @@ Base.copy!(dst::AbstractDimArray{T,1}, src::AbstractArray{T,1}) where T = copy!(
 Base.copy!(dst::AbstractArray{T,1}, src::AbstractDimArray{T,1}) where T = copy!(dst, parent(src))
 Base.copy!(dst::AbstractDimArray{T,1}, src::AbstractDimArray{T,1}) where T = copy!(parent(dst), parent(src))
 
+function Adapt.adapt_structure(to, A::AbstractDimArray) 
+    fields = map((parent(A), dims(A), refdims(A), mode(A))) do x
+        adapt(to, x) 
+    end
+    rebuild(A, fields..., Name(name(A)), NoMetadata()) 
+end
 
 # Concrete implementation ######################################################
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -120,6 +120,8 @@ month, hour, second etc., not the central point as is more common with spatial d
 abstract type TimeDim{T,Mo,Me} <: IndependentDim{T,Mo,Me} end
 
 ConstructionBase.constructorof(d::Type{<:Dimension}) = basetypeof(d)
+Adapt.adapt_structure(to, dim::Dimension) = 
+    rebuild(dim, adapt(to, val(dim)), adapt(to, mode(dim)), adapt(to, metadata(dim)))
 
 const DimType = Type{<:Dimension}
 const DimTuple = Tuple{<:Dimension,Vararg{<:Dimension}}

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -126,6 +126,8 @@ rebuild(s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s), metadata=me
 rebuildsliced(s::AbstractDimStack, data, I) =
     rebuild(s, data, slicedims(s, I)...)
 
+Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> adapt(to, A), s)
+
 # Dipatch on Tuple of Dimension, and map
 for func in (:index, :mode, :metadata, :sampling, :span, :bounds, :locus, :order)
     @eval ($func)(s::AbstractDimStack, args...) = ($func)(dims(s), args...)


### PR DESCRIPTION
Adds methods to convert `AbstractDimArray` for use on GPU as an argument to a kernel. Note that there are still some cases of dynamic dispatch that we need to track down to make this entirely usable.