### PR TITLE
Syntax overhaul

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -7,22 +7,22 @@ module DimensionalData
     read(path, String)
 end DimensionalData
 
-using Base.Broadcast: Broadcasted, BroadcastStyle, DefaultArrayStyle, AbstractArrayStyle, 
+using Base.Broadcast: Broadcasted, BroadcastStyle, DefaultArrayStyle, AbstractArrayStyle,
       Unknown
 
 using Adapt,
-      ConstructionBase, 
+      ConstructionBase,
       Dates,
-      LinearAlgebra, 
-      RecipesBase, 
-      Statistics, 
+      LinearAlgebra,
+      RecipesBase,
+      Statistics,
       SparseArrays,
       Tables
 
 using Base: tail, OneTo, @propagate_inbounds
 
 
-export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim, 
+export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim,
        X, Y, Z, Ti, ParametricDimension, Dim, AnonDim
 
 export Selector, At, Between, Contains, Near, Where
@@ -41,8 +41,7 @@ export Span, Regular, Irregular, AutoSpan
 
 export Mode, IndexMode, Auto, AutoMode, NoIndex
 
-export Aligned, AbstractSampled, Sampled,
-       AbstractCategorical, Categorical
+export Aligned, AbstractSampled, Sampled, AbstractCategorical, Categorical
 
 export Unaligned, Transformed
 
@@ -52,15 +51,15 @@ export AbstractDimTable, DimTable
 
 export AbstractDimStack, DimStack
 
-export Metadata, AbstractArrayMetadata, AbstractDimMetadata, AbstractStackMetadata, 
+export Metadata, AbstractArrayMetadata, AbstractDimMetadata, AbstractStackMetadata,
        ArrayMetadata, DimMetadata, StackMetadata, NoMetadata
 
-export AbstractName, Name, NoName 
+export AbstractName, Name, NoName
 
 export data, dims, refdims, mode, metadata, name, label, units,
        val, index, order, sampling, span, bounds, locus, <|
 
-export dimnum, hasdim, otherdims, commondims, setdims, swapdims, sortdims, 
+export dimnum, hasdim, otherdims, commondims, setdims, swapdims, sortdims,
        set, rebuild, reorder, modify, dimwise, dimwise!
 
 export order, indexorder, arrayorder, relation

--- a/src/identify.jl
+++ b/src/identify.jl
@@ -2,23 +2,21 @@
 """
     identify(indexmode, index)
 
-Identify an `IndexMode` and its fields from the index content 
+Identify an `IndexMode` and its fields from the index content
 and the existing `IndexMode`.
 
 These methods guess which mode is most appropriate, encoding information
 about the index in types that can later be used for dispatch. They also let
 you fill in part of the information you need to specify, and guess the rest.
 
-An example of the usefulness of identifying index traits up-front is if we 
+An example of the usefulness of identifying index traits up-front is if we
 check that the index is ordered, we can be sure it remains ordered
 unless it is indexed with a `Vector`. This means we will always use the
 correct `searchsorted` method for it.
 """
 function identify end
-
 # No more identification required for some types
 identify(mode::IndexMode, dimtype::Type, index) = mode
-
 # Auto
 identify(mode::Auto, dimtype::Type, index::AbstractArray) =
     identify(Sampled(), dimtype, index)
@@ -26,19 +24,43 @@ identify(mode::Auto, dimtype::Type, index::AbstractArray{<:CategoricalEltypes}) 
     order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))
 identify(mode::Auto, dimtype::Type, index::Val) =
     order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))
-
 # Sampled
