### PR TITLE
Simplify metadata

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -62,13 +62,8 @@ NoName
 ## Metadata
 
 ```@docs
+AbstractMetadata
 Metadata
-AbstractDimMetadata
-DimMetadata
-AbstractArrayMetadata
-ArrayMetadata
-AbstractStackMetadata
-StackMetadata
 NoMetadata
 ```
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -51,8 +51,7 @@ export AbstractDimTable, DimTable
 
 export AbstractDimStack, DimStack
 
-export Metadata, AbstractArrayMetadata, AbstractDimMetadata, AbstractStackMetadata,
-       ArrayMetadata, DimMetadata, StackMetadata, NoMetadata
+export AbstractMetadata, Metadata, NoMetadata
 
 export AbstractName, Name, NoName
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -22,7 +22,7 @@ attempt to guess the mode from the passed-in index value.
 
 `metadata` can hold any metadata object adding more information about
 the array axis - useful for extending DimensionalData for specific
-contexts, like geospatial data in GeoData.jl. By default it is `nothing`.
+contexts, like geospatial data in GeoData.jl. By default it is `NoMetadata()`.
 
 Example:
 
@@ -281,7 +281,7 @@ metadata: NoMetadata()
 type: Dim{:custom, Vector{Char}, AutoMode{AutoOrder}, NoMetadata}
 ```
 """
-struct Dim{S,T,Mo<:Mode,Me} <: ParametricDimension{S,T,Mo,Me}
+struct Dim{S,T,Mo<:Mode,Me<:AbstractMetadata} <: ParametricDimension{S,T,Mo,Me}
     val::T
     mode::Mo
     metadata::Me
@@ -339,7 +339,7 @@ end
 
 function dimmacro(typ, supertype, name::String=string(typ))
     quote
-        Base.@__doc__ struct $typ{T,Mo<:DimensionalData.Mode,Me} <: $supertype{T,Mo,Me}
+        Base.@__doc__ struct $typ{T,Mo<:DimensionalData.Mode,Me<:DimensionalData.AbstractMetadata} <: $supertype{T,Mo,Me}
             val::T
             mode::Mo
             metadata::Me
@@ -363,7 +363,7 @@ end
 """
     X <: XDim
 
-    X(val=:; mode=AutoMode(), metadata=nothing)
+    X(val=:; mode=AutoMode(), metadata=NoMetadata())
 
 X [`Dimension`](@ref). `X <: XDim <: IndependentDim`
 
@@ -381,7 +381,7 @@ mean(A; dims=X)
 """
     Y <: YDim
 
-    Y(val=:; mode=AutoMode(), metadata=nothing)
+    Y(val=:; mode=AutoMode(), metadata=NoMetadata())
 
 Y [`Dimension`](@ref). `Y <: YDim <: DependentDim`
 
@@ -399,7 +399,7 @@ mean(A; dims=Y)
 """
     Z <: ZDim
 
-    Z(val=:; mode=AutoMode(), metadata=nothing)
+    Z(val=:; mode=AutoMode(), metadata=NoMetadata())
 
 Z [`Dimension`](@ref). `Z <: ZDim <: Dimension`
 
@@ -417,7 +417,7 @@ mean(A; dims=Z)
 """m
     Ti <: TimeDim
     
-    Ti(val=:; mode=AutoMode(), metadata=nothing)
+    Ti(val=:; mode=AutoMode(), metadata=NoMetadata())
 
 Time [`Dimension`](@ref). `Ti <: TimeDim <: IndependentDim`
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -281,7 +281,7 @@ metadata: NoMetadata()
 type: Dim{:custom, Vector{Char}, AutoMode{AutoOrder}, NoMetadata}
 ```
 """
-struct Dim{S,T,Mo<:Mode,Me<:AbstractMetadata} <: ParametricDimension{S,T,Mo,Me}
+struct Dim{S,T,Mo<:Mode,Me<:AllMetadata} <: ParametricDimension{S,T,Mo,Me}
     val::T
     mode::Mo
     metadata::Me
@@ -339,7 +339,7 @@ end
 
 function dimmacro(typ, supertype, name::String=string(typ))
     quote
-        Base.@__doc__ struct $typ{T,Mo<:DimensionalData.Mode,Me<:DimensionalData.AbstractMetadata} <: $supertype{T,Mo,Me}
+        Base.@__doc__ struct $typ{T,Mo<:DimensionalData.Mode,Me<:DimensionalData.AllMetadata} <: $supertype{T,Mo,Me}
             val::T
             mode::Mo
             metadata::Me

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -7,9 +7,12 @@ const _MetadataContents = Union{AbstractDict,NamedTuple}
 
 Abstract supertype for all metadata wrappers.
 
-These allow tracking the contents and origin of metadata. This can facilitate
-conversion between metadata types (for saving a file to a differenet format)
+Metadata wrappers allow tracking the contents and origin of metadata. This can 
+facilitate conversion between metadata types (for saving a file to a differenet format)
 or simply saving data back to the same file type with identical metadata.
+
+Using a wrapper instead of `Dict` or `NamedTuple` also lets us pass metadata 
+objects to [`set`](@ref) without ambiguity about where to put them.
 """
 abstract type AbstractMetadata{X,T} end
 
