### PR TITLE
Mixed size stack

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -197,6 +197,7 @@ reorder
 reverse
 fill
 map
+Base.copy!
 ```
 
 ## Non-exported methods for developers

--- a/src/array.jl
+++ b/src/array.jl
@@ -51,7 +51,7 @@ This method can also be used with keyword arguments in place of regular argument
     rebuild(A, data, dims, refdims, name, metadata(A))
 end
 
-@inline rebuildsliced(A, data, I, name=name(A)) = rebuildsliced(getindex, A, data, I, name)
+@inline rebuildsliced(args...) = rebuildsliced(getindex, args...)
 @inline rebuildsliced(f::Function, A, data, I, name=name(A)) = rebuild(A, data, slicedims(f, A, I)..., name)
 
 for func in (:val, :index, :mode, :metadata, :order, :sampling, :span, :bounds, :locus,

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -12,7 +12,7 @@ const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 #### Stack getindex ####
 # Symbol key
 @propagate_inbounds Base.getindex(s::AbstractDimStack, key::Symbol) =
-    DimArray(data(s)[key], dims(s), refdims(s), key, nothing)
+    DimArray(data(s)[key], dims(s, layerdims(s, key)), refdims(s), key, layermetadata(s, key))
 @propagate_inbounds Base.getindex(s::AbstractDimStack, i::Int, I::Int...) =
     map(A -> Base.getindex(A, i, I...), data(s))
 
@@ -42,7 +42,7 @@ for f in (:getindex, :view, :dotview)
         @propagate_inbounds function Base.$f(s::AbstractDimStack, I...; kw...)
             vals = map(A -> Base.$f(A, I...; kw...), dimarrays(s))
             if all(map(v -> v isa AbstractDimArray, vals))
-                rebuildsliced(Base.$f, s, vals, (dims2indices(first(s), I)))
+                rebuildsliced(Base.$f, s, vals, (dims2indices(dims(s), I)))
             else
                 vals
             end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -19,9 +19,9 @@ for (m, f) in ((:Base, :sum), (:Base, :prod), (:Base, :maximum), (:Base, :minimu
         # Local dispatch methods
         # - Return a reduced DimArray
         $_f(A::AbstractDimArray, dims; kw...) =
-            rebuild(A, $m.$f(parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
+            rebuild(A, $m.$f(parent(A); dims=dimnum(A, _astuple(dims)), kw...), reducedims(A, dims))
         $_f(f, A::AbstractDimArray, dims; kw...) =
-            rebuild(A, $m.$f(f, parent(A); dims=dimnum(A, dims), kw...), reducedims(A, dims))
+            rebuild(A, $m.$f(f, parent(A); dims=dimnum(A, _astuple(dims)), kw...), reducedims(A, dims))
         # - Return a scalar
         $_f(A::AbstractDimArray, dims::Colon; kw...) = $m.$f(parent(A); kw...)
         $_f(f, A::AbstractDimArray, dims::Colon; kw...) =
@@ -37,7 +37,7 @@ for (m, f) in ((:Statistics, :std), (:Statistics, :var))
             $_f(A, corrected, mean, dims)
         # Local dispatch methods - Returns a reduced array
         $_f(A::AbstractDimArray, corrected, mean, dims) =
-            rebuild(A, $m.$f(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, dims)), reducedims(A, dims))
+            rebuild(A, $m.$f(parent(A); corrected=corrected, mean=mean, dims=dimnum(A, _astuple(dims))), reducedims(A, dims))
         # - Returns a scalar
         $_f(A::AbstractDimArray, corrected, mean, dims::Colon) =
             $m.$f(parent(A); corrected=corrected, mean=mean, dims=:)
@@ -50,7 +50,7 @@ for (m, f) in ((:Statistics, :median), (:Base, :any), (:Base, :all))
         $m.$f(A::AbstractDimArray; dims=:) = $_f(A, dims)
         # Local dispatch methods - Returns a reduced array
         $_f(A::AbstractDimArray, dims) =
-            rebuild(A, $m.$f(parent(A); dims=dimnum(A, dims)), reducedims(A, dims))
+            rebuild(A, $m.$f(parent(A); dims=dimnum(A, _astuple(dims))), reducedims(A, dims))
         # - Returns a scalar
         $_f(A::AbstractDimArray, dims::Colon) = $m.$f(parent(A); dims=:)
     end
@@ -58,7 +58,7 @@ end
 
 # These are not exported but it makes a lot of things easier using them
 function Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims)
-    rebuild(A, Base._mapreduce_dim(f, op, nt, parent(A), dimnum(A, dims)), reducedims(A, dims))
+    rebuild(A, Base._mapreduce_dim(f, op, nt, parent(A), dimnum(A, _astuple(dims))), reducedims(A, dims))
 end
 function Base._mapreduce_dim(f, op, nt::NamedTuple{(),<:Tuple}, A::AbstractDimArray, dims::Colon)
     Base._mapreduce_dim(f, op, nt, parent(A), dims)
@@ -97,7 +97,7 @@ end
 @inline Base.map(f, A::AbstractDimArray) = rebuild(A, map(f, parent(A)))
 
 function Base.mapslices(f, A::AbstractDimArray; dims=1, kw...)
-    dimnums = dimnum(A, dims)
+    dimnums = dimnum(A, _astuple(dims))
     _data = mapslices(f, parent(A); dims=dimnums, kw...)
     rebuild(A, _data, reducedims(A, DimensionalData.dims(A, dimnums)))
 end

--- a/src/set.jl
+++ b/src/set.jl
@@ -106,8 +106,10 @@ The values must be `AbstractArray of the same size as the original data, to
 match the `Dimension`s in the dims field.
 """
 set(s::AbstractDimStack, newdata::NamedTuple) = begin
-    map(data(s)) do l
-        axes(l) == axes(first(data(s))) || _axiserr(first(data(s)), l)
+    dat = data(s)
+    keys(dat) === keys(newdata) || _keyerr(keys(dat), keys(newdata))
+    map(dat, newdata) do d, nd
+        axes(d) == axes(nd) || _axiserr(d, nd)
     end
     rebuild(s; data=newdata)
 end
@@ -271,3 +273,4 @@ _set(::Nothing, ::Nothing) = nothing
 @noinline _onlydimerror(T) = throw(ArgumentError("Can only set $(typeof(T)) for a dimension. Specify which dimension you want to set it for"))
 @noinline _axiserr(a, b) = throw(ArgumentError("passed in axes $(axes(b)) do not match the currect axes $(axes(a))"))
 @noinline _wrongdimserr(dims, w) = throw(ArgumentError("dim $(basetypeof(w))) not in $(map(basetypeof, dims))"))
+@noinline _keyerr(ka, kb) = throw(ArgumentError("keys $ka and $kb do not match"))

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -5,7 +5,134 @@ Abstract supertype for dimensional stacks.
 
 These have multiple layers of data, but share dimensions.
 """