-identify(mode::AbstractSampled, dimtype::Type, index) = begin
-    mode = rebuild(mode;
+identify(mode::AbstractSampled, dimtype::Type, index) =
+    rebuild(mode;
         order=identify(order(mode), dimtype, index),
         span=identify(span(mode), dimtype, index),
         sampling=identify(sampling(mode), dimtype, index)
     )
-end
-
-# Order
 identify(order::Order, dimtype::Type, index) = order
 identify(order::AutoOrder, dimtype::Type, index) = _orderof(index)
+# Spant
+identify(span::AutoSpan, dimtype::Type, index::Union{AbstractArray,Val}) = Irregular()
+identify(span::AutoSpan, dimtype::Type, index::AbstractRange) = Regular(step(index))
+identify(span::Regular{AutoStep}, dimtype::Type, index::Union{AbstractArray,Val}) = _arraynosteperror()
+identify(span::Regular, dimtype::Type, index::Union{AbstractArray,Val}) = span
+identify(span::Regular{AutoStep}, dimtype::Type, index::AbstractRange) = Regular(step(index))
+identify(span::Regular, dimtype::Type, index::AbstractRange) = begin
+    step(span) isa Number && !(step(span) ≈ step(index)) && _steperror(index, span)
+    span
+end
+identify(span::Irregular{Nothing}, dimtype, index) =
+    if length(index) > 1
+        bound1 = index[1] - (index[2] - index[1]) / 2
+        bound2 = index[end] + (index[end] - index[end-1]) / 2
+        Irregular(sortbounds(bound1, bound2))
+    else
+        Irregular(nothing, nothing)
+    end
+identify(span::Irregular{<:Tuple}, dimtype, index) = span
+# Sampling
+identify(sampling::AutoSampling, dimtype::Type, index) = Points()
+identify(sampling::Points, dimtype::Type, index) = sampling
+identify(sampling::Intervals, dimtype::Type, index) =
+    rebuild(sampling, identify(locus(sampling), dimtype, index))
+# Locus
+identify(locus::AutoLocus, dimtype::Type, index) = Center()
+identify(locus::Locus, dimtype::Type, index) = locus
+
 
 _orderof(index::AbstractUnitRange) = Ordered()
 _orderof(index::AbstractRange) = Ordered(index=_indexorder(index))
@@ -46,7 +68,7 @@ _orderof(index::Val) = _detectorder(unwrap(index))
 _orderof(index::AbstractArray) = _detectorder(index)
 
 function _detectorder(index)
-    local sorted, indord 
+    local sorted, indord
     # This is awful. But we don't know if we can
     # call `issorted` on the contents of `index`.
     # This may be resolved by: https://github.com/JuliaLang/julia/pull/37239
@@ -59,37 +81,9 @@ function _detectorder(index)
     sorted ? Ordered(index=indord) : Unordered()
 end
 
-_indexorder(index) =
-    first(index) <= last(index) ? ForwardIndex() : ReverseIndex()
+_indexorder(index) = first(index) <= last(index) ? ForwardIndex() : ReverseIndex()
 
-# Span
-identify(span::AutoSpan, dimtype::Type, index::Union{AbstractArray,Val}) = Irregular()
-identify(span::AutoSpan, dimtype::Type, index::AbstractRange) = Regular(step(index))
-identify(span::Regular{AutoStep}, dimtype::Type, index::Union{AbstractArray,Val}) =
+@noinline _steperror(index, span) =
+    throw(ArgumentError("mode step $(step(span)) does not match index step $(step(index))"))
+@noinline _arraynosteperror() =
     throw(ArgumentError("`Regular` must specify `step` size with an index other than `AbstractRange`"))
-identify(span::Regular, dimtype::Type, index::Union{AbstractArray,Val}) = span
-identify(span::Regular{AutoStep}, dimtype::Type, index::AbstractRange) = Regular(step(index))
-identify(span::Regular, dimtype::Type, index::AbstractRange) = begin
-    step(span) isa Number && !(step(span) ≈ step(index)) && 
-        throw(ArgumentError("mode step $(step(span)) does not match index step $(step(index))"))
-    span
-end
-identify(span::Irregular{Nothing}, dimtype, index) =
-    if length(index) > 1
-        bound1 = index[1] - (index[2] - index[1]) / 2
-        bound2 = index[end] + (index[end] - index[end-1]) / 2
-        Irregular(sortbounds(bound1, bound2))
-    else
-        Irregular(nothing, nothing)
-    end
-identify(span::Irregular{<:Tuple}, dimtype, index) = span
-
-# Sampling
-identify(sampling::AutoSampling, dimtype::Type, index) = Points()
-identify(sampling::Points, dimtype::Type, index) = sampling
-identify(sampling::Intervals, dimtype::Type, index) =
-    rebuild(sampling, identify(locus(sampling), dimtype, index))
-
-# Locus
-identify(locus::AutoLocus, dimtype::Type, index) = Center()
-identify(locus::Locus, dimtype::Type, index) = locus

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,11 +2,11 @@
 
 """
     rebuild(x, args...)
-    rebuild(x; kwargs...)
+    rebuild(x; kw...)
 
-Rebuild an object struct with updated field values. 
+Rebuild an object struct with updated field values.
 
-This is an abstraction that alows inbuilt and custom types to be rebuilt 
+This is an abstraction that alows inbuilt and custom types to be rebuilt
 functionally to update them, as most objects in DimensionalData are immutable.
 
 `x` can be a `AbstractDimArray`, a `Dimension`, `IndexMode` or other custom types.
@@ -14,14 +14,14 @@ functionally to update them, as most objects in DimensionalData are immutable.
 The arguments reuired are defined for the abstract type that has a `rebuild` method.
 """
 function rebuild end
-rebuild(x; kwargs...) = ConstructionBase.setproperties(x, (;kwargs...))
+rebuild(x; kw...) = ConstructionBase.setproperties(x, (; kw...))
 
 """
     dims(x) => Tuple{Vararg{<:Dimension}}
     dims(x, dims::Tuple) => Tuple{Vararg{<:Dimension}}
     dims(x, dim) => Dimension
 
-Return a tuple of `Dimension`s for an object, in the order that matches 
+Return a tuple of `Dimension`s for an object, in the order that matches
 the axes or columns etc. of the underlying data.
 
 `dims` can be `Dimension`, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
@@ -40,7 +40,7 @@ array with more dimensions.
 
 `slicedims(a, dims)` returns a tuple containing the current new dimensions
 and the new reference dimensions. Refdims can be stored in a field or disgarded,
-as it is mostly to give context to plots. Ignoring refdims will simply leave some 
+as it is mostly to give context to plots. Ignoring refdims will simply leave some
 captions empty.
 
 The default is to return an empty `Tuple` `()`.
@@ -65,9 +65,9 @@ function val end
     index(dim::Dimension{<:AbstractArray}) => AbstractArray
     index(dims::NTuple{N}) => Tuple{Vararg{Union{AbstractArray,Tuple},N}}
 
-Return the contained index of a `Dimension`. 
+Return the contained index of a `Dimension`.
 
-Only valid when a `Dimension` contains an `AbstractArray` 
+Only valid when a `Dimension` contains an `AbstractArray`
 or a Val tuple like `Val{(:a, :b)}()`. The `Val` is unwrapped
 to return just the `Tuple`
 
@@ -76,12 +76,12 @@ to return just the `Tuple`
 function index end
 
 """
-    mode(dim:Dimension) => IndexMode 
+    mode(dim:Dimension) => IndexMode
     mode(dims::Tuple) => Tuple{Vararg{<:IndexMode,N}}
     mode(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
 Returns the [`IndexMode`](@ref) of a dimension. This dictates
-properties of the dimension such as array axis and index order, 
+properties of the dimension such as array axis and index order,
 and sampling properties.
 
 `dims` can be a `Dimension`, a dimension type, or a tuple of either.
@@ -95,7 +95,7 @@ function mode end
     metadata(A::AbstractDimArray) => (Array metadata)
 
 Returns the metadata for an array or the specified dimension(s).
-`dims` can be a `Symbol` (with `Dim{X}`, a `Dimension`, a `Dimension` type, 
+`dims` can be a `Symbol` (with `Dim{X}`, a `Dimension`, a `Dimension` type,
 or a mixed tuple.
 
 `dims` can be a `Dimension`, a dimension type, or a tuple of either.
@@ -136,7 +136,7 @@ name(x::Type) = ""
 Get the units of an array or `Dimension`, or a tuple of of either.
 
 Units do not have a set field, and may or may not be included in `metadata`.
-This method is to facilitate use in labels and plots when units are available, 
+This method is to facilitate use in labels and plots when units are available,
 not a guarantee that they will be. If not available, `nothing` is returned.
 
 `dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
@@ -159,7 +159,7 @@ label(x) = string(string(name(x)), (units(x) === nothing ? "" : string(" ", unit
 
 
 """
-    order(dim:Dimension) => Order 
+    order(dim:Dimension) => Order
     order(dims::Tuple) => Tuple{Vararg{<:Order,N}}
     order(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
@@ -170,7 +170,7 @@ Return the [`Order`](@ref) for each dimension.
 function order end
 
 """
-    sampling(dim:Dimension) => Sampling 
+    sampling(dim:Dimension) => Sampling
     sampling(dims::Tuple) => Tuple{Vararg{<:Sampling,N}}
     sampling(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
@@ -181,7 +181,7 @@ Return the [`Sampling`](@ref) for each dimension.
 function sampling end
 
 """
-    span(dim:Dimension) => Span 
+    span(dim:Dimension) => Span
     span(dims::Tuple) => Tuple{Vararg{<:Span,N}}
     span(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
@@ -192,7 +192,7 @@ Return the [`Span`](@ref) for each dimension.
 function span end
 
 """
-    locus(dim:Dimension) => Locus 
+    locus(dim:Dimension) => Locus
     locus(dims::Tuple) => Tuple{Vararg{<:Locus,N}}
     locus(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
@@ -207,7 +207,7 @@ function locus end
     arrayorder(dims::Tuple) => Tuple{Vararg{<:Union{Forward,Reverse},N}}
     arrayorder(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
-Return the [`Order`](@ref) (`Forward` or `Reverse`) of the array, 
+Return the [`Order`](@ref) (`Forward` or `Reverse`) of the array,
 for each dimension.
 
 `dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
@@ -220,7 +220,7 @@ arrayorder(args...) = order(ArrayOrder, args...)
     indexorder(dims::Tuple) => Tuple{Vararg{<:Union{Forward,Reverse},N}}
     indexorder(A::AbstractDimArray, [dims::Tuple]) => Tuple
 
-Return the [`Order`](@ref) (`Forward` or `Reverse`) of the dimension index, 
+Return the [`Order`](@ref) (`Forward` or `Reverse`) of the dimension index,
 for each dimension.
 
 `dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1,14 +1,14 @@
 using LinearAlgebra: AbstractTriangular, AbstractRotation
 
-Base.:*(A::AbstractDimVector, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::AbstractVector) = rebuildmul(A, B)
-Base.:*(A::AbstractDimVector, B::AbstractMatrix) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::AbstractMatrix) = rebuildmul(A, B)
-Base.:*(A::AbstractMatrix, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::AbstractVector, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::AbstractMatrix, B::AbstractDimMatrix) = rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::AbstractVector) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::AbstractMatrix) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::AbstractMatrix) = _rebuildmul(A, B)
+Base.:*(A::AbstractMatrix, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::AbstractVector, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::AbstractMatrix, B::AbstractDimMatrix) = _rebuildmul(A, B)
 
 # Copied from symmetric.jl
 const AdjTransVec = Union{Transpose{<:Any,<:AbstractVector},Adjoint{<:Any,<:AbstractVector}}
@@ -17,57 +17,58 @@ const RealHermSymComplexHerm{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, 
 const RealHermSymComplexSym{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, Symmetric{Complex{T},S}}
 
 # Ambiguities
-Base.:*(A::AbstractDimMatrix, B::Diagonal) = rebuildmul(A, B)
-Base.:*(A::AbstractDimVector, B::Adjoint{T,<:AbstractRotation}) where T = rebuildmul(A, B)
-Base.:*(A::AbstractDimVector, B::Adjoint{<:Any,<:AbstractMatrix}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimVector, B::AdjTransVec) = rebuildmul(A, B)
-Base.:*(A::AbstractDimVector, B::Transpose{<:Any,<:AbstractMatrix}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:RealHermSymComplexHerm}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:AbstractRotation}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:AbstractTriangular}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::Transpose{<:Any,<:AbstractTriangular}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::Transpose{<:Any,<:RealHermSymComplexSym}) = rebuildmul(A, B)
-Base.:*(A::AbstractDimMatrix, B::AbstractTriangular) = rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Diagonal) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::Adjoint{T,<:AbstractRotation}) where T = _rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::Adjoint{<:Any,<:AbstractMatrix}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::AdjTransVec) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimVector, B::Transpose{<:Any,<:AbstractMatrix}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:RealHermSymComplexHerm}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:AbstractRotation}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Adjoint{<:Any,<:AbstractTriangular}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Transpose{<:Any,<:AbstractTriangular}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::Transpose{<:Any,<:RealHermSymComplexSym}) = _rebuildmul(A, B)
+Base.:*(A::AbstractDimMatrix, B::AbstractTriangular) = _rebuildmul(A, B)
 
-Base.:*(A::Diagonal, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Diagonal, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:AbstractTriangular}, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:AbstractTriangular}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:AbstractVector}, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Real,<:AbstractVector}, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:AbstractVector}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:AbstractMatrix{T}}, B::AbstractDimArray{S,1}) where {T,S} = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:RealHermSymComplexSym}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Transpose{<:Any,<:RealHermSymComplexSym}, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::AbstractTriangular, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::AbstractTriangular, B::AbstractDimMatrix) = rebuildmul(A, B)
+Base.:*(A::Diagonal, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Diagonal, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:AbstractTriangular}, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:AbstractTriangular}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:AbstractVector}, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Real,<:AbstractVector}, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:AbstractVector}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:AbstractMatrix{T}}, B::AbstractDimArray{S,1}) where {T,S} = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:RealHermSymComplexSym}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Transpose{<:Any,<:RealHermSymComplexSym}, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::AbstractTriangular, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::AbstractTriangular, B::AbstractDimMatrix) = _rebuildmul(A, B)
 
-Base.:*(A::Adjoint{<:Any,<:AbstractTriangular}, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Any,<:AbstractVector}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Any,<:RealHermSymComplexHerm}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Any,<:AbstractTriangular}, B::AbstractDimMatrix) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Number,<:AbstractVector}, B::AbstractDimVector{<:Number}) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Any,<:AbstractMatrix{T}}, B::AbstractDimArray{S,1}) where {T,S} = rebuildmul(A, B)
-Base.:*(A::Adjoint{T,<:AbstractRotation}, B::AbstractDimMatrix) where T = rebuildmul(A, B)
-Base.:*(A::AdjTransVec, B::AbstractDimVector) = rebuildmul(A, B)
-Base.:*(A::Adjoint{<:Any,<:RealHermSymComplexHerm}, B::AbstractDimVector) = rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:AbstractTriangular}, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:AbstractVector}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:RealHermSymComplexHerm}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:AbstractTriangular}, B::AbstractDimMatrix) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Number,<:AbstractVector}, B::AbstractDimVector{<:Number}) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:AbstractMatrix{T}}, B::AbstractDimArray{S,1}) where {T,S} = _rebuildmul(A, B)
+Base.:*(A::Adjoint{T,<:AbstractRotation}, B::AbstractDimMatrix) where T = _rebuildmul(A, B)
+Base.:*(A::AdjTransVec, B::AbstractDimVector) = _rebuildmul(A, B)
+Base.:*(A::Adjoint{<:Any,<:RealHermSymComplexHerm}, B::AbstractDimVector) = _rebuildmul(A, B)
 
 
-rebuildmul(A::AbstractDimVector, B::AbstractDimMatrix) = begin
+function _rebuildmul(A::AbstractDimVector, B::AbstractDimMatrix)
     # Vector has no dim 2 to compare
     rebuild(A, parent(A) * parent(B), (first(dims(A)), last(dims(B)),))
 end
-rebuildmul(A::AbstractDimMatrix, B::AbstractDimVector) = begin
+function _rebuildmul(A::AbstractDimMatrix, B::AbstractDimVector)
     comparedims(last(dims(A)), first(dims(B)))
     rebuild(A, parent(A) * parent(B), (first(dims(A)),))
 end
-rebuildmul(A::AbstractDimMatrix, B::AbstractDimMatrix) = begin
+function _rebuildmul(A::AbstractDimMatrix, B::AbstractDimMatrix)
     comparedims(last(dims(A)), first(dims(B)))
     rebuild(A, parent(A) * parent(B), (first(dims(A)), last(dims(B))))
 end
-rebuildmul(A::AbstractDimVector, B::AbstractMatrix) =
+function _rebuildmul(A::AbstractDimVector, B::AbstractMatrix)
     rebuild(A, parent(A) * B, (first(dims(A)), AnonDim(Base.OneTo(size(B, 2)))))
-rebuildmul(A::AbstractDimMatrix, B::AbstractVector) = begin
+end
+function _rebuildmul(A::AbstractDimMatrix, B::AbstractVector)
     newdata = parent(A) * B
     if newdata isa AbstractArray
         rebuild(A, parent(A) * B, (first(dims(A)),))
@@ -75,11 +76,13 @@ rebuildmul(A::AbstractDimMatrix, B::AbstractVector) = begin
         newdata
     end
 end
-rebuildmul(A::AbstractDimMatrix, B::AbstractMatrix) =
+function _rebuildmul(A::AbstractDimMatrix, B::AbstractMatrix)
     rebuild(A, parent(A) * B, (first(dims(A)), AnonDim(Base.OneTo(size(B, 2)))))
-rebuildmul(A::AbstractVector, B::AbstractDimMatrix) =
+end
+function _rebuildmul(A::AbstractVector, B::AbstractDimMatrix)
     rebuild(B, A * parent(B), (AnonDim(Base.OneTo(size(A, 1))), last(dims(B))))
-rebuildmul(A::AbstractMatrix, B::AbstractDimVector) = begin
+end
+function _rebuildmul(A::AbstractMatrix, B::AbstractDimVector)
     newdata = A * parent(B)
     if newdata isa AbstractArray
         rebuild(B, A * parent(B), (AnonDim(Base.OneTo(1)),))
@@ -87,5 +90,6 @@ rebuildmul(A::AbstractMatrix, B::AbstractDimVector) = begin
         newdata
     end
 end
-rebuildmul(A::AbstractMatrix, B::AbstractDimMatrix) =
+function _rebuildmul(A::AbstractMatrix, B::AbstractDimMatrix)
     rebuild(B, A * parent(B), (AnonDim(Base.OneTo(size(A, 1))), last(dims(B))))
+end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -94,7 +94,6 @@ Base.haskey(::NoMetadata, args...) = false
 Base.get(::NoMetadata, key, fallback) = fallback
 Base.length(::NoMetadata) = 0
 
-
 # Metadata utils
 
 function metadatadict(dict)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1,75 +1,70 @@
 # Array info
-for (mod, fname) in ((:Base, :size), (:Base, :axes), (:Base, :firstindex), (:Base, :lastindex))
+for (m, f) in ((:Base, :size), (:Base, :axes), (:Base, :firstindex), (:Base, :lastindex))
     @eval begin
-        @inline ($mod.$fname)(A::AbstractDimArray, dims::AllDims) =
-            ($mod.$fname)(A, dimnum(A, dims))
+        @inline $m.$f(A::AbstractDimArray, dims::AllDims) = $m.$f(A, dimnum(A, dims))
     end
 end
 
 # Reducing methods
 
 # With a function arg version
-for (mod, fname) in ((:Base, :sum), (:Base, :prod), (:Base, :maximum), (:Base, :minimum), 
+for (m, f) in ((:Base, :sum), (:Base, :prod), (:Base, :maximum), (:Base, :minimum), 
                      (:Base, :extrema), (:Statistics, :mean))
-    _fname = Symbol('_', fname)
+    _f = Symbol('_', f)
     @eval begin
         # Base methods
-        ($mod.$fname)(A::AbstractDimArray; dims=:, kw...) =
-            ($_fname)(A::AbstractDimArray, dims; kw...)
-        ($mod.$fname)(f, A::AbstractDimArray; dims=:, kw...) =
-            ($_fname)(f, A::AbstractDimArray, dims; kw...)
+        $m.$f(A::AbstractDimArray; dims=:, kw...) = $_f(A::AbstractDimArray, dims; kw...)
+        $m.$f(f, A::AbstractDimArray; dims=:, kw...) =
+            $_f(f, A::AbstractDimArray, dims; kw...)
         # Local dispatch methods
         # - Return a reduced DimArray
-        ($_fname)(A::AbstractDimArray, dims; kw...) =
-            rebuild(A, ($mod.$fname)(parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
-        ($_fname)(f, A::AbstractDimArray, dims; kw...) =
-            rebuild(A, ($mod.$fname)(f, parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
+        $_f(A::AbstractDimArray, dims; kw...) =
+            rebuild(A, $m.$f(parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
+        $_f(f, A::AbstractDimArray, dims; kw...) =
+            rebuild(A, $m.$f(f, parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
         # - Return a scalar
-        ($_fname)(A::AbstractDimArray, dims::Colon; kw...) = 
-            ($mod.$fname)(parent(A); kw...)
-        ($_fname)(f, A::AbstractDimArray, dims::Colon; kw...) =
-            ($mod.$fname)(f, parent(A); dims=dims, kw...)
+        $_f(A::AbstractDimArray, dims::Colon; kw...) = $m.$f(parent(A); kw...)
+        $_f(f, A::AbstractDimArray, dims::Colon; kw...) =
+            $m.$f(f, parent(A); dims=dims, kw...)
     end
 end
-
 # With no function arg version
-for (mod, fname) in ((:Statistics, :std), (:Statistics, :var))
-    _fname = Symbol('_', fname)
+for (m, f) in ((:Statistics, :std), (:Statistics, :var))
+    _f = Symbol('_', f)
     @eval begin
         # Base methods
-        ($mod.$fname)(A::AbstractDimArray; corrected::Bool=true, mean=nothing, dims=:) =
-            ($_fname)(A, corrected, mean, dims)
-        # Local dispatch methods
-        # - Returns a reduced array
-        ($_fname)(A::AbstractDimArray, corrected, mean, dims) =
-            rebuild(A, ($mod.$fname)(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, dims)), reducedims(A, dims))
+        $m.$f(A::AbstractDimArray; corrected::Bool=true, mean=nothing, dims=:) =
+            $_f(A, corrected, mean, dims)
+        # Local dispatch methods - Returns a reduced array
+        $_f(A::AbstractDimArray, corrected, mean, dims) =
+            rebuild(A, $m.$f(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, dims)), reducedims(A, dims))
         # - Returns a scalar
-        ($_fname)(A::AbstractDimArray, corrected, mean, dims::Colon) =
-            ($mod.$fname)(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, dims))
+        $_f(A::AbstractDimArray, corrected, mean, dims::Colon) =
+            $m.$f(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, dims))
     end
 end
-for (mod, fname) in ((:Statistics, :median), (:Base, :any), (:Base, :all))
-    _fname = Symbol('_', fname)
+for (m, f) in ((:Statistics, :median), (:Base, :any), (:Base, :all))
+    _f = Symbol('_', f)
     @eval begin
         # Base methods
-        ($mod.$fname)(A::AbstractDimArray; dims=:) = ($_fname)(A, dims)
-        # Local dispatch methods
-        # - Returns a reduced array
-        ($_fname)(A::AbstractDimArray, dims) =
-            rebuild(A, ($mod.$fname)(parent(A); dims=dimnum(A, dims)), reducedims(A, dims))
+        $m.$f(A::AbstractDimArray; dims=:) = $_f(A, dims)
+        # Local dispatch methods - Returns a reduced array
+        $_f(A::AbstractDimArray, dims) =
+            rebuild(A, $m.$f(parent(A); dims=dimnum(A, dims)), reducedims(A, dims))
         # - Returns a scalar
-        ($_fname)(A::AbstractDimArray, dims::Colon) =
-            ($mod.$fname)(parent(A); dims=dimnum(A, dims))
+        $_f(A::AbstractDimArray, dims::Colon) = $m.$f(parent(A); dims=dimnum(A, dims))
     end
 end
 
 # These are not exported but it makes a lot of things easier using them
-Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims) =
+function Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims)
     rebuild(A, Base._mapreduce_dim(f, op, nt, parent(A), dimnum(A, dims)), reducedims(A, dims))
-Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims::Colon) =
+end
+function Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims::Colon)
     Base._mapreduce_dim(f, op, nt, parent(A), dims)
+end
 
-# TODO: Unfortunately Base/accumulate.jl kwargs methods all force dims to be Integer.
+# TODO: Unfortunately Base/accumulate.jl kw methods all force dims to be Integer.
 # accumulate wont work unless that is relaxed, or we copy half of the file here.
 # Base._accumulate!(op, B, A, dims::AllDims, init::Union{Nothing, Some}) =
     # Base._accumulate!(op, B, A, dimnum(A, dims), init)
@@ -86,21 +81,20 @@ end
 @inline _dropinds(A, dim::Dimension) = dims2indices(A, basetypeof(dim)(1))
 
 
-
 # Function application
 
 @inline Base.map(f, A::AbstractDimArray) = rebuild(A, map(f, parent(A)))
 
-function Base.mapslices(f, A::AbstractDimArray; dims=1, kwargs...)
+function Base.mapslices(f, A::AbstractDimArray; dims=1, kw...)
     dimnums = dimnum(A, dims)
-    _data = mapslices(f, parent(A); dims=dimnums, kwargs...)
+    _data = mapslices(f, parent(A); dims=dimnums, kw...)
     rebuild(A, _data, reducedims(A, DimensionalData.dims(A, dimnums)))
 end
 
 # This is copied from base as we can't efficiently wrap this function
-# through the kwarg with a rebuild in the generator. Doing it this way
+# through the kw with a rebuild in the generator. Doing it this way
 # also makes it faster to use a dim than an integer.
-function Base.eachslice(A::AbstractDimArray; dims=1, kwargs...)
+function Base.eachslice(A::AbstractDimArray; dims=1, kw...)
     if dims isa Tuple && length(dims) != 1
         throw(ArgumentError("only single dimensions are supported"))
     end
@@ -110,12 +104,11 @@ function Base.eachslice(A::AbstractDimArray; dims=1, kwargs...)
     return (view(A, idx1..., i, idx2...) for i in axes(A, dim))
 end
 
-
 # Duplicated dims
 
 for fname in (:cor, :cov)
-    @eval Statistics.$fname(A::AbstractDimArray{T,2}; dims=1, kwargs...) where T = begin
-        newdata = Statistics.$fname(parent(A); dims=dimnum(A, dims), kwargs...)
+    @eval function Statistics.$fname(A::AbstractDimArray{<:Any,2}; dims=1, kw...)
+        newdata = Statistics.$fname(parent(A); dims=dimnum(A, dims), kw...)
         removed_idx = dimnum(A, dims)
         newrefdims = $dims(A)[removed_idx]
         newdims = $dims(A)[3 - removed_idx]
@@ -123,72 +116,66 @@ for fname in (:cor, :cov)
     end
 end
 
-
 # Rotations
 
-struct Rot90 end
-struct Rot180 end
-struct Rot270 end
-struct Rot360 end
+struct _Rot90 end
+struct _Rot180 end
+struct _Rot270 end
+struct _Rot360 end
+
+Base.rotl90(A::AbstractDimMatrix) = rebuild(A, rotl90(parent(A)), _rot(_Rot90(), dims(A)))
+Base.rotl90(A::AbstractDimMatrix, k::Integer) =
+    rebuild(A, rotl90(parent(A), k), _rot(_rottype(k), dims(A)))
+
+Base.rotr90(A::AbstractDimMatrix) = rebuild(A, rotr90(parent(A)), _rot(_Rot270(), dims(A)))
+Base.rotr90(A::AbstractDimMatrix, k::Integer) =
+    rebuild(A, rotr90(parent(A), k), _rot(_rottype(-k), dims(A)))
+
+Base.rot180(A::AbstractDimMatrix) = rebuild(A, rot180(parent(A)), _rot(_Rot180(), dims(A)))
 
 # Not type stable - but we have to lose type stability somewhere when
 # dims are being swapped, by an Int value, so it may as well be here
-function rottype(k)
+function _rottype(k)
     k = mod(k, 4)
     if k == 1
-        Rot90()
+        _Rot90()
     elseif k == 2
-        Rot180()
+        _Rot180()
     elseif k == 3
-        Rot270()
+        _Rot270()
     else
-        Rot360()
+        _Rot360()
     end
 end
 
-Base.rotl90(A::AbstractDimMatrix) =
-    rebuild(A, rotl90(parent(A)), rotdims(Rot90(), dims(A)))
-Base.rotl90(A::AbstractDimMatrix, k::Integer) =
-    rebuild(A, rotl90(parent(A), k), rotdims(rottype(k), dims(A)))
-
-Base.rotr90(A::AbstractDimMatrix) =
-    rebuild(A, rotr90(parent(A)), rotdims(Rot270(), dims(A)))
-Base.rotr90(A::AbstractDimMatrix, k::Integer) =
-    rebuild(A, rotr90(parent(A), k), rotdims(rottype(-k), dims(A)))
-
-Base.rot180(A::AbstractDimMatrix) =
-    rebuild(A, rot180(parent(A)), rotdims(Rot180(), dims(A)))
-
-rotdims(::Rot90, (dima, dimb)) = (flip(Relation, dimb), dima)
-rotdims(::Rot180, dims) = map(d -> flip(Relation, d), dims)
-rotdims(::Rot270, (dima, dimb)) = (dimb, flip(Relation, dima))
-rotdims(::Rot360, dims) = dims
-
+_rot(::_Rot90, (dima, dimb)) = (flip(Relation, dimb), dima)
+_rot(::_Rot180, dims) = map(d -> flip(Relation, d), dims)
+_rot(::_Rot270, (dima, dimb)) = (dimb, flip(Relation, dima))
+_rot(::_Rot360, dims) = dims
 
 # Dimension reordering
 
 for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint),
                      (:Base, :transpose), (:LinearAlgebra, :Transpose)]
     @eval begin
-        @inline $pkg.$fname(A::AbstractDimArray{T,2}) where T =
+        @inline $pkg.$fname(A::AbstractDimArray{<:Any,2}) =
             rebuild(A, $pkg.$fname(parent(A)), reverse(dims(A)))
-        @inline $pkg.$fname(A::AbstractDimArray{T,1}) where T =
+        @inline $pkg.$fname(A::AbstractDimArray{<:Any,1}) =
             rebuild(A, $pkg.$fname(parent(A)), (AnonDim(Base.OneTo(1)), dims(A)...))
     end
 end
-
 for fname in [:permutedims, :PermutedDimsArray]
     @eval begin
-        @inline Base.$fname(A::AbstractDimArray{T,N}, perm) where {T,N} =
+        @inline function Base.$fname(A::AbstractDimArray, perm)
             rebuild(A, $fname(parent(A), dimnum(A, perm)), sortdims(dims(A), perm))
+        end
     end
 end
 
-
 # Concatenation
-
-Base._cat(catdims::Union{Int,Base.Dims}, Xin::AbstractDimArray...) =
+function Base._cat(catdims::Union{Int,Base.Dims}, Xin::AbstractDimArray...)
     Base._cat(dims(first(Xin), catdims), Xin...)
+end
 function Base._cat(catdims::AllDims, Xin::AbstractDimArray...)
     A1 = first(Xin)
     comparedims(Xin...)
@@ -211,27 +198,32 @@ function Base._cat(catdims::AllDims, Xin::AbstractDimArray...)
     rebuild(A1, newA, formatdims(newA, newdims))
 end
 
-_catifcatdim(catdims::Tuple, ds) =
-    any(map(cd -> basetypeof(cd) <: basetypeof(ds[1]), catdims)) ? vcat(ds...) : ds[1]
-_catifcatdim(catdim, ds) = basetypeof(catdim) <: basetypeof(ds[1]) ? vcat(ds...) : ds[1]
+function _catifcatdim(catdims::Tuple, dims)
+    anydimsmatch = any(map(d -> basetypeof(d) <: basetypeof(dims[1]), catdims)) 
+    anydimsmatch ? vcat(dims...) : dims[1]
+end
+function _catifcatdim(catdim, dims) 
+    basetypeof(catdim) <: basetypeof(dims[1]) ? vcat(dims...) : dims[1]
+end
 
-Base.vcat(dims::Dimension...) = begin
+function Base.vcat(dims::Dimension...)
     newmode = _vcat_modes(mode(dims)...)
     rebuild(dims[1], _vcat_index(newmode, index(dims)...), newmode)
 end
 
 # IndexModes may need adjustment for `cat`
 _vcat_modes(modes::IndexMode...) = first(modes)
-_vcat_modes(modes::AbstractSampled...) =
+function _vcat_modes(modes::AbstractSampled...)
     _vcat_modes(sampling(first(modes)), span(first(modes)), modes...)
-_vcat_modes(::Any, ::Regular, modes...) = begin
+end
+function _vcat_modes(::Any, ::Regular, modes...)
     _step = step(first(modes))
     map(modes) do mode
         step(span(mode)) == _step || error("Step sizes $(step(span(mode))) and $_step do not match ")
     end
     first(modes)
 end
-_vcat_modes(::Intervals, ::Irregular, modes...) = begin
+function _vcat_modes(::Intervals, ::Irregular, modes...)
     allbounds = map(bounds ∘ span, modes)
     @show allbounds
     newbounds = minimum(map(first, allbounds)), maximum(map(last, allbounds))
@@ -240,14 +232,11 @@ _vcat_modes(::Intervals, ::Irregular, modes...) = begin
 end
 _vcat_modes(::Points, ::Irregular, modes...) = first(modes)
 
-# Index vcat depends on mode:
-# NoIndex is always just Base.OneTo(length)
+# Index vcat depends on mode: NoIndex is always just Base.OneTo(length)
 # TODO: handle vcat OffsetArrays?
 _vcat_index(mode::NoIndex, A...) = Base.OneTo(sum(map(length, A)))
 # Otherwise just vcat. TODO: handle order breaking vcat?
 _vcat_index(mode::IndexMode, A...) = vcat(A...)
-
-
 
 
 Base.inv(A::AbstractDimArray{T,2}) where T =

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -151,7 +151,6 @@ indexorder(order::Unordered) = UnorderedIndex()
 arrayorder(order::Unordered) = ForwardArray()
 relation(order::Unordered) = order.relation
 
-
 # Get the order specifying type
 order(ot::Type{<:IndexOrder}, order::Union{Ordered,Unordered}) = indexorder(order)
 order(ot::Type{<:ArrayOrder}, order::Union{Ordered,Unordered}) = arrayorder(order)
@@ -302,7 +301,6 @@ Irregular(lowerbound, upperbound) = Irregular((lowerbound, upperbound))
 
 bounds(span::Irregular) = span.bounds
 
-
 """
 Supertype for all `Dimension` modes.
 Defines or modifies dimension behaviour.
@@ -341,7 +339,6 @@ Base.step(mode::AutoMode, dim) = Base.step(index(dim))
 
 const Auto = AutoMode
 
-
 bounds(mode::IndexMode, dim) = bounds(indexorder(mode), mode, dim)
 bounds(::ForwardIndex, ::IndexMode, dim) = first(dim), last(dim)
 bounds(::ReverseIndex, ::IndexMode, dim) = last(dim), first(dim)
@@ -355,11 +352,10 @@ indexorder(mode::IndexMode) = indexorder(order(mode))
 relation(mode::IndexMode) = relation(order(mode))
 locus(mode::IndexMode) = Center()
 
-Base.step(mode::T) where T <: IndexMode =
+@noinline Base.step(mode::T) where T <: IndexMode =
     error("No step provided by $T. Use a `Sampled` with `Regular`")
 
 slicemode(mode::IndexMode, index, I) = mode
-
 
 
 """
@@ -430,30 +426,19 @@ locus(mode::AbstractSampled) = locus(sampling(mode))
 Base.step(mode::AbstractSampled) = step(span(mode))
 
 # bounds
-bounds(mode::AbstractSampled, dim) =
-    bounds(sampling(mode), span(mode), mode, dim)
-
-bounds(::Points, span, mode::AbstractSampled, dim) =
-    bounds(indexorder(mode), mode, dim)
-
-bounds(::Intervals, span::Irregular, mode::AbstractSampled, dim) =
-    bounds(span)
-
+bounds(mode::AbstractSampled, dim) = bounds(sampling(mode), span(mode), mode, dim)
+bounds(::Points, span, mode::AbstractSampled, dim) = bounds(indexorder(mode), mode, dim)
+bounds(::Intervals, span::Irregular, mode::AbstractSampled, dim) = bounds(span)
 bounds(::Intervals, span::Regular, mode::AbstractSampled, dim) =
     bounds(locus(mode), indexorder(mode), span, mode, dim)
-
-bounds(::Start, ::ForwardIndex, span, mode, dim) =
-    first(dim), last(dim) + step(span)
-bounds(::Start, ::ReverseIndex, span, mode, dim) =
-    last(dim), first(dim) - step(span)
+bounds(::Start, ::ForwardIndex, span, mode, dim) = first(dim), last(dim) + step(span)
+bounds(::Start, ::ReverseIndex, span, mode, dim) = last(dim), first(dim) - step(span)
 bounds(::Center, ::ForwardIndex, span, mode, dim) =
     first(dim) - step(span) / 2, last(dim) + step(span) / 2
 bounds(::Center, ::ReverseIndex, span, mode, dim) =
     last(dim) + step(span) / 2, first(dim) - step(span) / 2
-bounds(::End, ::ForwardIndex, span, mode, dim) =
-    first(dim) - step(span), last(dim)
-bounds(::End, ::ReverseIndex, span, mode, dim) =
-    last(dim) + step(span), first(dim)
+bounds(::End, ::ForwardIndex, span, mode, dim) = first(dim) - step(span), last(dim)
+bounds(::End, ::ReverseIndex, span, mode, dim) = last(dim) + step(span), first(dim)
 
 # Bounds are always in ascending order
 sortbounds(mode::IndexMode, bounds) = sortbounds(indexorder(mode), bounds)
@@ -470,7 +455,7 @@ slicemode(::Intervals, ::Irregular, mode::AbstractSampled, index, I) = begin
 end
 
 slicebounds(m::IndexMode, index, I) =
-    slicebounds(locus(m), bounds(span(m)), index, maybeflip(indexorder(m), index, I))
+    slicebounds(locus(m), bounds(span(m)), index, _maybeflip(indexorder(m), index, I))
 slicebounds(locus::Start, bounds, index, I) =
     index[first(I)], last(I) >= lastindex(index) ? bounds[2] : index[last(I) + 1]
 slicebounds(locus::End, bounds, index, I) =

--- a/src/name.jl
+++ b/src/name.jl
@@ -1,12 +1,11 @@
-
 """
 Abstract supertype for name wrappers.
 """
 abstract type AbstractName end
 
 """
-Name wrapper. This lets arrays keep symbol names when the array wrapp neeeds 
-to be `isbits, like for use on GPUs. It makes the name a property of the type. 
+Name wrapper. This lets arrays keep symbol names when the array wrapp neeeds
+to be `isbits, like for use on GPUs. It makes the name a property of the type.
 It's not necessary to use in normal use, a symbol is probably easier.
 """
 struct Name{X} <: AbstractName end
@@ -16,8 +15,8 @@ Base.Symbol(::Name{X}) where X = X
 Base.string(::Name{X}) where X = string(X)
 
 """
-NoName specifies an array is not named, and is the default `name` 
-value for all `DimArray`s. It can be used in `set` to remove the 
+NoName specifies an array is not named, and is the default `name`
+value for all `DimArray`s. It can be used in `set` to remove the
 array name:
 
 ```julia

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -11,10 +11,10 @@ struct DimensionalPlot end
 end
 
 @recipe function f(::DimensionalPlot, A::AbstractArray)
-    Afwd = forwardorder(A)
+    Afwd = _forwardorder(A)
     sertype = get(plotattributes, :seriestype, :none)
     if !(sertype in [:marginalhist])
-        :title --> refdims_title(Afwd)
+        :title --> _refdims_title(Afwd)
     end
     if sertype in [:heatmap, :contour, :volume, :marginalhist, 
                    :surface, :contour3d, :wireframe, :scatter3d]
@@ -44,7 +44,7 @@ end
     index(dim), parent(A)
 end
 @recipe function f(::SeriesLike, A::AbstractArray{T,2}) where T
-    A = maybe_permute(A, (IndependentDim, DependentDim))
+    A = _maybe_permute(A, (IndependentDim, DependentDim))
     ind, dep = dims(A)
     :xguide --> label(ind)
     :yguide --> label(A)
@@ -59,7 +59,7 @@ end
     index(dim), parent(A)
 end
 @recipe function f(::HistogramLike, A::AbstractArray{T,2}) where T
-    A = maybe_permute(A, (IndependentDim, DependentDim))
+    A = _maybe_permute(A, (IndependentDim, DependentDim))
     ind, dep = dims(A)
     :xguide --> label(A)
     :legendtitle --> label(dep)
@@ -73,7 +73,7 @@ end
     parent(A)
 end
 @recipe function f(::ViolinLike, A::AbstractArray{T,2}) where T
-    A = maybe_permute(A, (IndependentDim, DependentDim))
+    A = _maybe_permute(A, (IndependentDim, DependentDim))
     ind, dep = dims(A)
     :xguide --> label(dep)
     :yguide --> label(A)
@@ -90,7 +90,7 @@ end
 end
 
 @recipe function f(::HeatMapLike, A::AbstractArray{T,2}) where T
-    A = maybe_permute(A, (YDim, XDim))
+    A = _maybe_permute(A, (YDim, XDim))
     y, x = dims(A)
     :xguide --> label(x)
     :yguide --> label(y)
@@ -99,15 +99,15 @@ end
     reverse(map(index, dims(A)))..., parent(A)
 end
 
-maybe_permute(A, dims) = all(hasdim(A, dims)) ? permutedims(A, dims) : A
+_maybe_permute(A, dims) = all(hasdim(A, dims)) ? permutedims(A, dims) : A
 
-forwardorder(A::AbstractArray) =
+_forwardorder(A::AbstractArray) =
     reorder(A, ForwardIndex) |> a -> reorder(a, ForwardRelation)
 
-refdims_title(A::AbstractArray) = join(map(refdims_title, refdims(A)), ", ")
-refdims_title(refdim::Dimension) = 
-    string(name(refdim), ": ", refdims_title(mode(refdim), refdim))
-refdims_title(mode::AbstractSampled, refdim::Dimension) = begin
+function _refdims_title(refdim::Dimension) 
+    string(name(refdim), ": ", _refdims_title(mode(refdim), refdim))
+end
+function _refdims_title(mode::AbstractSampled, refdim::Dimension)
     start, stop = map(string, bounds(refdim))
     if start == stop
         start
@@ -115,5 +115,6 @@ refdims_title(mode::AbstractSampled, refdim::Dimension) = begin
          "$start to $stop"
     end
 end
-refdims_title(mode::IndexMode, refdim::Dimension) = string(val(refdim))
+_refdims_title(A::AbstractArray) = join(map(_refdims_title, refdims(A)), ", ")
+_refdims_title(mode::IndexMode, refdim::Dimension) = string(val(refdim))
 

--- a/src/set.jl
+++ b/src/set.jl
@@ -1,3 +1,6 @@
+const InDims = Union{AbstractDimMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
+const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
+
 """
 
 Set the field matching the supertypes of values in xs and return a new object.
@@ -52,13 +55,8 @@ set(da, custom=Ordered(array=Reverse()), Z=Unordered())
 ```
 """
 function set end
-
-const DimArrayOrDataset = Union{AbstractDimArray,AbstractDimStack}
-
-set(A::DimArrayOrDataset, name::T) where {T<:Union{Mode,ModeComponent}} = _onlydimerror(T)
+set(A::DimArrayOrStack, name::T) where {T<:Union{Mode,ModeComponent}} = _onlydimerror(T)
 set(A, x) = _cantseterror(A, x)
-_set(A, x) = _cantseterror(A, x)
-
 """
     set(x, args::Pairs...) => x with updated field/s
     set(x, args...; kw...) => x with updated field/s
@@ -72,13 +70,8 @@ tuples of values wrapped in the intended dimensions. Or fully or partially
 constructed dimensions with val, mode or metadata fields set to intended
 values. Dimension fields not assigned a value will be ignored, and the orginals kept.
 """
-set(A::DimArrayOrDataset, args::Union{Dimension,DimTuple,Pair}...; kw...) =
+set(A::DimArrayOrStack, args::Union{Dimension,DimTuple,Pair}...; kw...) =
     rebuild(A, data(A), _set(dims(A), args...; kw...))
-
-_set(dim::DimArrayOrDataset, ::Type{T}) where T = _set(dim, T())
-
-# Array
-
 """
     set(A::AbstractDimArray, data::AbstractArray) => AbstractDimArray
 
@@ -103,9 +96,6 @@ set(A::AbstractDimArray, metadata::Union{AbstractArrayMetadata,NoMetadata}) =
 Symbols are always names, and update the `name` field of the array.
 """
 set(A::AbstractDimArray, name::Union{Symbol,AbstractName}) = rebuild(A; name=name)
-
-# Dataset
-
 """
     set(s::AbstractDimStack, data::NamedTuple) => AbstractDimStack
 
@@ -126,10 +116,6 @@ StackMetadata update the `metadata` field of the dataset.
 """
 set(s::AbstractDimStack, metadata::Union{AbstractStackMetadata,NoMetadata}) = 
     rebuild(s; metadata=metadata)
-
-
-const InDims = Union{AbstractDimMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
-
 """
     set(dim::Dimension, index::Unioon{AbstractArray,Val}) => Dimension
     set(dim::Dimension, mode::Mode) => Dimension
@@ -140,13 +126,16 @@ Set fields of the dimension
 """
 set(dim::Dimension, x::InDims) = _set(dim, x)
 
+# Array or Stack
+_set(x::DimArrayOrStack, ::Type{T}) where T = _set(x, T())
+_set(A, x) = _cantseterror(A, x)
 
-# Convert args/kwargs to dims and set
-_set(dims_::DimTuple, args::Dimension...; kw...) = _set(dims_, (args..., _kwargdims(kw)...))
+# Dimension
+# Convert args/kw to dims and set
+_set(dims_::DimTuple, args::Dimension...; kw...) = _set(dims_, (args..., _kwdims(kw)...))
 # Convert pairs to wrapped dims and set
 _set(dims_::DimTuple, p::Pair, ps::Vararg{<:Pair}) = _set(dims_, (p, ps...))
 _set(dims_::DimTuple, ps::Tuple{Vararg{<:Pair}}) = _set(dims_, _pairdims(ps...))
-
 # Set dims with (possibly unsorted) wrapper vals
 _set(dims::DimTuple, wrappers::DimTuple) = begin
     # Check the dimension types match
@@ -158,11 +147,8 @@ _set(dims::DimTuple, wrappers::DimTuple) = begin
     # Swaps existing dims with non-nothing new dims
     swapdims(dims, newdims)
 end
-
-
 # Set things wrapped in dims
 _set(dim::Dimension, wrapper::Dimension{<:InDims}) = _set(dim::Dimension, val(wrapper))
-
 # Set the index
 _set(dim::Dimension, index::Val) = rebuild(dim; val=index)
 _set(dim::Dimension, index::AbstractArray) = rebuild(dim; val=index)
@@ -172,12 +158,9 @@ _set(dim::Dimension, index::AbstractRange) = begin
     _set(mode(dim), dim, index)
 end
 _set(dim::Dimension, index::Colon) = dim
-
-_set(mode::IndexMode, dim::Dimension, index::AbstractRange) = rebuild(dim; val=index)
 # Update the Sampling mode of Sampled dims - it must match the range.
 _set(mode::AbstractSampled, dim::Dimension, index::AbstractRange) =
     rebuild(dim; val=index, mode=_set(mode, Regular(step(index))))
-
 # Set the dim, checking the mode
 _set(dim::Dimension, newdim::Dimension) = begin
     # Get new metadata and val
@@ -187,28 +170,19 @@ _set(dim::Dimension, newdim::Dimension) = begin
     # then wrap the updated dim in the new type
     basetypeof(newdim)(val(dim), mode(dim), metadata(dim))
 end
-
 # Construct types
 _set(dim::Dimension, ::Type{T}) where T = _set(dim, T())
-
 _set(dim::Dimension, key::Symbol) = _set(dim, key2dim(key))
 _set(dim::Dimension, dt::DimType) = basetypeof(dt)(val(dim), mode(dim), metadata(dim))
-
 # Set the mode
 _set(dim::Dimension, newmode::IndexMode) = rebuild(dim; mode=_set(mode(dim), newmode))
-
 # Otherwise pass this on to set fields on the mode
 _set(dim::Dimension, x::ModeComponent) = rebuild(dim; mode=_set(mode(dim), x))
 
-
 # IndexMode
-
-# AutoMode
 _set(mode::IndexMode, newmode::AutoMode) = mode
-# Categorical
 _set(mode::IndexMode, newmode::Categorical) =
     rebuild(newmode; order=_set(order(mode), order(newmode)))
-# Sampled
 _set(mode::IndexMode, newmode::AbstractSampled) = begin
     # Update each field separately. The old mode may not have these fields, or may have
     # a subset with the rest being traits. The new mode may have some auto fields.
@@ -218,14 +192,11 @@ _set(mode::IndexMode, newmode::AbstractSampled) = begin
     # Rebuild the new mode with the merged fields
     rebuild(newmode; order=o, span=sp, sampling=sa)
 end
-# NoIndex
 _set(mode::IndexMode, newmode::NoIndex) = newmode
-
 
 # Order
 _set(mode::IndexMode, neworder::Order) = rebuild(mode; order=_set(order(mode), neworder))
 _set(mode::NoIndex, neworder::Order) = mode
-
 _set(order::Union{Ordered,Unordered}, neworder::Ordered) = begin
     index = _set(indexorder(order), indexorder(neworder))
     array = _set(arrayorder(order), arrayorder(neworder))
@@ -234,28 +205,22 @@ _set(order::Union{Ordered,Unordered}, neworder::Ordered) = begin
 end
 _set(order::Union{Ordered,Unordered}, neworder::Unordered) =
     Unordered(_set(relation(order), relation(neworder)))
-
-
 # AutoOrder
 _set(order::Order, neworder::AutoOrder) = order
 _set(order::AutoOrder, neworder::Order) = order
 _set(order::AutoOrder, neworder::AutoOrder) = AutoOrder()
-
 # SubOrder
 _set(order::Unordered, suborder::Relation) =
     rebuild(order; relation=_set(relation(order), suborder))
-
 _set(order::Ordered, suborder::IndexOrder) =
     rebuild(order; index=_set(indexorder(order), suborder))
 _set(order::Ordered, suborder::ArrayOrder) =
     rebuild(order; array=_set(arrayorder(order), suborder))
 _set(order::Ordered, suborder::Relation) =
     rebuild(order; relation=_set(relation(order), suborder))
-
 _set(suborder::ArrayOrder, newsuborder::ArrayOrder) = newsuborder
 _set(suborder::IndexOrder, newsuborder::IndexOrder) = newsuborder
 _set(suborder::Relation, newsuborder::Relation) = newsuborder
-
 
 # Span
 _set(mode::AbstractSampled, span::Span) = rebuild(mode; span=span)
@@ -263,14 +228,12 @@ _set(mode::AbstractSampled, span::AutoSpan) = mode
 _set(span::Span, newspan::Span) = newspan
 _set(span::Span, newspan::AutoSpan) = span
 
-
 # Sampling
 _set(mode::AbstractSampled, newsampling::Sampling) =
     rebuild(mode; sampling=_set(sampling(mode), newsampling))
 _set(mode::AbstractSampled, sampling::AutoSampling) = mode
 _set(sampling::Sampling, newsampling::Sampling) = newsampling
 _set(sampling::Sampling, newsampling::AutoSampling) = sampling
-
 
 # Locus
 _set(mode::AbstractSampled, locus::Locus) =
@@ -280,7 +243,7 @@ _set(sampling::Points, locus::Locus) = _locuserror()
 _set(sampling::Intervals, locus::Locus) = Intervals(locus)
 _set(sampling::Intervals, locus::AutoLocus) = sampling
 
-
+# Metadata
 _set(dim::Dimension, newmetadata::Union{AbstractDimMetadata,NoMetadata}) =
     rebuild(dim, val(dim), mode(dim), newmetadata)
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,5 +1,5 @@
 # Full printing for DimArray
-Base.show(io::IO, A::AbstractDimArray) = begin
+function Base.show(io::IO, A::AbstractDimArray)
     l = nameof(typeof(A))
     printstyled(io, nameof(typeof(A)); color=:blue)
     if label(A) != ""
@@ -27,7 +27,7 @@ end
 # Short printing for DimArray
 Base.show(io::IO, ::MIME"text/plain", A::AbstractDimArray) = show(io, A)
 # Full printing version for dimensions
-Base.show(io::IO, ::MIME"text/plain", dim::Dimension) = begin
+function Base.show(io::IO, ::MIME"text/plain", dim::Dimension)
     print(io, "Dimension ")
     printstyled(io, name(dim); color=:red)
     if name(dim) != nameof(typeof(dim))
@@ -47,7 +47,7 @@ Base.show(io::IO, ::MIME"text/plain", dim::Dimension) = begin
     show(io, typeof(dim))
 end
 # short printing version for dimensions
-Base.show(io::IO, dim::Dimension) = begin
+function Base.show(io::IO, dim::Dimension)
     printstyled(io, name(dim); color=:red)
     if name(dim) ≠ string(nameof(typeof(dim)))
         print(io, " (type ")
@@ -56,12 +56,12 @@ Base.show(io::IO, dim::Dimension) = begin
     end
     printdimproperties(io, dim)
 end
-Base.show(io::IO, dim::Dim) = begin
+function Base.show(io::IO, dim::Dim)
     printstyled(io, name(dim); color=:red)
     printdimproperties(io, dim)
 end
 
-printdimproperties(io, dim) = begin
+function printdimproperties(io, dim)
     if !(mode(dim) isa NoIndex)
         print(io, ": ")
         _printdimval(io, val(dim))
@@ -84,13 +84,13 @@ function printlimited(io, v::AbstractVector)
 end
 
 Base.show(io::IO, mode::IndexMode) = _printmode(io, mode)
-Base.show(io::IO, mode::AbstractSampled) = begin
+function Base.show(io::IO, mode::AbstractSampled)
     _printmode(io, mode)
     _printorder(io, mode)
     print(io, " ", nameof(typeof(span(mode))))
     print(io, " ", nameof(typeof(sampling(mode))))
 end
-Base.show(io::IO, mode::AbstractCategorical) = begin
+function Base.show(io::IO, mode::AbstractCategorical)
     _printmode(io, mode)
     _printorder(io, mode)
 end
@@ -100,13 +100,16 @@ _printmode(io, mode) = printstyled(io, nameof(typeof(mode)); color=:green)
 _printorder(io, mode) = print(io, ": ", nameof(typeof(order(mode))))
 
 # Thanks to Michael Abbott for the following function
-custom_show(io::IO, A::AbstractArray{T,0}) where T =
+function custom_show(io::IO, A::AbstractArray{T,0}) where T
     Base.show(IOContext(io, :compact => true, :limit => true), A)
-custom_show(io::IO, A::AbstractArray{T,1}) where T =
+end
+function custom_show(io::IO, A::AbstractArray{T,1}) where T
     Base.show(IOContext(io, :compact => true, :limit => true), A)
-custom_show(io::IO, A::AbstractArray{T,2}) where T =
+end
+function custom_show(io::IO, A::AbstractArray{T,2}) where T
     Base.print_matrix(IOContext(io, :compact => true, :limit => true), A)
-custom_show(io::IO, A::AbstractArray{T,N}) where {T,N} = begin
+end
+function custom_show(io::IO, A::AbstractArray{T,N}) where {T,N}
     o = ones(Int, N-2)
     frame = A[:, :, o...]
     onestring = join(o, ", ")

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -7,14 +7,14 @@ Tables.columnaccess(::Type{<:DimTableSources}) = true
 Tables.columns(x::DimTableSources) = DimTable(x)
 
 Tables.columnnames(A::AbstractDimArray) = _colnames(DimStack(A))
-Tables.schema(A::AbstractDimArray) = Tables.schema(DimStack(A))
-
 Tables.columnnames(s::AbstractDimStack) = _colnames(s)
-Tables.schema(s::AbstractDimStack) = 
-    Tables.Schema(_colnames(s), (map(eltype, dims(s))..., map(eltype, data(s))...))
 
-@inline Tables.getcolumn(x::DimTableSources, i::Int) =
-    Tables.getcolumn(DimTable(x), i)
+Tables.schema(A::AbstractDimArray) = Tables.schema(DimStack(A))
+function Tables.schema(s::AbstractDimStack)
+    Tables.Schema(_colnames(s), (map(eltype, dims(s))..., map(eltype, data(s))...))
+end
+
+@inline Tables.getcolumn(x::DimTableSources, i::Int) = Tables.getcolumn(DimTable(x), i)
 @inline Tables.getcolumn(x::DimTableSources, key::Symbol) =
     Tables.getcolumn(DimTable(x), key)
 @inline Tables.getcolumn(x::DimTableSources, ::Type{T}, i::Int, key::Symbol) where T =
@@ -28,11 +28,11 @@ Tables.schema(s::AbstractDimStack) =
     DimColumn(dim::Dimension, dims::Tuple{Vararg{<:DimTuple}})
     DimColumn(dim::DimColumn, length::Int, dimstride::Int)
 
-A table column based on a `Dimension` and it's relationship with other 
-`Dimension`s in `dims`. 
+A table column based on a `Dimension` and it's relationship with other
+`Dimension`s in `dims`.
 
-`length` is the product of all dim lengths (usually the length of the corresponding 
-array data), while stride is the product of the preceding dimension lengths, which 
+`length` is the product of all dim lengths (usually the length of the corresponding
+array data), while stride is the product of the preceding dimension lengths, which
 may or may not be the real stride of the corresponding array depending on the data type.
 For `A isa Array`, the `dimstride` will match the `stride`.
 
@@ -47,10 +47,10 @@ struct DimColumn{T,D<:Dimension} <: AbstractVector{T}
     length::Int
     dimstride::Int
 end
-DimColumn(dim::D, dims::DimTuple) where D<:Dimension = begin
-    # This is the apparent stride for indexing purposes, 
+function DimColumn(dim::D, dims::DimTuple) where D<:Dimension
+    # This is the apparent stride for indexing purposes,
     # it is not always the real array stride
-    stride = dimstride(dims, dim) 
+    stride = dimstride(dims, dim)
     len = prod(map(length, dims))
     DimColumn{eltype(dim),D}(dim, len, stride)
 end
@@ -61,12 +61,12 @@ dimstride(c::DimColumn) = getfield(c, :dimstride)
 # Simple Array interface
 
 Base.length(c::DimColumn) = getfield(c, :length)
-@inline Base.getindex(c::DimColumn, i::Int) = begin
+@inline function Base.getindex(c::DimColumn, i::Int)
     Base.@boundscheck checkbounds(c, i)
     dim(c)[mod((i - 1) ÷ dimstride(c), length(dim(c))) + 1]
 end
 Base.getindex(c::DimColumn, ::Colon) = vec(c)
-Base.getindex(c::DimColumn, A::AbstractArray) = [c[i] for i in A] 
+Base.getindex(c::DimColumn, A::AbstractArray) = [c[i] for i in A]
 Base.size(c::DimColumn) = (length(c),)
 Base.axes(c::DimColumn) = (Base.OneTo(length(c)),)
 Base.vec(c::DimColumn{T}) where T = [c[i] for i in eachindex(c)]
@@ -79,12 +79,12 @@ abstract type AbstractDimTable <: Tables.AbstractColumns end
 
 Construct a Tables.jl compatible object out of an `AbstractDimArray`.
 
-This table will have a column for the array data and columns for each 
+This table will have a column for the array data and columns for each
 `Dimension` index, as a [`DimColumn`]. These are lazy, and generated
 as required.
 
-Column names are converted from the dimension types using 
-[`DimensionalData.dim2key`](@ref). This means type `Ti` becomes the 
+Column names are converted from the dimension types using
+[`DimensionalData.dim2key`](@ref). This means type `Ti` becomes the
 column name `:Ti`, and `Dim{:custom}` becomes `:custom`.
 
 To get dimension columns, you can index with `Dimension` (`X()`) or
@@ -95,9 +95,10 @@ struct DimTable{Keys,DS,C} <: AbstractDimTable
     dimcolumns::C
 end
 DimTable(A::AbstractDimArray, As::AbstractDimArray...) = DimTable((A, As...))
-DimTable(As::Tuple{<:AbstractDimArray,Vararg{<:AbstractDimArray}}...) = 
+function DimTable(As::Tuple{<:AbstractDimArray,Vararg{<:AbstractDimArray}}...)
     DimTable(DimStack(As...))
-DimTable(s::AbstractDimStack) = begin
+end
+function DimTable(s::AbstractDimStack)
     dims_ = dims(s)
     dimcolumns = map(d -> DimColumn(d, dims_), dims_)
     keys = _colnames(s)
@@ -108,7 +109,7 @@ dataset(t::DimTable) = getfield(t, :dataset)
 dimcolumns(t::DimTable) = getfield(t, :dimcolumns)
 dims(t::DimTable) = dims(dataset(t))
 
-for func in (:dims, :val, :index, :mode, :metadata, :order, :sampling, :span, :bounds, :locus, 
+for func in (:dims, :val, :index, :mode, :metadata, :order, :sampling, :span, :bounds, :locus,
              :name, :label, :units, :arrayorder, :indexorder, :relation)
     @eval ($func)(t::DimTable, args...) = ($func)(dataset(t), args...)
 end
@@ -119,13 +120,13 @@ Tables.istable(::DimTable) = true
 Tables.columnaccess(::Type{<:DimTable}) = true
 Tables.columns(t::DimTable) = t
 Tables.columnnames(c::DimTable{Keys}) where Keys = Keys
-Tables.schema(t::DimTable{Keys}) where Keys = begin
+function Tables.schema(t::DimTable{Keys}) where Keys
     s = dataset(t)
     Tables.Schema(Keys, (map(eltype, dims(s))..., map(eltype, data(s))...))
 end
 
-@inline Tables.getcolumn(t::DimTable{Keys}, i::Int) where Keys = begin
-    nkeys = length(Keys) 
+@inline function Tables.getcolumn(t::DimTable{Keys}, i::Int) where Keys
+    nkeys = length(Keys)
     if i > length(dims(t))
         vec(values(data(dataset(t)))[i - length(dims(t))])
     elseif i < nkeys
@@ -134,20 +135,22 @@ end
         error("There is no column $i")
     end
 end
-@inline Tables.getcolumn(t::DimTable, dim::DimOrDimType) =
+@inline function Tables.getcolumn(t::DimTable, dim::DimOrDimType)
     Tables.getcolumn(t, dimnum(t, dim))
+end
 # Retrieve a column by name
-@inline Tables.getcolumn(t::DimTable{Keys}, key::Symbol) where Keys = begin
+@inline function Tables.getcolumn(t::DimTable{Keys}, key::Symbol) where Keys
     if key in keys(dataset(t))
         vec(dataset(t)[key])
     else
         dimcolumns(t)[dimnum(dims(t), key)]
     end
 end
-@inline Tables.getcolumn(t::DimTable, ::Type{T}, i::Int, key::Symbol) where T =
+@inline function Tables.getcolumn(t::DimTable, ::Type{T}, i::Int, key::Symbol) where T
     Tables.getcolumn(t, key)
+end
 
-_colnames(s::AbstractDimStack) = begin
+function _colnames(s::AbstractDimStack)
     dimkeys = map(dim2key, (dims(s)))
     # The data is always the last column/s
     (dimkeys..., keys(s)...)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -2,7 +2,7 @@ using DimensionalData, Statistics, Test, Unitful, SparseArrays, Dates
 
 using LinearAlgebra: Transpose
 
-using DimensionalData: Rot90, Rot180, Rot270, Rot360, rotdims, rottype
+using DimensionalData: _Rot90, _Rot180, _Rot270, _Rot360, _rottype
 
 @testset "map" begin
     a = [1 2; 3 4]
@@ -197,17 +197,17 @@ end
 
 
 @testset "dimension rotating methods" begin
-    @test rottype(-100) == Rot360()
-    @test rottype(-4) == Rot360()
-    @test rottype(-3) == Rot90()
-    @test rottype(-2) == Rot180()
-    @test rottype(-1) == Rot270()
-    @test rottype(0) == Rot360()
-    @test rottype(1) == Rot90()
-    @test rottype(2) == Rot180()
-    @test rottype(3) == Rot270()
-    @test rottype(4) == Rot360()
-    @test rottype(101) == Rot90()
+    @test _rottype(-100) == _Rot360()
+    @test _rottype(-4) == _Rot360()
+    @test _rottype(-3) == _Rot90()
+    @test _rottype(-2) == _Rot180()
+    @test _rottype(-1) == _Rot270()
+    @test _rottype(0) == _Rot360()
+    @test _rottype(1) == _Rot90()
+    @test _rottype(2) == _Rot180()
+    @test _rottype(3) == _Rot270()
+    @test _rottype(4) == _Rot360()
+    @test _rottype(101) == _Rot90()
 
     da = DimArray([1 2; 3 4], (X([:a, :b]), Y([1.0, 2.0])))
 


### PR DESCRIPTION
This PR is just cleanup. It attempts to use BlueStyle as much as possible and make a lot of the code easier to read.

The one major exception to this is using `function` for every method longer than 92 characters. In practice doing that here for `set.jl`, `selectors.jl` or `primitives.jl` etc. makes the harder to read than they are currently. Constantly swapping between one-line form and multiline form with what are oftern 100 of the same method makes it hard to read what they are dispatching on.