@@ -20,9 +23,8 @@ abstract type AbstractMetadata{X,T} end
     Metadata{X}(pairs::Pair...) => Metadata{Dict}
     Metadata{X}(; kw...) => Metadata{NamedTuple}
 
-General [`Metadata`](@ref) object. `A` and `B` type parameters
-label and categorise the metadata for dispatch. `A` may be te object type `:Dimension`, `:Array`
-or `:Stack`, `B` may refer to the source of the metadata.
+General [`Metadata`](@ref) object. The `X` type parameter
+categorises the metadata for method dispatch, if required. 
 """
 struct Metadata{X,T<:_MetadataContents} <: AbstractMetadata{X,T}
     val::T

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,7 +1,4 @@
 
-const _MetadataContents = Union{AbstractDict,NamedTuple}
-
-
 """
     AbstractMetadata{X,T}
 
@@ -15,6 +12,9 @@ Using a wrapper instead of `Dict` or `NamedTuple` also lets us pass metadata
 objects to [`set`](@ref) without ambiguity about where to put them.
 """
 abstract type AbstractMetadata{X,T} end
+
+const _MetadataContents =Union{AbstractDict,NamedTuple}
+const AllMetadata = Union{AbstractMetadata,AbstractDict}
 
 Base.get(m::AbstractMetadata, args...) = get(val(m), args...)
 Base.getindex(m::AbstractMetadata, key) = getindex(val(m), Symbol(key))
@@ -97,5 +97,6 @@ units(x) = units(metadata(x))
 units(m::NoMetadata) = nothing
 units(m::Nothing) = nothing
 units(m::Metadata) = get(m, :units, nothing)
+units(m::AbstractDict) = get(m, :units, nothing)
 
 label(x) = string(string(name(x)), (units(x) === nothing ? "" : string(" ", units(x))))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -16,6 +16,18 @@ objects to [`set`](@ref) without ambiguity about where to put them.
 """
 abstract type AbstractMetadata{X,T} end
 
