### PR TITLE
generalise units field and method to all object metadata

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -113,7 +113,7 @@ end
 
 """
     DimArray(data, dims, refdims, name)
-    DimArray(data, dims::Tuple [, name::Symbol]; refdims=(), metadata=nothing)
+    DimArray(data, dims::Tuple [, name::Symbol]; refdims=(), metadata=NoMetadata())
 
 The main concrete subtype of [`AbstractDimArray`](@ref).
 
@@ -128,7 +128,7 @@ moves dimensions to reference dimension `refdims` after reducing operations
 - `name`: A string name for the array. Shows in plots and tables.
 - `refdims`: refence dimensions. Usually set programmatically to track past
   slices and reductions of dimension for labelling and reconstruction.
-- `metadata`: Array metadata, or `nothing`
+- `metadata`: Array metadata, or `NoMetadata()`
 
 Indexing can be done with all regular indices, or with [`Dimension`](@ref)s
 and/or [`Selector`](@ref)s. Indexing AbstractDimArray with non-range `AbstractArray`
@@ -156,11 +156,11 @@ struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDi
     metadata::Me
 end
 # 2 or 3 argument version
-function DimArray(data::AbstractArray, dims, name=NoName(); refdims=(), metadata=nothing)
+function DimArray(data::AbstractArray, dims, name=NoName(); refdims=(), metadata=NoMetadata())
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
 end
 # All keyword argument version
-function DimArray(; data, dims, refdims=(), name=NoName(), metadata=nothing)
+function DimArray(; data, dims, refdims=(), name=NoName(), metadata=NoMetadata())
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
 end
 # Construct from another AbstractDimArray

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -156,8 +156,6 @@ index(dim::Dimension{<:AbstractArray}) = val(dim)
 index(dim::Dimension{<:Val}) = unwrap(val(dim))
 
 name(dim::Dimension) = name(typeof(dim))
-units(dim::Dimension) =
-    metadata(dim) isa NoMetadata ? nothing : get(metadata(dim), :units, nothing)
 
 bounds(dim::Dimension) = bounds(mode(dim), dim)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -143,7 +143,11 @@ not a guarantee that they will be. If not available, `nothing` is returned.
 `dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function units end
-units(x) = metadata(x) isa NoMetadata ? nothing : get(metadata(x), :units, nothing)
+units(x) = if metadata(x) isa Nothing || metadata(x) isa NoMetadata 
+        nothing
+    else
+        get(metadata(x), :units, nothing)
+    end
 
 """
     label(x) => String

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -142,7 +142,7 @@ not a guarantee that they will be. If not available, `nothing` is returned.
 `dims` can be `Dimension`s, `Dimension` types, or `Symbols` for `Dim{Symbol}`.
 """
 function units end
-units(x) = nothing
+units(x) = metadata(x) isa NoMetadata ? nothing : get(metadata(x), :units, nothing)
 
 """
     label(x) => String

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -101,6 +101,7 @@ or a mixed tuple.
 `dims` can be a `Dimension`, a dimension type, or a tuple of either.
 """
 function metadata end
+metadata(x) = NoMetadata()
 
 """
     bounds(dim::Dimension) => Tuple{T,T}}

--- a/src/show.jl
+++ b/src/show.jl
@@ -2,9 +2,9 @@
 function Base.show(io::IO, A::AbstractDimArray)
     l = nameof(typeof(A))
     printstyled(io, nameof(typeof(A)); color=:blue)
-    if label(A) != ""
+    if name(A) != Symbol("")
         print(io, " (named ")
-        printstyled(io, label(A); color=:blue)
+        printstyled(io, string(name(A)); color=:blue)
         print(io, ")")
     end
 


### PR DESCRIPTION
So that `label` will return the name and units for a array as well as a dimension.