### PR TITLE
Explicit spans

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -117,6 +117,7 @@ Index modes for [`Intervals`](@ref)
 Span
 Regular
 Irregular
+Explicit
 AutoSpan
 ```
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -37,7 +37,7 @@ export IndexOrder, ArrayOrder, Relation,
 
 export Sampling, Points, Intervals
 
-export Span, Regular, Irregular, AutoSpan
+export Span, Regular, Irregular, Explicit, AutoSpan
 
 export Mode, IndexMode, Auto, AutoMode, NoIndex
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -176,7 +176,7 @@ index(dim::Dimension{<:Val}) = unwrap(val(dim))
 name(dim::Dimension) = name(typeof(dim))
 name(dim::Val{D}) where D = name(D)
 
-bounds(dim::Dimension) = bounds(mode(dim), dim)
+bounds(dim::Dimension) = _bounds(mode(dim), dim)
 
 modetype(dim::Dimension) = typeof(mode(dim))
 modetype(::Type{<:Dimension{<:Any,Mo}}) where Mo = Mo

--- a/src/identify.jl
+++ b/src/identify.jl
@@ -39,7 +39,7 @@ identify(mode::AbstractSampled, dimtype::Type, index) =
     )
 identify(order::Order, dimtype::Type, index) = order
 identify(order::AutoOrder, dimtype::Type, index) = _orderof(index)
-# Spant
+# Span
 identify(span::AutoSpan, dimtype::Type, index::Union{AbstractArray,Val}) = Irregular()
 identify(span::AutoSpan, dimtype::Type, index::AbstractRange) = Regular(step(index))
 identify(span::Regular{AutoStep}, dimtype::Type, index::Union{AbstractArray,Val}) = _arraynosteperror()
@@ -49,7 +49,9 @@ identify(span::Regular, dimtype::Type, index::AbstractRange) = begin
     step(span) isa Number && !(step(span) ≈ step(index)) && _steperror(index, span)
     span
 end
+identify(span::Irregular{AutoBounds}, dimtype, index) = Irregular(nothing, nothing)
 identify(span::Irregular{<:Tuple}, dimtype, index) = span
+identify(span::Explicit, dimtype, index) = span
 # Sampling
 identify(sampling::AutoSampling, dimtype::Type, index) = Points()
 identify(sampling::Points, dimtype::Type, index) = sampling

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -228,7 +228,8 @@ function _vcat_modes(::Intervals, ::Irregular, modes...)
     newbounds = minimum(map(first, allbounds)), maximum(map(last, allbounds))
     rebuild(modes[1]; span=Irregular(newbounds))
 end
-_vcat_modes(::Points, ::Irregular, modes...) = rebuild(first(modes); span=Irregular())
+_vcat_modes(::Points, ::Irregular, modes...) = 
+    rebuild(first(modes); span=Irregular(nothing, nothing))
 
 # Index vcat depends on mode: NoIndex is always Colon()
 _vcat_index(mode::NoIndex, A...) = OneTo(sum(map(length, A)))

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -325,6 +325,7 @@ Span will be guessed and replaced by a constructor.
 struct AutoSpan <: Span end
 
 struct AutoStep end
+struct AutoBounds end
 
 """
     Regular <: Span
@@ -353,13 +354,28 @@ Irregular have irrigular size. To enable bounds tracking and accuract
 selectors, the starting bounds must be provided as a 2 tuple,
 or 2 arguments.
 """
-struct Irregular{B<:Union{<:Tuple{<:Any,<:Any},Nothing}} <: Span
+struct Irregular{B<:Union{<:Tuple{<:Any,<:Any},AutoBounds}} <: Span
     bounds::B
 end
-Irregular() = Irregular(nothing, nothing)
+Irregular() = Irregular(AutoBounds())
 Irregular(lowerbound, upperbound) = Irregular((lowerbound, upperbound))
 
 bounds(span::Irregular) = span.bounds
+val(span::Irregular) = span.bounds
+
+"""
+    Explicit(bounds::AbstractMatix)
+
+Explicit span is explicitly listed for every interval. This uses a matrix where
+with length 2 columns for each index value - holding the lower and upper bounds
+for that specific index. 
+"""
+struct Explicit{B} <: Span
+    val::B
+end
+Explicit() = Explicit(AutoBounds())
+
+val(span::Explicit) = span.val
 
 """
     Mode 
@@ -372,7 +388,7 @@ abstract type Mode end
 """
     IndexMode <: Mode
 
-Types defining the behaviour of a dimension index, how it is plotted 
+Types defining the behaviour of a dimension index, how it is plotted
 and how [`Selector`](@ref)s like [`Between`](@ref) work.
 
 An `IndexMode` may be a simple type like [`NoIndex`](@ref) indicating that the index is
@@ -416,15 +432,15 @@ Base.step(mode::AutoMode, dim) = Base.step(index(dim))
 
 const Auto = AutoMode
 
-bounds(mode::IndexMode, dim) = bounds(indexorder(mode), mode, dim)
-bounds(::ForwardIndex, ::IndexMode, dim) = first(dim), last(dim)
-bounds(::ReverseIndex, ::IndexMode, dim) = last(dim), first(dim)
-bounds(::UnorderedIndex, ::IndexMode, dim) = (nothing, nothing)
+_bounds(mode::IndexMode, dim) = _bounds(indexorder(mode), mode, dim)
+_bounds(::ForwardIndex, ::IndexMode, dim) = first(dim), last(dim)
+_bounds(::ReverseIndex, ::IndexMode, dim) = last(dim), first(dim)
+_bounds(::UnorderedIndex, ::IndexMode, dim) = (nothing, nothing)
 
 @noinline Base.step(mode::T) where T <: IndexMode =
     error("No step provided by $T. Use a `Sampled` with `Regular`")
 
-slicemode(mode::IndexMode, index, I) = mode
+_slicemode(mode::IndexMode, index, I) = mode
 
 
 """
@@ -474,6 +490,7 @@ map(mode, dims(A))
 struct NoIndex <: Aligned{Ordered{ForwardIndex,ForwardArray,ForwardRelation}} end
 
 order(mode::NoIndex) = Ordered(ForwardIndex(), ForwardArray(), ForwardRelation())
+span(mode::NoIndex) = Regular(1)
 
 Base.step(mode::NoIndex) = 1
 
@@ -490,46 +507,61 @@ or a `rebuild` method that accpts them as keyword arguments.
 abstract type AbstractSampled{O<:Order,Sp<:Span,Sa<:Sampling} <: Aligned{O} end
 
 span(mode::AbstractSampled) = mode.span
+@noinline span(mode::T) where T<:IndexMode =
+    error("$T has no span. Pass a `span` field manually.")
+
 sampling(mode::AbstractSampled) = mode.sampling
 locus(mode::AbstractSampled) = locus(sampling(mode))
 
 Base.step(mode::AbstractSampled) = step(span(mode))
 
 # bounds
-bounds(mode::AbstractSampled, dim) = bounds(sampling(mode), span(mode), mode, dim)
-bounds(::Points, span, mode::AbstractSampled, dim) = bounds(indexorder(mode), mode, dim)
-bounds(::Intervals, span::Irregular, mode::AbstractSampled, dim) = bounds(span)
-bounds(::Intervals, span::Regular, mode::AbstractSampled, dim) =
-    bounds(locus(mode), indexorder(mode), span, mode, dim)
-bounds(::Start, ::ForwardIndex, span, mode, dim) = first(dim), last(dim) + step(span)
-bounds(::Start, ::ReverseIndex, span, mode, dim) = last(dim), first(dim) - step(span)
-bounds(::Center, ::ForwardIndex, span, mode, dim) =
+_bounds(mode::AbstractSampled, dim) = _bounds(sampling(mode), span(mode), mode, dim)
+
+_bounds(::Points, span, mode::AbstractSampled, dim) = _bounds(indexorder(mode), mode, dim)
+_bounds(::Intervals, span::Irregular, mode::AbstractSampled, dim) = bounds(span)
+_bounds(sampling::Intervals, span::Explicit, mode::AbstractSampled, dim) = 
+    _bounds(indexorder(dim), sampling, span, mode, dim)
+_bounds(::ForwardIndex, ::Intervals, span::Explicit, mode::AbstractSampled, dim) = 
+    (val(span)[1, 1], val(span)[2, end])
+_bounds(::ReverseIndex, ::Intervals, span::Explicit, mode::AbstractSampled, dim) = 
+    (val(span)[1, end], val(span)[2, 1])
+_bounds(::Intervals, span::Regular, mode::AbstractSampled, dim) =
+    _bounds(locus(mode), indexorder(mode), span, mode, dim)
+_bounds(::Start, ::ForwardIndex, span, mode, dim) = first(dim), last(dim) + step(span)
+_bounds(::Start, ::ReverseIndex, span, mode, dim) = last(dim), first(dim) - step(span)
+_bounds(::Center, ::ForwardIndex, span, mode, dim) =
     first(dim) - step(span) / 2, last(dim) + step(span) / 2
-bounds(::Center, ::ReverseIndex, span, mode, dim) =
+_bounds(::Center, ::ReverseIndex, span, mode, dim) =
     last(dim) + step(span) / 2, first(dim) - step(span) / 2
-bounds(::End, ::ForwardIndex, span, mode, dim) = first(dim) - step(span), last(dim)
-bounds(::End, ::ReverseIndex, span, mode, dim) = last(dim) + step(span), first(dim)
+_bounds(::End, ::ForwardIndex, span, mode, dim) = first(dim) - step(span), last(dim)
+_bounds(::End, ::ReverseIndex, span, mode, dim) = last(dim) + step(span), first(dim)
 
 # TODO: deal with unordered AbstractArray indexing
-slicemode(mode::AbstractSampled, index, i) =
+_slicemode(mode::AbstractSampled, index, i) =
     slicemode(sampling(mode), span(mode), mode, index, i)
-slicemode(::Any, ::Any, mode::AbstractSampled, index, i) = mode
-slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::UnitRange) = mode
-slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::AbstractRange) =
+_slicemode(::Any, ::Any, mode::AbstractSampled, index, i) = mode
+_slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::UnitRange) = mode
+_slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::AbstractRange) =
     rebuild(mode; span=Regular(step(mode) * step(i)))
-slicemode(::Intervals, ::Irregular, mode::AbstractSampled, index, i) =
-    rebuild(mode; span=Irregular(slicebounds(mode, index, i)))
+_slicemode(::Intervals, ::Union{Irregular,Explicit}, mode::AbstractSampled, index, i) = begin
+    span = _slicespan(mode, index, i)
+    rebuild(mode; order=order(mode), span=span, sampling=sampling(mode))
+end
 
-slicebounds(m::IndexMode, index, I) =
-    slicebounds(locus(m), bounds(span(m)), index, _maybeflip(indexorder(m), index, I))
-slicebounds(locus::Start, bounds, index, I) =
-    index[first(I)], last(I) >= lastindex(index) ? bounds[2] : index[last(I) + 1]
-slicebounds(locus::End, bounds, index, I) =
-    first(I) <= firstindex(index) ? bounds[1] : index[first(I) - 1], index[last(I)]
-slicebounds(locus::Center, bounds, index, I) =
-    first(I) <= firstindex(index) ? bounds[1] : (index[first(I) - 1] + index[first(I)]) / 2,
-    last(I)  >= lastindex(index)  ? bounds[2] : (index[last(I) + 1]  + index[last(I)]) / 2
-
+_slicespan(m::IndexMode, index, i) =
+    _slicespan(span(m), m, index, _maybeflip(indexorder(m), index, i))
+_slicespan(span::Explicit, m::IndexMode, index, i::Int) = Explicit(val(span)[:, i])
+_slicespan(span::Explicit, m::IndexMode, index, i::AbstractArray) = Explicit(val(span)[:, i])
+_slicespan(span::Irregular, m::IndexMode, index, i) =
+    Irregular(_slicespan(locus(m), span, index, i))
+_slicespan(locus::Start, span::Irregular, index, i) =
+    index[first(i)], last(i) >= lastindex(index) ? bounds(span)[2] : index[last(i) + 1]
+_slicespan(locus::End, span::Irregular, index, i) =
+    first(i) <= firstindex(index) ? bounds(span)[1] : index[first(i) - 1], index[last(i)]
+_slicespan(locus::Center, span::Irregular, index, i) =
+    first(i) <= firstindex(index) ? bounds(span)[1] : (index[first(i) - 1] + index[first(i)]) / 2,
+    last(i)  >= lastindex(index)  ? bounds(span)[2] : (index[last(i) + 1]  + index[last(i)]) / 2
 
 """
     Sampled <: AbstractSampled

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -507,8 +507,6 @@ or a `rebuild` method that accpts them as keyword arguments.
 abstract type AbstractSampled{O<:Order,Sp<:Span,Sa<:Sampling} <: Aligned{O} end
 
 span(mode::AbstractSampled) = mode.span
-@noinline span(mode::T) where T<:IndexMode =
-    error("$T has no span. Pass a `span` field manually.")
 
 sampling(mode::AbstractSampled) = mode.sampling
 locus(mode::AbstractSampled) = locus(sampling(mode))
@@ -539,7 +537,7 @@ _bounds(::End, ::ReverseIndex, span, mode, dim) = last(dim) + step(span), first(
 
 # TODO: deal with unordered AbstractArray indexing
 _slicemode(mode::AbstractSampled, index, i) =
-    slicemode(sampling(mode), span(mode), mode, index, i)
+    _slicemode(sampling(mode), span(mode), mode, index, i)
 _slicemode(::Any, ::Any, mode::AbstractSampled, index, i) = mode
 _slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::UnitRange) = mode
 _slicemode(::Any, ::Regular, mode::AbstractSampled, index, i::AbstractRange) =

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -371,14 +371,13 @@ end
 @inline _slicedims(d::Dimension, i) = _slicedims(mode(d), d, i)
 @inline _slicedims(::IndexMode, d::Dimension, i::Colon) = (d,), ()
 @inline _slicedims(::IndexMode, d::Dimension, i::Integer) =
-    (), (rebuild(d, d[relate(d, i)], slicemode(mode(d), val(d), i)),)
+    (), (rebuild(d, d[relate(d, i)], _slicemode(mode(d), val(d), i)),)
 @inline _slicedims(::NoIndex, d::Dimension, i::Integer) = (), (rebuild(d, i),)
-
 # TODO deal with unordered arrays trashing the index order
 @inline _slicedims(::IndexMode, d::Dimension{<:Val{Index}}, i::AbstractArray) where Index =
-    (rebuild(d, Val{Index[relate(d, i)]}(), slicemode(mode(d), val(d), i)),), ()
+    (rebuild(d, Val{Index[relate(d, i)]}(), _slicemode(mode(d), val(d), i)),), ()
 @inline _slicedims(::IndexMode, d::Dimension{<:AbstractArray}, i::AbstractArray) =
-    (rebuild(d, d[relate(d, i)], slicemode(mode(d), val(d), i)),), ()
+    (rebuild(d, d[relate(d, i)], _slicemode(mode(d), val(d), i)),), ()
 @inline _slicedims(::NoIndex, d::Dimension{<:AbstractArray}, i::AbstractArray) =
     (rebuild(d, d[relate(d, i)]),), ()
 # Should never happen, just for ambiguity
@@ -435,6 +434,12 @@ end
 @inline _reducedims(::Regular, ::Any, mode::AbstractSampled, dim::Dimension) = begin
     mode = rebuild(mode; order=Ordered(), span=Regular(step(mode) * length(dim)))
     rebuild(dim, _reducedims(locus(mode), dim), mode)
+end
+@inline _reducedims(span::Explicit, ::Intervals, mode::AbstractSampled, dim::Dimension) = begin
+    index = _reducedims(Center(mode), dim)
+    bnds = val(span)
+    mode = rebuild(mode; order=Ordered(), span=Explicit([bnds[1, 1], bnds[2, end]]))
+    rebuild(dim, index, mode)
 end
 # Get the index value at the reduced locus.
 # This is the start, center or end point of the whole index.

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -373,6 +373,15 @@ function contains(span::Regular, ::Intervals, order, locus, dim::Dimension, sel:
     end
     i
 end
+# Explicit Intervals ---------------------------
+function contains(span::Explicit, ::Intervals, order, locus, dim::Dimension, sel::Contains)
+    x = val(sel)
+    i = searchsortedlast(view(val(span), 1, :), x; rev=isrev(order))
+    if i <= 0 || val(span)[2, i] < x 
+        _notcontainederror(x)
+    end
+    i
+end
 # Irregular Intervals -------------------------
 function contains(span::Irregular, ::Intervals, order::IndexOrder, locus::Locus, dim::Dimension, sel::Contains)
     _locus_checkbounds(locus, bounds(span), val(sel))
@@ -432,6 +441,14 @@ end
 function between(span::Regular, ::Intervals, o::IndexOrder, mode::IndexMode, dim::Dimension, sel::Between)
     b1, b2 = _maybeflip(o, _sorttuple(sel) .+ _locus_adjust(mode))
     _inbounds((_searchfirst(o, dim, b1), _searchlast(o, dim, b2)), dim)
+end
+# Explicit Intervals -------------------------
+function between(span::Explicit, ::Intervals, o::IndexOrder, mode::IndexMode, dim::Dimension, sel::Between)
+    _inbounds(
+        (searchsortedfirst(view(val(span), 1, :), first(val(sel)); rev=isrev(o), lt=<),
+         searchsortedlast(view(val(span), 2, :), last(val(sel)); rev=isrev(o), lt=<)),
+        dim
+    )
 end
 # Irregular Intervals -----------------------
 function between(span::Irregular, ::Intervals, o::IndexOrder, mode::IndexMode, d::Dimension, sel::Between)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -309,7 +309,7 @@ end
             irp_dim = vcat(X([1, 3, 4], Sampled(Ordered(), Irregular(1, 5), Points())), 
                           X([7, 8], Sampled(Ordered(), Irregular(7, 9), Points())))
             @test span(irp_dim) == Irregular(nothing, nothing)
-            @test mode(irp_dim) == Sampled(Ordered(), Irregular(), Points())
+            @test mode(irp_dim) == Sampled(Ordered(), Irregular(nothing, nothing), Points())
             @test index(irp_dim) == [1, 3, 4, 7, 8]
             @test bounds(irp_dim) == (1, 8)
         end

--- a/test/mode.jl
+++ b/test/mode.jl
@@ -146,14 +146,14 @@ end
             ind = 10.0:10.0:50.0
             dim = X(ind; mode=Sampled(Ordered(), Irregular(0.0, 50000.0), Intervals(Start())))
             @test bounds(dim) == (0.0, 50000.0)
-            @test bounds(DimensionalData.slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
+            @test bounds(DimensionalData._slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
         end
         @testset "Explicit bounds are is stored in span matrix" begin
             ind = 10.0:10.0:50.0
             bnds = vcat(ind', (ind .+ 10)')
             dim = X(ind; mode=Sampled(Ordered(), Explicit(bnds), Intervals(Start())))
             @test bounds(dim) == (10.0, 60.0)
-            @test bounds(DimensionalData.slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
+            @test bounds(DimensionalData._slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
         end
     end
 

--- a/test/mode.jl
+++ b/test/mode.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful
-using DimensionalData: slicebounds, slicemode, isrev
+using DimensionalData: _slicespan, _slicemode, isrev, _bounds
 
 @testset "order" begin
     @test indexorder(Ordered()) == ForwardIndex()
@@ -38,10 +38,10 @@ end
         Unordered(ReverseRelation())
     @test reverse(IndexOrder, Ordered(ForwardIndex(), ReverseArray(), ForwardRelation())) ==
         Ordered(ReverseIndex(), ReverseArray(), ReverseRelation())
-    @test order(reverse(IndexOrder, Sampled(order=Ordered(ForwardIndex(), ReverseArray(), ForwardRelation())))) ==
+    @test order(reverse(IndexOrder, Sampled(order=Ordered(ForwardIndex(), ReverseArray(), ForwardRelation()), span=Regular(1)))) ==
         Ordered(ReverseIndex(), ReverseArray(), ReverseRelation())
         Ordered(ForwardIndex(), ForwardArray(), ReverseRelation())
-    @test order(reverse(IndexOrder, Sampled(order=Ordered(ForwardIndex(), ReverseArray(), ReverseRelation())))) ==
+    @test order(reverse(IndexOrder, Sampled(order=Ordered(ForwardIndex(), ReverseArray(), ReverseRelation()), span=Regular(1)))) ==
         Ordered(ReverseIndex(), ReverseArray(), ForwardRelation())
     @test order(reverse(IndexOrder, Categorical(order=Ordered(ForwardIndex(), ReverseArray(), ReverseRelation())))) ==
         Ordered(ReverseIndex(), ReverseArray(), ForwardRelation())
@@ -49,62 +49,62 @@ end
 
 @testset "slicebounds" begin
     index = [10.0, 20.0, 30.0, 40.0, 50.0]
-    bound = (10.0, 60.0)
-    @test slicebounds(Start(), bounds, index, 2:3) == (20.0, 40.0)
-    bound = (0.0, 50.0)
-    @test slicebounds(End(), bounds, index, 2:3) == (10.0, 30.0)
-    bound = (0.5, 55.0)
-    @test slicebounds(Center(), bounds, index, 2:3) == (15.0, 35.0)
+    span_ = Irregular(10.0, 60.0)
+    @test _slicespan(Start(), span_, index, 2:3) == (20.0, 40.0)
+    span_ = Irregular(0.0, 50.0)
+    @test _slicespan(End(), span_, index, 2:3) == (10.0, 30.0)
+    span_ = Irregular(0.5, 55.0)
+    @test _slicespan(Center(), span_, index, 2:3) == (15.0, 35.0)
 end
 
-@testset "slicemode" begin
+@testset "_slicemode" begin
     ind = [10.0, 20.0, 30.0, 40.0, 50.0]
 
     @testset "Irregular forwards" begin
         mode_ = Sampled(span=Irregular((10.0, 60.0)), sampling=Intervals(Start()))
         mode_ = Sampled(Ordered(), Irregular((10.0, 60.0)), Intervals(Start()))
-        @test bounds(slicemode(mode_, ind, 3), X(ind)) == (30.0, 40.0)
-        @test bounds(slicemode(mode_, ind, 1:5), X(ind)) == (10.0, 60.0)
-        @test bounds(slicemode(mode_, ind, 2:3), X(ind)) == (20.0, 40.0)
+        @test _bounds(_slicemode(mode_, ind, 3), X(ind)) == (30.0, 40.0)
+        @test _bounds(_slicemode(mode_, ind, 1:5), X(ind)) == (10.0, 60.0)
+        @test _bounds(_slicemode(mode_, ind, 2:3), X(ind)) == (20.0, 40.0)
     end
 
     @testset "Irregular reverse" begin
         mode_ = Sampled(order=Ordered(index=ReverseIndex()), span=Irregular(10.0, 60.0),
-                       sampling=Intervals(Start()))
+                        sampling=Intervals(Start()))
         mode_ = Sampled(Ordered(index=ReverseIndex()), Irregular(10.0, 60.0), Intervals(Start()))
-        @test bounds(slicemode(mode_, ind, 1:5), X(ind)) == (10.0, 60.0)
-        @test bounds(slicemode(mode_, ind, 1:3), X(ind)) == (30.0, 60.0)
+        @test _bounds(_slicemode(mode_, ind, 1:5), X(ind)) == (10.0, 60.0)
+        @test _bounds(_slicemode(mode_, ind, 1:3), X(ind)) == (30.0, 60.0)
     end
 
     @testset "Irregular with no bounds" begin
-        mode = Sampled(span=Irregular(), sampling=Intervals(Start()))
-        mode = Sampled(Ordered(), Irregular(), Intervals(Start()))
-        @test bounds(slicemode(mode, ind, 3), X()) == (30.0, 40.0)
-        @test bounds(slicemode(mode, ind, 2:4), X()) == (20.0, 50.0)
+        mode = Sampled(span=Irregular(nothing, nothing), sampling=Intervals(Start()))
+        mode = Sampled(Ordered(), Irregular(nothing, nothing), Intervals(Start()))
+        @test _bounds(_slicemode(mode, ind, 3), X()) == (30.0, 40.0)
+        @test _bounds(_slicemode(mode, ind, 2:4), X()) == (20.0, 50.0)
         # TODO should this be built into `identify` to at least get one bound?
-        @test bounds(slicemode(mode, ind, 1:5), X()) == (10.0, nothing)
-        mode = Sampled(span=Irregular(), sampling=Intervals(End()))
-        mode = Sampled(Ordered(), Irregular(), Intervals(End()))
-        @test bounds(slicemode(mode, ind, 3), X()) == (20.0, 30.0)
-        @test bounds(slicemode(mode, ind, 2:4), X()) == (10.0, 40.0)
-        @test bounds(slicemode(mode, ind, 1:5), X()) == (nothing, 50.0)
-        mode = Sampled(span=Irregular(), sampling=Intervals(Center()))
-        mode = Sampled(Ordered(), Irregular(), Intervals(Center()))
-        @test bounds(slicemode(mode, ind, 3), X()) == (25.0, 35.0)
-        @test bounds(slicemode(mode, ind, 2:4), X()) == (15.0, 45.0)
-        @test bounds(slicemode(mode, ind, 1:5), X()) == (nothing, nothing)
+        @test _bounds(_slicemode(mode, ind, 1:5), X()) == (10.0, nothing)
+        mode = Sampled(span=Irregular(nothing, nothing), sampling=Intervals(End()))
+        mode = Sampled(Ordered(), Irregular(nothing, nothing), Intervals(End()))
+        @test _bounds(_slicemode(mode, ind, 3), X()) == (20.0, 30.0)
+        @test _bounds(_slicemode(mode, ind, 2:4), X()) == (10.0, 40.0)
+        @test _bounds(_slicemode(mode, ind, 1:5), X()) == (nothing, 50.0)
+        mode = Sampled(span=Irregular(nothing, nothing), sampling=Intervals(Center()))
+        mode = Sampled(Ordered(), Irregular(nothing, nothing), Intervals(Center()))
+        @test _bounds(_slicemode(mode, ind, 3), X()) == (25.0, 35.0)
+        @test _bounds(_slicemode(mode, ind, 2:4), X()) == (15.0, 45.0)
+        @test _bounds(_slicemode(mode, ind, 1:5), X()) == (nothing, nothing)
     end
 
     @testset "Regular is unchanged" begin
         mode = Sampled(span=Regular(1.0), sampling=Intervals(Start()))
         mode = Sampled(Ordered(), Regular(1.0), Intervals(Start()))
-        @test slicemode(mode, ind, 2:3) === mode
+        @test _slicemode(mode, ind, 2:3) === mode
     end
 
     @testset "Points is unchanged" begin
         mode = Sampled(span=Regular(1.0), sampling=Points())
         mode = Sampled(Ordered(), Regular(1.0), Points())
-        @test slicemode(mode, ind, 2:3) === mode
+        @test _slicemode(mode, ind, 2:3) === mode
     end
 
 end
@@ -146,6 +146,14 @@ end
             ind = 10.0:10.0:50.0
             dim = X(ind; mode=Sampled(Ordered(), Irregular(0.0, 50000.0), Intervals(Start())))
             @test bounds(dim) == (0.0, 50000.0)
+            @test bounds(DimensionalData.slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
+        end
+        @testset "Explicit bounds are is stored in span matrix" begin
+            ind = 10.0:10.0:50.0
+            bnds = vcat(ind', (ind .+ 10)')
+            dim = X(ind; mode=Sampled(Ordered(), Explicit(bnds), Intervals(Start())))
+            @test bounds(dim) == (10.0, 60.0)
+            @test bounds(DimensionalData.slicedims(dim, 2:3)[1][1]) == (20.0, 40.0)
         end
     end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Dates
-using DimensionalData: flip
+using DimensionalData: flip, shiftloci
 
 @testset "reverse" begin
     @testset "dimension" begin
@@ -207,4 +207,42 @@ end
         @test dc3p == cat([2 4 6; 8 10 12], [12 14 16; 18 20 22]; dims=3)
     end
 
+end
+
+@testset "shiftindexloci" begin
+    dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(Center())))
+    @test val(shiftloci(Start(), dim)) == 0.5:1.0:2.5
+    @test val(shiftloci(End(), dim)) == 1.5:1.0:3.5
+    @test val(shiftloci(Center(), dim)) == 1.0:1.0:3.0
+    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(Start())))
+    @test val(shiftloci(End(), dim)) == [4, 5, 6]
+    @test val(shiftloci(Center(), dim)) == [3.5, 4.5, 5.5]
+    @test val(shiftloci(Start(), dim)) == [3, 4, 5]
+    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(End())))
+    @test val(shiftloci(End(), dim)) == [3, 4, 5]
+    @test val(shiftloci(Center(), dim)) == [2.5, 3.5, 4.5]
+    @test val(shiftloci(Start(), dim)) == [2, 3, 4]
+end
+
+@testset "dim2boundsmatrix" begin
+    @testset "Regular span" begin
+        dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(Center())))
+        @test DimensionalData.dim2boundsmatrix(dim) == [0.5 1.5 2.5 
+                                                        1.5 2.5 3.5]
+        dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(Start())))
+        @test DimensionalData.dim2boundsmatrix(dim) == [1.0 2.0 3.0 
+                                                        2.0 3.0 4.0]
+        dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(End())))
+        @test DimensionalData.dim2boundsmatrix(dim) == [0.0 1.0 2.0 
+                                                        1.0 2.0 3.0]
+        dim = X(3.0:-1:1.0; mode=Sampled(Ordered(index=ReverseIndex()), Regular(1.0), Intervals(Center())))
+        @test DimensionalData.dim2boundsmatrix(dim) == [2.5 1.5 0.5 
+                                                        3.5 2.5 1.5]
+    end
+    @testset "Explicit span" begin
+        dim = X(1.0:3.0; mode=Sampled(Ordered(), Explicit([0.0 1.0 2.0 
+                                                           1.0 2.0 3.0]), Intervals(End())))
+        @test DimensionalData.dim2boundsmatrix(dim) == [0.0 1.0 2.0 
+                                                        1.0 2.0 3.0]
+    end
 end


### PR DESCRIPTION
This PR adds an `Explicit` span mode that specifies the bounds of every interval (but not applicable for `Points`). This follows the CF standard used in netcdf - a matrix with 2 rows and `length(dim)` columns.

Primarily this will allow complete import of netcdf dimensions, e.g. in GeoData.jl. But may also be useful for other use cases that require each cell to be specified exactly.