+Base.get(m::AbstractMetadata, args...) = get(val(m), args...)
+Base.getindex(m::AbstractMetadata, key) = getindex(val(m), Symbol(key))
+Base.setindex!(m::AbstractMetadata, x, key) = setindex!(val(m), x, Symbol(key))
+Base.haskey(m::AbstractMetadata, key) = haskey(val(m), Symbol(key))
+Base.keys(m::AbstractMetadata) = keys(val(m))
+Base.iterate(m::AbstractMetadata, args...) = iterate(val(m), args...)
+Base.IteratorSize(m::AbstractMetadata) = Base.IteratorSize(val(m))
+Base.IteratorEltype(m::AbstractMetadata) = Base.IteratorEltype(val(m))
+Base.eltype(m::AbstractMetadata) = eltype(val(m))
+Base.length(m::AbstractMetadata) = length(val(m))
+Base.:(==)(m1::AbstractMetadata, m2::AbstractMetadata) = m1 isa typeof(m2) && val(m1) == val(m2)
+
 """
     Metadata <: AbstractMetadata
 
@@ -29,8 +41,7 @@ categorises the metadata for method dispatch, if required.
 struct Metadata{X,T<:_MetadataContents} <: AbstractMetadata{X,T}
     val::T
 end
-Metadata(val::T) where {T<:_MetadataContents} = Metadata{Nothing,Nothing,T}(val)
-Metadata{X}(val::T) where {X,T<:_MetadataContents} = Metadata{X,Nothing,T}(val)
+Metadata(val::T) where {T<:_MetadataContents} = Metadata{Nothing,T}(val)
 Metadata{X}(val::T) where {X,T<:_MetadataContents} = Metadata{X,T}(val)
 
 # NamedTuple/Dict constructor
@@ -45,18 +56,6 @@ end
 ConstructionBase.constructorof(::Type{<:Metadata{X}}) where {X} = Metadata{X}
 
 val(m::Metadata) = m.val
-
-Base.get(m::Metadata, args...) = get(val(m), args...)
-Base.getindex(m::Metadata, key) = getindex(val(m), Symbol(key))
-Base.setindex!(m::Metadata, x, key) = setindex!(val(m), x, Symbol(key))
-Base.haskey(m::Metadata, key) = haskey(val(m), Symbol(key))
-Base.keys(m::Metadata) = keys(val(m))
-Base.iterate(m::Metadata, args...) = iterate(val(m), args...)
-Base.IteratorSize(m::Metadata) = Base.IteratorSize(val(m))
-Base.IteratorEltype(m::Metadata) = Base.IteratorEltype(val(m))
-Base.eltype(m::Metadata) = eltype(val(m))
-Base.length(m::Metadata) = length(val(m))
-Base.:(==)(m1::Metadata, m2::Metadata) = m1 isa typeof(m2) && val(m1) == val(m2)
 
 # Metadata nearly always contains strings, which break GPU compat.
 # For now just remove everything, but we could strip all strings

--- a/src/set.jl
+++ b/src/set.jl
@@ -1,4 +1,4 @@
-const InDims = Union{AbstractMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
+const InDims = Union{AllMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
 const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 
 """
@@ -87,12 +87,11 @@ set(A::AbstractDimArray, newdata::AbstractArray) = begin
     rebuild(A; data=newdata)
 end
 """
-    set(A::AbstractDimArray, metadata::AbstractMetadata) => AbstractDimArray
+    set(A::AbstractDimArray, metadata::Union{AbstractMetadata,AbstractDict}) => AbstractDimArray
 
 Update the `metadata` field of the array.
 """
-set(A::AbstractDimArray, metadata::AbstractMetadata) = 
-    rebuild(A; metadata=metadata)
+set(A::AbstractDimArray, metadata::AllMetadata) = rebuild(A; metadata=metadata)
 """
     set(A::AbstractDimArray, name::AbstractName) => AbstractDimArray
 
@@ -106,7 +105,7 @@ set(A::AbstractDimArray, name::Union{Symbol,AbstractName}) = rebuild(A; name=nam
 The values must be `AbstractArray of the same size as the original data, to
 match the `Dimension`s in the dims field.
 """
-set(s::AbstractDimStack, newdata::NamedTuple) = begin
+set(s::AbstractDimStack, newdata::AllMetadata) = begin
     map(data(s)) do l
         axes(l) == axes(first(data(s))) || _axiserr(first(data(s)), l)
     end
@@ -259,7 +258,7 @@ _set(sampling::Intervals, locus::Locus) = Intervals(locus)
 _set(sampling::Intervals, locus::AutoLocus) = sampling
 
 # Metadata