-abstract type AbstractDimStack{L,N,D} end
+abstract type AbstractDimStack{L,D} end
+
+data(s::AbstractDimStack) = s.data
+dims(s::AbstractDimStack) = s.dims
+dims(s::AbstractDimStack, key::Symbol) = dims(s, layerdims(s)[key])
+refdims(s::AbstractDimStack) = s.refdims
+layerdims(s::AbstractDimStack) = s.layerdims
+layerdims(s::AbstractDimStack, key::Symbol) = layerdims(s)[key]
+metadata(s::AbstractDimStack) = s.metadata
+layermetadata(s::AbstractDimStack) = s.layermetadata
+layermetadata(s::AbstractDimStack, key::Symbol) = layermetadata(s)[key]
+
+layerdims(A::AbstractDimArray) = basedims(A)
+
+@inline Base.keys(s::AbstractDimStack) = keys(data(s))
+Base.values(s::AbstractDimStack) = values(dimarrays(s))
+Base.first(s::AbstractDimStack) = s[first(keys(s))]
+Base.last(s::AbstractDimStack) = s[last(keys(s))]
+# Only compare data and dim - metadata and refdims can be different
+Base.:(==)(s1::AbstractDimStack, s2::AbstractDimStack) =
+    data(s1) == data(s2) && dims(s1) == dims(s2) && layerdims(s1) == layerdims(s2)
+Base.length(s::AbstractDimStack) = length(data(s))
+Base.iterate(s::AbstractDimStack, args...) = iterate(dimarrays(s), args...)
+
+rebuild(s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s), 
+        layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)) =
+    basetypeof(s)(data, dims, refdims, layerdims, metadata, layermetadata)
+
+function rebuildsliced(f::Function, s::AbstractDimStack, data, I) 
+    layerdims = map(basedims, data)
+    dims, refdims = slicedims(s, I)
+    rebuild(s; data=map(parent, data), dims=dims, refdims=refdims, layerdims=layerdims)
+end
+
+function dimarrays(s::AbstractDimStack{<:NamedTuple{Keys}}) where Keys
+    NamedTuple{Keys}(map(K -> s[K], Keys))
+end
+
+
+Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> adapt(to, A), s)
+
+# Dipatch on Tuple of Dimension, and map
+for func in (:index, :mode, :metadata, :sampling, :span, :bounds, :locus, :order)
+    @eval ($func)(s::AbstractDimStack, args...) = ($func)(dims(s), args...)
+end
+
+"""
+    Base.map(f, s::AbstractDimStack)
+
+Apply functrion `f` to each layer of the stack `s`, and rebuild it.
+
+If `f` returns `DimArray`s the result will be another `DimStack`.
+Other values will be returned in a `NamedTuple`.
+"""
+Base.map(f, s::AbstractDimStack) = maybestack(map(f, dimarrays(s)))
+
+maybestack(As::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}}) = DimStack(As)
+maybestack(x::NamedTuple) = x
+
+
+"""
+    Base.copy!(dst::AbstractDimStack, src::AbstractDimStack, [keys=keys(dst)])
+
+Copy all or a subset of layers from one stack to another.
+
+## Example
+
+Copy just the `:sea_surface_temp` and `:humidity` layers from `src` to `dst`.
+
+```julia
+copy!(dst::AbstractDimStack, src::AbstractDimStack, keys=(:sea_surface_temp, :humidity))
+```
+"""
+function Base.copy!(dst::AbstractDimStack, src::AbstractDimStack, keys=keys(dst))
+    # Check all keys first so we don't copy anything if there is any error
+    for key in keys
+        key in Base.keys(dst) || throw(ArgumentError("key $key not found in dest keys"))
+        key in Base.keys(src) || throw(ArgumentError("key $key not found in source keys"))
+    end
+    for key in keys
+        copy!(dst[key], src[key])
+    end
+end
+
+# Array methods
+
+# Methods with no arguments that return a DimStack
+for (mod, fnames) in
+    (:Base => (:inv, :adjoint, :transpose), :LinearAlgebra => (:Transpose,))
+    for fname in fnames
+        @eval ($mod.$fname)(s::AbstractDimStack) = map(A -> ($mod.$fname)(A), s)
+    end
+end
+
+# Methods with an argument that return a DimStack
+for fname in (:rotl90, :rotr90, :rot180, :PermutedDimsArray, :permutedims)
+    @eval (Base.$fname)(s::AbstractDimStack, args...) =
+        map(A -> (Base.$fname)(A, args...), s)
+end
+
+# Methods with keyword arguments that return a DimStack
+for (mod, fnames) in
+    (:Base => (:sum, :prod, :maximum, :minimum, :extrema, :dropdims),
+     :Statistics => (:cor, :cov, :mean, :median, :std, :var))
+    for fname in fnames
+        @eval ($mod.$fname)(s::AbstractDimStack; kw...) =
+            maybestack(map(A -> ($mod.$fname)(A; kw...), dimarrays(s)))
+    end
+end
+
+# Methods that take a function
+for (mod, fnames) in (:Base => (:reduce, :sum, :prod, :maximum, :minimum, :extrema),
+                      :Statistics => (:mean,))
+    for fname in fnames
+        _fname = Symbol(:_, fname)
+        @eval begin
+            ($mod.$fname)(f::Function, s::AbstractDimStack; dims=Colon()) =
+                ($_fname)(f, s, dims)
+            # Colon returns a NamedTuple
+            ($_fname)(f::Function, s::AbstractDimStack, dims::Colon) =
+                map(A -> ($mod.$fname)(f, A), data(s))
+            # Otherwise return a DimStack
+            ($_fname)(f::Function, s::AbstractDimStack, dims) =
+                map(A -> ($mod.$fname)(f, A; dims=dims), s)
+        end
+    end
+end
+
 
 """
     DimStack <: AbstractDimStack
@@ -15,13 +142,13 @@ abstract type AbstractDimStack{L,N,D} end
     DimStack(data::NamedTuple{Keys,Vararg{<:AbstractDimArray}})
     DimStack(data::NamedTuple, dims::DimTuple; metadata=NoMetadata())
 
-DimStack holds multiple objects with the same dimensions, in a `NamedTuple`.
+DimStack holds multiple objects sharing some dimensions, in a `NamedTuple`.
 Indexing operates as for [`AbstractDimArray`](@ref), except it occurs for all
 data layers of the stack simulataneously. Layer objects can hold values of any type.
 
 DimStack can be constructed from multiple `AbstractDimArray` or a `NamedTuple`
 of `AbstractArray` and a matching `dims` `Tuple`. If `AbstractDimArray`s have
-the same name they will be given the name `:layer1`, substitiuting the actual
+the same name they will be given the name `:layer1`, substitiuting the
 layer number for `1`.
 
 `getindex` with `Int` or `Dimension`s or `Selector`s that resolve to `Int` will
@@ -33,7 +160,7 @@ Indexing with a `Vector` or `Colon` will return another `DimStack` where
 all data layers have been sliced.  `setindex!` must pass a `Tuple` or `NamedTuple` maching
 the layers.
 
-Most `Base` and `Statistics` methods that apply gto `AbstractArray` can be used on
+Most `Base` and `Statistics` methods that apply to `AbstractArray` can be used on
 all layers of the stack simulataneously. The result is a `DimStack`, or
 a `NamedTuple` if methods like `mean` are used without `dims` arguments, and
 return a single non-array value.
@@ -64,114 +191,33 @@ true
 ```
 
 """
