### PR TITLE
add op kw to primitives to allow both way dimsmatch

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -4,7 +4,7 @@
 const UnionAllTupleOrVector = Union{Vector{UnionAll},Tuple{UnionAll,Vararg}}
 
 """
-    sortdims(tosort, order) => Tuple
+    sortdims(tosort, order; op=(<:)) => Tuple
 
 Sort dimensions `tosort` by `order`. Dimensions
 in `order` but missing from `tosort` are replaced with `nothing`.
@@ -12,6 +12,8 @@ in `order` but missing from `tosort` are replaced with `nothing`.
 `tosort` and `order` can be `Tuple`s or `Vector`s or Dimension
 or dimension type. Abstract supertypes like [`TimeDim`](@ref)
 can be used in `order`.
+
+`op` is `<:` by default, but can be `>:` to sort abstract types by concrete types.
 """
 @inline sortdims(tosort, order; op=<:) = sortdims(Tuple(tosort), Tuple(order); op=op)
 @inline sortdims(tosort::Tuple, order::Tuple{<:Integer,Vararg}; op=<:) =
@@ -72,13 +74,15 @@ _opasfunc(::Type{typeof(<:)}) = <:
 _opasfunc(::Type{typeof(>:)}) = >:
 
 """
-    commondims(x, lookup) => Tuple{Vararg{<:Dimension}}
+    commondims(x, lookup; op=<:) => Tuple{Vararg{<:Dimension}}
 
 This is basically `dims(x, lookup)` where the order of the original is kept, 
 unlike [`dims`](@ref) where the lookup tuple determines the order
 
 Also unlike `dims`,`commondims` always returns a `Tuple`, no matter the input.
 No errors are thrown if dims are absent from either `x` or `lookup`.
+
+`op` is `<:` by default, but can be `>:` to sort abstract types by concrete types.
 
 ```jldoctest
 julia> using DimensionalData
@@ -121,9 +125,11 @@ julia> commondims(A, Ti)
 
 Compare 2 dimensions are of the same base type, or 
 are at least rotations/transformations of the same type.
+
+`op` is `<:` by default, but can be `>:` to match abstract types to concrete types.
 """
 @inline dimsmatch(dims::Tuple, lookups::Tuple; op=<:) = 
-    all(map((d, l) ->dimsmatch(d, l; op=op), dims, lookups))
+    all(map((d, l) -> dimsmatch(d, l; op=op), dims, lookups))
 @inline dimsmatch(dim::Dimension, lookup::Dimension; op=<:) = dimsmatch(typeof(dim), typeof(lookup); op=op)
 @inline dimsmatch(dim::Type, lookup::Dimension; op=<:) = dimsmatch(dim, typeof(lookup); op=op)
 @inline dimsmatch(dim::Dimension, lookup::Type; op=<:) = dimsmatch(typeof(dim), lookup; op=op)
@@ -242,6 +248,7 @@ julia> dimnum(A, Y)
 ## Arguments
 - `x`: any object with a `dims` method, a `Tuple` of `Dimension` or a single `Dimension`.
 - `lookup`: Tuple or single `Dimension` or dimension `Type`.
+- `op`: `<:` by default, but can be `>:` to match abstract types to concrete types.
 
 Check if an object or tuple contains an `Dimension`, or a tuple of dimensions.
 
@@ -279,6 +286,7 @@ false
 ## Arguments
 - `x`: any object with a `dims` method, a `Tuple` of `Dimension`.
 - `lookup`: Tuple or single `Dimension` or dimension `Type`.
+- `op`: `<:` by default, but can be `>:` to match abstract types to concrete types.
 
 A tuple holding the unmatched dimensions is always returned.
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -3,7 +3,6 @@ using DimensionalData, Test
 using DimensionalData: val, basetypeof, slicedims, dims2indices, mode,
       @dim, reducedims, XDim, YDim, ZDim, commondims, dim2key, key2dim, dimstride
 
-
 @testset "sortdims" begin
     dimz = (X(), Y(), Z(), Ti())
     @test @inferred sortdims((Y(1:2), X(1)), dimz) == (X(1), Y(1:2), nothing, nothing)
@@ -179,11 +178,16 @@ end
     # Dims are always in the base order
     @test commondims(da, (X, Y)) == dims(da, (X, Y))
     @test commondims(da, (Y, X)) == dims(da, (X, Y))
-    @test basetypeof(commondims(da, DimArray(zeros(5), Y))[1]) <: Y
+    @test basetypeof(commondims(da, DimArray(zeros(5), Y()))[1]) <: Y
 
     @testset "with Dim{X} and symbols" begin
-        @test commondims((Dim{:a}(), Dim{:b}()), (:a, :c)) == (Dim{:a}(),)
-        @test commondims((Dim{:a}(), Y(), Dim{:b}()), (Y, :b, :z)) == (Y(), Dim{:b}())
+        @test @inferred commondims((Dim{:a}(), Dim{:b}()), (:a, :c)) == (Dim{:a}(),)
+        @test @inferred commondims((Dim{:a}(), Y(), Dim{:b}()), (Y, :b, :z)) == (Y(), Dim{:b}())
+    end
+
+    @testset "with abstract types" begin
+        @test @inferred commondims((Z(), Y(), Ti()), (ZDim, Dimension)) == (Z(), Y())
+        @test @inferred commondims((TimeDim, YDim), (Z(), Ti(), Dim{:a}); op=(>:)) == (TimeDim,)
     end
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -200,9 +200,7 @@ end
 
     @testset "hasdim for Abstract types" begin
         @test hasdim(dims(da), (XDim, YDim)) == (true, true)
-        # TODO : should this actually be (true, false) ?
-        # Do we remove the second one for hasdim as well?
-        @test hasdim(dims(da), (XDim, XDim)) == (true, true)
+        @test hasdim(dims(da), (XDim, XDim)) == (true, false)
         @test hasdim(dims(da), (ZDim, YDim)) == (false, true)
         @test hasdim(dims(da), (ZDim, ZDim)) == (false, false)
     end


### PR DESCRIPTION
generalise primitives to work when matching concrete types to abstact, or abstract to concrete