-_set(dim::Dimension, newmetadata::AbstractMetadata) =
+_set(dim::Dimension, newmetadata::AllMetadata) =
     rebuild(dim, val(dim), mode(dim), newmetadata)
 
 _set(x, ::Nothing) = x

--- a/src/set.jl
+++ b/src/set.jl
@@ -1,4 +1,4 @@
-const InDims = Union{AbstractDimMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
+const InDims = Union{AbstractMetadata,Type,UnionAll,Dimension,IndexMode,ModeComponent,Symbol,Nothing}
 const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 
 """
@@ -87,14 +87,14 @@ set(A::AbstractDimArray, newdata::AbstractArray) = begin
     rebuild(A; data=newdata)
 end
 """
-    set(A::AbstractDimArray, metadata::AbstractArrayMetadata) => AbstractDimArray
+    set(A::AbstractDimArray, metadata::AbstractMetadata) => AbstractDimArray
 
 Update the `metadata` field of the array.
 """
-set(A::AbstractDimArray, metadata::Union{AbstractArrayMetadata,NoMetadata}) =
+set(A::AbstractDimArray, metadata::AbstractMetadata) = 
     rebuild(A; metadata=metadata)
 """
-    set(A::AbstractDimArray, metadata::DimMetadata) => AbstractDimArray
+    set(A::AbstractDimArray, name::AbstractName) => AbstractDimArray
 
 Symbols are always names, and update the `name` field of the array.
 """
@@ -113,17 +113,16 @@ set(s::AbstractDimStack, newdata::NamedTuple) = begin
     rebuild(s; data=newdata)
 end
 """
-    set(s::AbstractDimStack, metadata::Union{StackMetadata,NoMetadata}) => AbstractDimStack
+    set(s::AbstractDimStack, metadata::AbstractMetadata) => AbstractDimStack
 
-StackMetadata update the `metadata` field of the dataset.
+Update the `metadata` field of the stack.
 """
-set(s::AbstractDimStack, metadata::Union{AbstractStackMetadata,NoMetadata}) =
-    rebuild(s; metadata=metadata)
+set(s::AbstractDimStack, metadata::AbstractMetadata) = rebuild(s; metadata=metadata)
 """
     set(dim::Dimension, index::Unioon{AbstractArray,Val}) => Dimension
     set(dim::Dimension, mode::Mode) => Dimension
     set(dim::Dimension, modecomponent::ModeComponent) => Dimension
-    set(dim::Dimension, metadata::AbstractDimMetadata) => Dimension
+    set(dim::Dimension, metadata::AbstractMetadata) => Dimension
 
 Set fields of the dimension
 """
@@ -260,7 +259,7 @@ _set(sampling::Intervals, locus::Locus) = Intervals(locus)
 _set(sampling::Intervals, locus::AutoLocus) = sampling
 
 # Metadata
-_set(dim::Dimension, newmetadata::Union{AbstractDimMetadata,NoMetadata}) =
+_set(dim::Dimension, newmetadata::AbstractMetadata) =
     rebuild(dim, val(dim), mode(dim), newmetadata)
 
 _set(x, ::Nothing) = x

--- a/src/set.jl
+++ b/src/set.jl
@@ -105,7 +105,7 @@ set(A::AbstractDimArray, name::Union{Symbol,AbstractName}) = rebuild(A; name=nam
 The values must be `AbstractArray of the same size as the original data, to
 match the `Dimension`s in the dims field.
 """
-set(s::AbstractDimStack, newdata::AllMetadata) = begin
+set(s::AbstractDimStack, newdata::NamedTuple) = begin
     map(data(s)) do l
         axes(l) == axes(first(data(s))) || _axiserr(first(data(s)), l)
     end

--- a/test/adapt.jl
+++ b/test/adapt.jl
@@ -12,11 +12,11 @@ Base.getindex(x::CustomArray, y...) = getindex(x.arr, y...)
 Base.count(x::CustomArray) = count(x.arr)
 
 @testset "Metadata" begin
-    @test adapt(CustomArray, DimMetadata(Dict(:a=>"1", :b=>"2"))) == NoMetadata()
+    @test adapt(CustomArray, Metadata(:a=>"1", :b=>"2")) == NoMetadata()
 end
 
 @testset "Dimension" begin
-    d = X([1:10...]; metadata=DimMetadata(Dict(:a=>"1", :b=>"2")))
+    d = X([1:10...]; metadata=Metadata(:a=>"1", :b=>"2"))
     d1 = adapt(CustomArray, d)
     @test val(d1) isa CustomArray
     @test val(d1).arr == [1:10...]

--- a/test/array.jl
+++ b/test/array.jl
@@ -6,9 +6,9 @@ a2 = [1 2 3 4
       3 4 5 6
       4 5 6 7]
 dimz2 = (Dim{:row}((10, 30)), Dim{:column}((-20, 10)))
-xmeta = DimMetadata(:meta => "X")
-ymeta = DimMetadata(:meta => "Y")
-ameta = ArrayMetadata(:meta => "da")
+xmeta = Metadata(:meta => "X")
+ymeta = Metadata(:meta => "Y")
+ameta = Metadata(:meta => "da")
 dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=xmeta),
         Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=ymeta))
 refdimz = (Ti(1:1),)

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -9,7 +9,7 @@ using DimensionalData: slicedims, basetypeof, formatdims, modetype, name
     @test DimensionalData.name(TestDim) == :Testname
     @test label(TestDim) == "Testname"
     @test val(TestDim(:testval)) == :testval