-struct DimStack{L,N,D,R,M} <: AbstractDimStack{L,N,D}
+struct DimStack{L,D<:Tuple,R<:Tuple,LD<:NamedTuple,M,LM<:NamedTuple} <: AbstractDimStack{L,D}
     data::L
     dims::D
     refdims::R
+    layerdims::LD
     metadata::M
-    DimStack(data::L, dims::D, refdims::R, metadata::M) where {L,D,R,M} = begin
-        N = length(dims)
-        new{L,N,D,R,M}(data, dims, refdims, metadata)
-    end
+    layermetadata::LM
 end
-DimStack(das::AbstractDimArray...) = DimStack(das)
-function DimStack(das::Tuple{Vararg{<:AbstractDimArray}})
-    DimStack(NamedTuple{uniquekeys(das)}(das))
+DimStack(das::AbstractDimArray...; kwargs...) = DimStack(das; kwargs...)
+function DimStack(das::Tuple{Vararg{<:AbstractDimArray}}; kwargs...)
+    DimStack(NamedTuple{uniquekeys(das)}(das); kwargs...)
 end
-function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}})
+function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}}; 
+    refdims=(), metadata=NoMetadata(), layermetadata=map(DD.metadata, das)
+)
     data = map(parent, das)
-    dims = comparedims(das...)
-    meta = map(metadata, das)
-    refdims = () # das might have different refdims
-    DimStack(data, dims, refdims, meta)
+    dims = combinedims(das...)
+    layerdims = map(basedims, das)
+    DimStack(data, dims, refdims, layerdims, metadata, layermetadata)
 end
