### PR TITLE
fix logical indexing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -20,7 +20,7 @@ abstract type AbstractDimArray{T,N,D<:Tuple,A} <: AbstractArray{T,N} end
 const AbstractDimVector = AbstractDimArray{T,1} where T
 const AbstractDimMatrix = AbstractDimArray{T,2} where T
 
-const StandardIndices = Union{AbstractVector{<:Integer},Colon,Integer}
+const StandardIndices = Union{AbstractArray{<:Integer},Colon,Integer}
 
 # DimensionalData.jl interface methods ####################################################
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -30,6 +30,8 @@ for f in (:getindex, :view, :dotview)
         # Linear indexing returns parent type
         @propagate_inbounds Base.$f(A::AbstractDimArray, i::Union{Colon,AbstractVector{<:Integer}}) =
             Base.$f(parent(A), i)
+        @propagate_inbounds Base.$f(A::AbstractDimArray, i::AbstractArray{<:Bool}) =
+            Base.$f(parent(A), i)
         # Except 1D DimArrays
         @propagate_inbounds Base.$f(A::AbstractDimArray{<:Any, 1}, i::Union{Colon,AbstractVector{<:Integer}}) =
             rebuildsliced(A, Base.$f(parent(A), i), (i,))

--- a/test/array.jl
+++ b/test/array.jl
@@ -73,6 +73,15 @@ end
 
 end
 
+@testset "logical indexing" begin
+    A = DimArray(zeros(40, 50), (X, Y));
+    I = rand(40, 50) .< 0.5
+    @test all(A[I] .== 0.0)
+    A[I] .= 3
+    @test all(A[I] .== 3.0)
+    @test all(view(A, I .== 3.0))
+end
+
 @testset "view returns DimensionArray containing views" begin
     v = view(da, Y(1), X(1))
     @test v[] == 1


### PR DESCRIPTION
Minor fix to handle logical indexing in `getindex/view/dotview` methods.

Closes #230