-    @test metadata(TestDim(1, AutoMode(), "metadata")) == "metadata"
+    @test metadata(TestDim(1, AutoMode(), Metadata(a=1))) == Metadata(a=1)
     @test units(TestDim) == nothing
     @test label(TestDim) == "Testname"
     @test eltype(TestDim(1)) == Int
@@ -51,10 +51,10 @@ end
     @test formatdims(A, (a=[:A, :B], b=(10.0:10.0:30.0))) ==
     (Dim{:a}([:A, :B], Categorical(Unordered()), NoMetadata()),
      Dim{:b}(10.0:10:30.0, Sampled(Ordered(), Regular(10.0), Points()), NoMetadata()))
-    @test formatdims(A, (X([:A, :B]; metadata=5),
-           Y(10.0:10.0:30.0, Categorical(Ordered()), Dict("metadata"=>1)))) ==
-          (X([:A, :B], Categorical(Unordered()), 5),
-           Y(10.0:10:30.0, Categorical(Ordered()), Dict("metadata"=>1)))
+    @test formatdims(A, (X([:A, :B]; metadata=Metadata(a=5)),
+           Y(10.0:10.0:30.0, Categorical(Ordered()), Metadata("metadata"=>1)))) ==
+          (X([:A, :B], Categorical(Unordered()), Metadata(a=5)),
+           Y(10.0:10:30.0, Categorical(Ordered()), Metadata("metadata"=>1)))
     @test formatdims(zeros(3, 4), 
         (Dim{:row}(Val((:A, :B, :C))), 
          Dim{:column}(Val((-20, -10, 0, 10)), Sampled(), NoMetadata()))) ==

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -26,7 +26,7 @@ using DimensionalData: dims2indices
     @testset "dims2indices with Transformed" begin
         tdimz = Dim{:trans1}(mode=Transformed(identity, X())), 
                 Dim{:trans2}(mode=Transformed(identity, Y())), 
-                Z(1:1, NoIndex(), nothing)
+                Z(1:1, NoIndex(), NoMetadata())
         @test dims2indices(tdimz, (X(1), Y(2), Z())) == (1, 2, Colon())
         @test dims2indices(tdimz, (Dim{:trans1}(1), Dim{:trans2}(2), Z())) == (1, 2, Colon())
     end