-function DimStack(data::NamedTuple, dims::Tuple; refdims=(), metadata=NoMetadata())
-    DimStack(data, formatdims(first(data), dims), refdims, metadata)
-end
-data(s::AbstractDimStack) = s.data
-dims(s::DimStack) = s.dims
-metadata(s::AbstractDimStack) = s.metadata
-
-Base.keys(s::AbstractDimStack) = keys(data(s))
-Base.values(s::AbstractDimStack) = values(dimarrays(s))
-Base.first(s::AbstractDimStack) = first(dimarrays(s))
-# Only compare data and dim - metadata and refdims can be different
-Base.:(==)(s1::AbstractDimStack, s2::AbstractDimStack) =
-    data(s1) == data(s2) && dims(s1) == dims(s2)
-
-rebuild(s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s), metadata=metadata(s)) =
-    basetypeof(s)(data, dims, refdims, metadata)
-
-rebuildsliced(s::AbstractDimStack, data, I) = rebuild(s, data, slicedims(s, I)...)
-
-function dimarrays(s::AbstractDimStack{<:NamedTuple{Keys}}) where Keys
-    NamedTuple{Keys}(map(Keys, values(data(s))) do k, A
-         DimArray(A, dims(s), refdims(s), k, NoMetadata())
-    end)
+# Same sized arrays
+function DimStack(data::NamedTuple, dims::Tuple; 
+    refdims=(), metadata=NoMetadata(), layermetadata=map(_ -> NoMetadata(), data)
+)
+    all(map(d -> axes(d) == axes(first(data)), data)) || _stack_size_mismatch()
+    layerdims = map(_ -> basedims(dims), data)
+    DimStack(data, formatdims(first(data), dims), refdims, layerdims, metadata, layermetadata)
 end
 
-Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> adapt(to, A), s)
-
-# Dipatch on Tuple of Dimension, and map
-for func in (:index, :mode, :metadata, :sampling, :span, :bounds, :locus, :order)
-    @eval ($func)(s::AbstractDimStack, args...) = ($func)(dims(s), args...)
-end
-
-"""
-    Base.map(f, s::AbstractDimStack)
-
-Apply functrion `f` to each layer of the stack `s`, and rebuild it.
-
-If `f` returns `DimArray`s the result will be another `DimStack`.
-Other values will be returned in a `NamedTuple`.
-"""
-Base.map(f, s::AbstractDimStack) = _maybestack(map(f, dimarrays(s)))
-
-_maybestack(As::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}}) = DimStack(As)
-_maybestack(x::NamedTuple) = x
-
-
-# Array methods
-
-# Methods with no arguments that return a DimStack
-for (mod, fnames) in
-    (:Base => (:inv, :adjoint, :transpose), :LinearAlgebra => (:Transpose,))
-    for fname in fnames
-        @eval ($mod.$fname)(s::AbstractDimStack) = map(A -> ($mod.$fname)(A), s)
-    end
-end
-
-# Methods with an argument that return a DimStack
-for fname in (:rotl90, :rotr90, :rot180, :PermutedDimsArray, :permutedims)
-    @eval (Base.$fname)(s::AbstractDimStack, args...) =
-        map(A -> (Base.$fname)(A, args...), s)
-end
-
-# Base/Statistics methods with keyword arguments that return a DimStack
-for (mod, fnames) in
-    (:Base => (:sum, :prod, :maximum, :minimum, :extrema, :dropdims),
-     :Statistics => (:cor, :cov, :mean, :median, :std, :var))
-    for fname in fnames
-        @eval ($mod.$fname)(s::AbstractDimStack; kw...) =
-            _maybestack(map(A -> ($mod.$fname)(A; kw...), dimarrays(s)))
-    end
-end
-
-# Methods that take a function
-for (mod, fnames) in (:Base => (:reduce, :sum, :prod, :maximum, :minimum, :extrema),
-                      :Statistics => (:mean,))
-    for fname in fnames
-        _fname = Symbol(:_, fname)
-        @eval begin
-            ($mod.$fname)(f::Function, s::AbstractDimStack; dims=Colon()) =
-                ($_fname)(f, s, dims)
-            # Colon returns a NamedTuple
-            ($_fname)(f::Function, s::AbstractDimStack, dims::Colon) =
-                map(A -> ($mod.$fname)(f, A), data(s))
-            # Otherwise return a DimStack
-            ($_fname)(f::Function, s::AbstractDimStack, dims) =
-                map(A -> ($mod.$fname)(f, A; dims=dims), s)
-        end
-    end
-end
-
+@noinline _stack_size_mismatch() = throw(ArgumentError("Arrays must have identical axes. For mixed dimensions, use DimArrays`"))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -136,7 +136,8 @@ modify(CuArray, A)
 
 This also works for all the data layers in a `DimStack`.
 """
-modify(f, s::AbstractDimStack) = map(f, s)
+function modify end
+modify(f, s::AbstractDimStack) = map(a -> modify(f, a), s)
 function modify(f, A::AbstractDimArray)
     newdata = f(parent(A))
     size(newdata) == size(A) || error("$f returns an array with a different size")
@@ -314,3 +315,6 @@ maybeshiftlocus(locus::Locus, dim::Dimension) = _maybeshiftlocus(locus, sampling
 
 _maybeshiftlocus(locus::Locus, sampling::Intervals, dim::Dimension) = shiftlocus(locus, dim)
 _maybeshiftlocus(locus::Locus, sampling::Sampling, dim::Dimension) = dim
+
+_astuple(t::Tuple) = t
+_astuple(x) = (x,)

--- a/test/set.jl
+++ b/test/set.jl
@@ -25,8 +25,10 @@ s = DimStack(da2, DimArray(2a2, dimz2, :test3))
 end
 
 @testset "DimStack fields" begin
-    s2 = set(s, (x=a2, y=3a2))
-    @test keys(s2) == (:x, :y)
+    @test_throws ArgumentError set(s, (x=a2, y=3a2))
+    @test_throws ArgumentError set(s, (test2=a2, test3=hcat(a2, a2)))
+    s2 = set(s, (test2=a2, test3=3a2))
+    @test keys(s2) == (:test2, :test3)
     @test values(s2) == (a2, 3a2)
     @test metadata(set(s, Metadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -2,12 +2,15 @@ using DimensionalData, Test, LinearAlgebra, Statistics
 
 A = [1.0 2.0 3.0;
      4.0 5.0 6.0]
-dimz = (X([:a, :b]), Y(10.0:10.0:30.0))
-da1 = DimArray(A, dimz, :one)
-da2 = DimArray(Float32.(2A), dimz, :two)
-da3 = DimArray(Int.(3A), dimz, :three)
+x, y, z = X([:a, :b]), Y(10.0:10.0:30.0), Z()
+dimz = x, y
+da1 = DimArray(A, (x, y), :one)
+da2 = DimArray(Float32.(2A), (x, y), :two)
+da3 = DimArray(Int.(3A), (x, y), :three)
+da4 = DimArray(cat(4A, 5A, 6A; dims=3), (x, y, z), :extradim)
 
 s = DimStack((da1, da2, da3))
+mixed = DimStack((da1, da2, da4))
 
 @testset "Constructors" begin
     @test DimStack((one=A, two=2A, three=3A), dimz) == s
@@ -18,10 +21,81 @@ end
 @testset "Properties" begin
     @test DimensionalData.dims(s) == dims(da1)
     @test keys(data(s)) == (:one, :two, :three)
-    @test keys(data(s)) == (:one, :two, :three)
+    @test keys(data(mixed)) == (:one, :two, :extradim)
     da1x = s[:one]
     @test parent(da1x) === parent(da1)
     @test dims(da1x) === dims(da1)
+end
+
+@testset "getindex" begin
+    @test s[1, 1] === (one=1.0, two=2.0f0, three=3)
+    @test s[X(2), Y(3)] === (one=6.0, two=12.0f0, three=18)
+    @test s[X=:b, Y=10.0] === (one=4.0, two=8.0f0, three=12)
+    slicedds = s[:a, :]
+    @test slicedds[:one] == [1.0, 2.0, 3.0]
+    @test data(slicedds) == (one=[1.0, 2.0, 3.0], two=[2.0f0, 4.0f0, 6.0f0], three=[3, 6, 9])
+    @testset "linear indices" begin
+        linear2d = s[1:2]
+        @test linear2d isa NamedTuple
+        @test linear2d == (one=[1.0, 4.0], two=[2.0f0, 8.0f0], three=[3, 12])
+        linear1d = s[Y(1)][1:2]
+        @test linear1d isa DimStack
+        @test data(linear1d) == (one=[1.0, 4.0], two=[2.0f0, 8.0f0], three=[3, 12])
+    end
+    @testset "mixed" begin
+        noz = mixed[Z(1)]
+        @test dims(noz) == dims(da1)
+        @test refdims(noz) == (Z(1; mode=NoIndex()),)
+        @test mixed[X(1), Y(1)] == (one=1.0, two=2.0f0, extradim=mixed[:extradim][1, 1, :])
+        linear = mixed[1:2]
+        @test linear isa NamedTuple
+        @test linear == (one=[1.0, 4.0], two=[2.0f0, 8.0f0], extradim=[4.0, 16.0])
+    end
+end
+
+@testset "view" begin
+    sv = view(s, 1, 1)
+    @test sv.data == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
+    @test dims(sv) == ()
+    sv = view(s, X(1:2), Y(3:3)) 
+    @test sv.data == (one=[3.0 6.0]', two=[6.0f0 12.0f0]', three=[9 18]')
+    slicedds = view(s, X=:a, Y=:)
+    @test slicedds[:one] == [1.0, 2.0, 3.0]
+    @test data(slicedds) == (one=[1.0, 2.0, 3.0], two=[2.0f0, 4.0f0, 6.0f0], three=[3, 6, 9])
+    @testset "linear indices" begin
+        linear2d = view(s, 1)
+        @test linear2d isa NamedTuple
+        @test linear2d == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
+        linear1d = view(s[X(1)], 1)
+        @test_broken linear1d isa DimStack
+        @test_broken data(linear1d) == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
+    end
+end
+
+@testset "setindex!" begin
+    s_set = deepcopy(s)
+    s_set[1, 1] = (one=9, two=10, three=11)
+    @test s_set[1, 1] === (one=9.0, two=10.0f0, three=11) 
+    s_set[X=:b, Y=10.0] = (one=7, two=11, three=13)
+    @test s_set[2, 1] === (one=7.0, two=11.0f0, three=13) 
+end
+
+
+@testset "Empty getindedex/view/setindex throws a BoundsError" begin
+    @test_throws BoundsError s[]
+    @test_throws BoundsError view(s)
+    @test_throws BoundsError s[] = 1
+end
+
+@testset "Cartesian indices work as usual" begin
+    @test s[CartesianIndex(2, 2)] == (one=5.0, two=10.0, three=15.0)
+    @test view(s, CartesianIndex(2, 2)) == map(d -> view(d, 2, 2), data(s))
+    s_set = deepcopy(s)
+    s_set[CartesianIndex(2, 2)] = (one=5, two=6, three=7)
+    @test s_set[2, 2] === (one=5.0, two=6.0f0, three=7)
+    s_set[CartesianIndex(2, 2)] = (9, 10, 11)
+    @test s_set[2, 2] === (one=9.0, two=10.0f0, three=11)
+    @test_throws ArgumentError s_set[CartesianIndex(2, 2)] = (seven=5, two=6, three=7)
 end
 
 @testset "map" begin
@@ -29,8 +103,6 @@ end
     @test dims(map(a -> a .* 2, s)) == dims(DimStack(2da1, 2da2, 2da3))
     @test map(a -> a[1], s) == (one=1.0, two=2.0, three=3.0)
 end
-
-
 
 @testset "Methods with no arguments" begin
     @testset "permuting methods" begin
@@ -81,6 +153,9 @@ end
         @test std(s; dims=X) == DimStack(std(da1; dims=X), std(da2; dims=X), std(da3; dims=X))
         @test var(s; dims=X) == DimStack(var(da1; dims=X), var(da2; dims=X), var(da3; dims=X))
         @test median(s; dims=X) == DimStack(median(da1; dims=X), median(da2; dims=X), median(da3; dims=X))
+        mean(mixed; dims=X)
+        mean(mixed; dims=Y)
+        @test_broken mean(mixed; dims=Z)
     end
 
     @testset "dim duplicating methods" begin


### PR DESCRIPTION
This PR add mixed size stacks as discussed in #221.

- Indexing into the stack indexes only the dimensions each layer has.
- Table columns are all the same length, smaller arrays are looped over the missing dimension lazily.

The main open questions are:
- what to do when you index away the dimensions of one layer to leave only a scalar, but other layers are still `DimArray`. Possibly just returning a `NamedTuple` is best at that point, as we do when all the values are scalars.
- what to do about `mean` and other methods that take a `dims` argument, when the dim only exists for some layers.

@ali-ramadhan do you have any thoughts on this?

Closes #221