@@ -35,9 +35,9 @@ end
 
 @testset "array" begin
     a = [1 2; 3 4]
-    xmeta = DimMetadata(:meta => "X")
-    ymeta = DimMetadata(:meta => "Y")
-    ameta = ArrayMetadata(:meta => "da")
+    xmeta = Metadata(:meta => "X")
+    ymeta = Metadata(:meta => "Y")
+    ameta = Metadata(:meta => "da")
     dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=xmeta),
             Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=ymeta))
     refdimz = (Ti(1:1),)

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -3,19 +3,18 @@ using DimensionalData, Test
 @testset "Metadata" begin
     nt = (a="test1", units="km")
     d = (:a=>"test1", :units=>"km")
-    @test val(DimMetadata(nt)) isa NamedTuple
-    @test val(DimMetadata(d)) isa Dict
-    @test val(DimMetadata()) isa Dict
-    @test DimMetadata(nt) == DimMetadata(; nt...)
-    @test DimMetadata(d) == DimMetadata(d...) == DimMetadata(Dict(d))
-    dm = DimMetadata(d)
+    @test val(Metadata(nt)) isa NamedTuple
+    @test val(Metadata(d)) isa Dict
+    @test val(Metadata()) isa Dict
+    @test Metadata(nt) == Metadata(; nt...)
+    @test Metadata(d) == Metadata(d...) == Metadata(Dict(d))
+    dm = Metadata(d)
     dm[:c] = "added metadata"
     @test dm[:c] == "added metadata"
     @test units(nothing) === nothing
     @test units(NoMetadata()) === nothing
 
-    for md in (DimMetadata(; nt...), ArrayMetadata(; nt...), StackMetadata(; nt...),
-               DimMetadata(d...), ArrayMetadata(d...), StackMetadata(d...))
+    for md in (Metadata(; nt...), Metadata{:Test}(; nt...), Metadata{:Test1,:Test2}(; nt...))
         @test units(md) == "km"
         @test length(md) == 2
         @test haskey(md, :a)
@@ -41,7 +40,7 @@ using DimensionalData, Test
         @test Base.IteratorEltype(md) == Base.HasEltype()
     end
 
-    @test_throws ArgumentError DimMetadata(:a => "1"; units="km")
+    @test_throws ArgumentError Metadata{:Test}(:a => "1"; units="km")
 end
 
 @testset "NoMetadata" begin

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -14,7 +14,7 @@ using DimensionalData, Test
     @test units(nothing) === nothing
     @test units(NoMetadata()) === nothing
 
-    for md in (Metadata(; nt...), Metadata{:Test}(; nt...))
+    for md in (Metadata(; nt...), Metadata{:Test}(; nt...), Dict(pairs(nt)))
         @test units(md) == "km"
         @test length(md) == 2
         @test haskey(md, :a)
@@ -22,7 +22,7 @@ using DimensionalData, Test
         @test get(md, :a, nothing) == "test1" 
         @test md[:a] == "test1" 
         @test md[:units] == "km" 
-        if val(md) isa Dict
+        if md isa Dict || val(md) isa Dict
             @test [x for x in md] == [:a=>"test1", :units=>"km"]
             @test all(keys(md) .== [:a, :units])
             @test eltype(md) == Pair{Symbol,String}

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -14,7 +14,7 @@ using DimensionalData, Test
     @test units(nothing) === nothing
     @test units(NoMetadata()) === nothing
 
-    for md in (Metadata(; nt...), Metadata{:Test}(; nt...), Metadata{:Test1,:Test2}(; nt...))
+    for md in (Metadata(; nt...), Metadata{:Test}(; nt...))
         @test units(md) == "km"
         @test length(md) == 2
         @test haskey(md, :a)

--- a/test/set.jl
+++ b/test/set.jl
@@ -2,8 +2,8 @@ using DimensionalData, Test
 using DimensionalData: _set, AutoSampling
 
 a = [1 2; 3 4]
-dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=DimMetadata(Dict(:meta => "X"))),
-        Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=DimMetadata(Dict(:meta => "Y"))))
+dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=Metadata(Dict(:meta => "X"))),
+        Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=Metadata(Dict(:meta => "Y"))))
 da = DimArray(a, dimz, :test)
 
 a2 = [1 2 3 4
@@ -18,7 +18,7 @@ s = DimStack(da2, DimArray(2a2, dimz2, :test3))
     @test name(set(da2, :newname)) == :newname
     @test name(set(da2, Name(:newname))) == Name{:newname}()
     @test name(set(da2, NoName())) == NoName()
-    @test metadata(set(da2, ArrayMetadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
+    @test metadata(set(da2, Metadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
     @test parent(set(da2, fill(9, 3, 4))) == fill(9, 3, 4)
     # A differently sized array can't be set
     @test_throws ArgumentError parent(set(da2, [9 9; 9 9])) == [9 9; 9 9]
@@ -28,7 +28,7 @@ end
     s2 = set(s, (x=a2, y=3a2))
     @test keys(s2) == (:x, :y)
     @test values(s2) == (a2, 3a2)
-    @test metadata(set(s, StackMetadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
+    @test metadata(set(s, Metadata(Dict(:testa => "test")))).val == Dict(:testa => "test")
 end
 
 @testset "DimStack Dimension" begin
@@ -127,22 +127,22 @@ end
 
 
 @testset "metadata" begin
-    @test metadata(set(X(), DimMetadata(Dict(:a=>1, :b=>2)))).val == Dict(:a=>1, :b=>2)
-    dax = set(da, X(DimMetadata(Dict(:a=>1, :b=>2))))
+    @test metadata(set(X(), Metadata(Dict(:a=>1, :b=>2)))).val == Dict(:a=>1, :b=>2)
+    dax = set(da, X(Metadata(Dict(:a=>1, :b=>2))))
     @test metadata(dims(dax), X).val == Dict(:a=>1, :b=>2)
     @test metadata(dims(dax), Y).val == Dict(:meta => "Y") 
-    dax = set(da, X(; metadata=DimMetadata(Dict(:a=>1, :b=>2))))
+    dax = set(da, X(; metadata=Metadata(Dict(:a=>1, :b=>2))))
     @test metadata(dims(dax, X)).val == Dict(:a=>1, :b=>2)
-    dax = set(da2, row=DimMetadata(Dict(:a=>1, :b=>2)))
+    dax = set(da2, row=Metadata(Dict(:a=>1, :b=>2)))
     @test metadata(dims(dax, :row)).val == Dict(:a=>1, :b=>2)
-    dax = set(da2, column=DimMetadata(Dict(:a=>1, :b=>2)))
+    dax = set(da2, column=Metadata(Dict(:a=>1, :b=>2)))
     @test metadata(dims(dax, :column)).val == Dict(:a=>1, :b=>2)
     @test metadata(set(da, NoMetadata())) == NoMetadata()
     @test metadata(set(da, NoMetadata)) == NoMetadata()
 end
 
 @testset "all dim fields" begin
-    dax = set(da, X(20:-10:10; mode=Sampled(), metadata=DimMetadata(Dict(:a=>1, :b=>2))))
+    dax = set(da, X(20:-10:10; mode=Sampled(), metadata=Metadata(Dict(:a=>1, :b=>2))))
     x = dims(dax, X)
     @test val(x) == 20:-10:10
     @test order(x) == Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())


### PR DESCRIPTION
Metadata is too complicated. so this PR simplifies it somewhat.

Now you can just use `Metadata(a=1, b=2)` for any metadata field. But you can also do
`Metadata{:GDAL}(kw...)` or whatever to label it for dispatch, if that's required.

@Datseris this now forces the `metadata` field to be `<: AbstractMetadata`, so that error can't happen. It needs to go one way or the other, and this way is more restrictive, but less ambiguous.

Closes #245