### PR TITLE
better show

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,12 @@
 using Pkg
 Pkg.activate(@__DIR__)
 
-using Documenter, DimensionalData, CoordinateTransformations
+using Documenter, DimensionalData, CoordinateTransformations, Dates
 
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
 
 docsetup = quote 
-    using DimensionalData, Random 
+    using DimensionalData, Random, Dates
     Random.seed!(1234)
 end
 DocMeta.setdocmeta!(DimensionalData, :DocTestSetup, docsetup; recursive=true)

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -37,11 +37,11 @@ A = DimArray(zeros(3, 5, 12), (y, x, ti))
 
 # output
 
-DimArray (named ) with dimensions:
- Y: Char[a, b, c] (Categorical: Unordered)
- X: 2:2:10 (Sampled: Ordered Regular Points)
- Time (type Ti): Dates.DateTime("2021-01-01T00:00:00"):Dates.Month(1):Dates.DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
-and data: 3×5×12 Array{Float64, 3}
+DimArray{Float64,3} with dimensions:
+  Y: Char[a, b, c] (Categorical - Unordered)
+  X: 2:2:10 (Sampled - Ordered Regular Points)
+  Ti (Time): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled - Ordered Regular Points)
+and data:
 [:, :, 1]
  0.0  0.0  0.0  0.0  0.0
  0.0  0.0  0.0  0.0  0.0
@@ -57,13 +57,24 @@ x = A[X(2), Y(3)]
 
 # output
 
-DimArray (named ) with dimensions:
- Time (type Ti): Dates.DateTime("2021-01-01T00:00:00"):Dates.Month(1):Dates.DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
+DimArray{Float64,1} with dimensions:
+  Ti (Time): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled - Ordered Regular Points)
 and referenced dimensions:
- Y: c (Categorical: Unordered)
- X: 4 (Sampled: Ordered Regular Points)
-and data: 12-element Vector{Float64}
-[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  Y: c (Categorical - Unordered)
+  X: 4 (Sampled - Ordered Regular Points)
+and data:
+12-element Vector{Float64}:
+ 0.0
+ 0.0
+ 0.0
+ 0.0
+ 0.0
+ ⋮
+ 0.0
+ 0.0
+ 0.0
+ 0.0
+ 0.0
 ```
 
 A `Dimension` can also wrap [`Selector`](@ref).
@@ -73,12 +84,12 @@ x = A[X(Between(3, 4)), Y(At('b'))]
 
 # output
 
-DimArray (named ) with dimensions:
- X: 4:2:4 (Sampled: Ordered Regular Points)
- Time (type Ti): Dates.DateTime("2021-01-01T00:00:00"):Dates.Month(1):Dates.DateTime("2021-12-01T00:00:00") (Sampled: Ordered Regular Points)
+DimArray{Float64,2} with dimensions:
+  X: 4:2:4 (Sampled - Ordered Regular Points)
+  Ti (Time): DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") (Sampled - Ordered Regular Points)
 and referenced dimensions:
- Y: b (Categorical: Unordered)
-and data: 1×12 Matrix{Float64}
+  Y: b (Categorical - Unordered)
+and data:
  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
 ```
 
@@ -276,11 +287,9 @@ dim = Dim{:custom}(['a', 'b', 'c'])
 
 # output
 
-Dimension custom (type Dim):
-val: Char[a, b, c]
-mode: AutoMode
-metadata: NoMetadata()
-type: Dim{:custom, Vector{Char}, AutoMode{AutoOrder}, NoMetadata}
+Dim : custom Dimension
+  val: Char[a, b, c]
+Dim{:custom, Vector{Char}, AutoMode{AutoOrder}, NoMetadata}
 ```
 """
 struct Dim{S,T,Mo<:Mode,Me<:AllMetadata} <: ParametricDimension{S,T,Mo,Me}

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -474,7 +474,7 @@ map(mode, dims(A))
 
 # output
 
-(NoIndex, NoIndex)
+(NoIndex(), NoIndex())
 ```
 
 Is identical to:
@@ -485,7 +485,7 @@ map(mode, dims(A))
 
 # output
 
-(NoIndex, NoIndex)
+(NoIndex(), NoIndex())
 ```
 """
 struct NoIndex <: Aligned{Ordered{ForwardIndex,ForwardArray,ForwardRelation}} end
@@ -603,7 +603,7 @@ map(mode, dims(A))
 
 # output
 
-(Sampled: Ordered Regular Intervals, Sampled: Ordered Regular Intervals)
+(Sampled{Ordered{ReverseIndex, ForwardArray, ForwardRelation}, Regular{Int64}, Intervals{Center}}(Ordered{ReverseIndex, ForwardArray, ForwardRelation}(ReverseIndex(), ForwardArray(), ForwardRelation()), Regular{Int64}(-10), Intervals{Center}(Center())), Sampled{Ordered{ForwardIndex, ForwardArray, ForwardRelation}, Regular{Int64}, Intervals{Center}}(Ordered{ForwardIndex, ForwardArray, ForwardRelation}(ForwardIndex(), ForwardArray(), ForwardRelation()), Regular{Int64}(2), Intervals{Center}(Center())))
 ```
 """
 struct Sampled{O,Sp,Sa} <: AbstractSampled{O,Sp,Sa}
@@ -659,7 +659,7 @@ map(mode, dims(A))
 
 # output
 
-(Categorical: Unordered, Categorical: Unordered)
+(Categorical{Unordered{ForwardRelation}}(Unordered{ForwardRelation}(ForwardRelation())), Categorical{Unordered{ForwardRelation}}(Unordered{ForwardRelation}(ForwardRelation())))
 ```
 """
 struct Categorical{O<:Order} <: AbstractCategorical{O}

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -137,10 +137,10 @@ julia> using DimensionalData
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 julia> commondims(A, X)
-(X (NoIndex),)
+(X{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()),)
 
 julia> commondims(A, (X, Z))
-(X (NoIndex), Z (NoIndex))
+(X{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()), Z{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()))
 
 julia> commondims(A, Ti)
 ()
@@ -244,13 +244,13 @@ julia> using DimensionalData
 julia> A = DimArray(ones(10, 10, 10), (X, Y, Z));
 
 julia> otherdims(A, X)
-(Y (NoIndex), Z (NoIndex))
+(Y{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()), Z{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()))
 
 julia> otherdims(A, (Y, Z))
-(X (NoIndex),)
+(X{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()),)
 
 julia> otherdims(A, Ti)
-(X (NoIndex), Y (NoIndex), Z (NoIndex))
+(X{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()), Y{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()), Z{Base.OneTo{Int64}, NoIndex, NoMetadata}(Base.OneTo(10), NoIndex(), NoMetadata()))
 ```
 """
 @inline otherdims(args...) = _call(_otherdims_presort, AlwaysTuple(), args...)

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -162,10 +162,10 @@ A[X(Between(15, 25)), Y(Between(4, 6.5))]
 
 # output
 
-DimArray (named ) with dimensions:
- X: 20:10:20 (Sampled: Ordered Regular Points)
- Y: 5:6 (Sampled: Ordered Regular Points)
-and data: 1×2 Matrix{Int64}
+DimArray{Int64,2} with dimensions:
+  X: 20:10:20 (Sampled - Ordered Regular Points)
+  Y: 5:6 (Sampled - Ordered Regular Points)
+and data:
  4  5
 ```
 """
@@ -192,10 +192,10 @@ A[X(Where(x -> x > 15)), Y(Where(x -> x in (19, 21)))]
 
 # output
 
-DimArray (named ) with dimensions:
- X: Int64[20] (Sampled: Ordered Regular Points)
- Y: Int64[19, 21] (Sampled: Ordered Regular Points)
-and data: 1×2 Matrix{Int64}
+DimArray{Int64,2} with dimensions:
+  X: Int64[20] (Sampled - Ordered Regular Points)
+  Y: Int64[19, 21] (Sampled - Ordered Regular Points)
+and data:
  4  6
 ```
 """

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,79 +1,149 @@
-# Full printing for DimArray
-function Base.show(io::IO, A::AbstractDimArray)
-    l = nameof(typeof(A))
-    printstyled(io, nameof(typeof(A)); color=:blue)
-    if name(A) != Symbol("")
-        print(io, " (named ")
-        printstyled(io, string(name(A)); color=:blue)
+
+function Base.show(io::IO, mime::MIME"text/plain", A::AbstractDimArray{T,N}) where {T,N}
+    lines = 4
+    printstyled(io, string(nameof(typeof(A)), "{$T,$N}"); color=:blue)
+    _printname(io, name(A))
+    lines += _printdims(io, mime, dims(A))
+    lines += _printrefdims(io, mime, refdims(A))
+    print(io, "and data: \n")
+    ds = displaysize(io)
+    ioctx = IOContext(io, :displaysize => (ds[1] - lines, ds[2]))
+    _show_array(ioctx, mime, parent(A))
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", dim::Dimension)
+    get(io, :compact, false) && return _show_compact(io::IO, dim)
+
+    printstyled(io, nameof(typeof(dim)); color=:red)
+    print(io, " : ")
+    printstyled(io, name(dim); color=:light_yellow)
+    printstyled(io, " Dimension "; color=:light_yellow)
+    printstyled(io, "\n  val: ")
+    _printdimval(io, val(dim))
+
+    if !(mode(dim) isa AutoMode)
+        printstyled(io, "\n  mode: ")
+        show(io, mime, mode(dim))
+    end
+    if !(metadata(dim) isa NoMetadata)
+        printstyled(io, "\n  metadata: ")
+        show(io, mime, metadata(dim))
+    end
+    println(io)
+    show(io, mime, typeof(dim))
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", metadata::Metadata{N}) where N
+    print(io, "Metadata")
+    if N !== Nothing
+        print(io, "{")
+        show(io, N)
+        print(io, "}")
+    end
+    print(io, " of ")
+    show(io, mime, val(metadata))
+end
+Base.show(io::IO, mime::MIME"text/plain", mode::IndexMode) = _printmode(io, mode)
+
+function Base.show(io::IO, mime::MIME"text/plain", mode::AbstractSampled)
+    _printmode(io, mode)
+    print(io, " - ")
+    _printorder(io, mode)
+    print(io, " ")
+    _printspan(io, mode)
+    print(io, " ")
+    _printsampling(io, mode)
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", mode::AbstractCategorical)
+    _printmode(io, mode)
+    print(io, " - ")
+    _printorder(io, mode)
+end
+
+# short printing version for dimensions
+function _show_compact(io::IO, dim::Dimension)
+    printstyled(io, nameof(typeof(dim)); color=:red)
+    if name(dim) != nameof(typeof(dim))
+        print(io, " (")
+        printstyled(io, name(dim); color=:grey)
         print(io, ")")
     end
+    _printdimproperties(io, dim)
+end
+function _show_compact(io::IO, dim::Dim)
+    printstyled(io, "Dim{:$(name(dim))}"; color=:red)
+    _printdimproperties(io, dim)
+end
 
-    print(io, " with dimensions:\n")
-    for d in dims(A)
-        print(io, " ", d, "\n")
+function _printname(io::IO, name)
+    if !(name == Symbol("") || name isa NoName)
+        print(io, " (")
+        printstyled(io, string(name); color=:light_yellow)
+        print(io, ")")
     end
-    if !isempty(refdims(A))
+end
+
+# Note GeoData uses these
+function _printdims(io::IO, mime, dims)
+    length(dims) > 0 || return 0
+    ctx = IOContext(io, :compact=>true)
+    print(io, " with dimensions: ")
+
+    # No mode, print one one line 
+    if all(m -> m isa NoIndex, mode(dims))
+        for d in dims[1:end-1]
+            show(ctx, mime, d)
+            print(io, ", ")
+        end
+        show(ctx, mime, dims[end])
+        print(io, " ")
+        return 0
+    else # Dims get a line each
+        lines = 1
+        println(io)
+        for d in dims
+            print(io, "  ")
+            show(ctx, mime, d)
+            println(io)
+            lines += 1
+        end
+        return lines
+    end
+end
+
+function _printrefdims(io::IO, mime, refdims)
+    lines = 0
+    if !isempty(refdims)
         print(io, "and referenced dimensions:\n")
-        for d in refdims(A)
-            print(io, " ", d, "\n")
+        lines += 1
+        for d in refdims
+            print(io, "  ")
+            show(IOContext(io, :compact=>true), mime, d)
+            println(io)
+            lines += 1
         end
     end
-    print(io, "and")
-    printstyled(io, " data: "; color=:green)
-    dataA = parent(A)
-    print(io, summary(dataA), "\n")
-    custom_show(io, parent(A))
+    lines
 end
-# Short printing for DimArray
-Base.show(io::IO, ::MIME"text/plain", A::AbstractDimArray) = show(io, A)
-# Full printing version for dimensions
-function Base.show(io::IO, ::MIME"text/plain", dim::Dimension)
-    print(io, "Dimension ")
-    printstyled(io, name(dim); color=:red)
-    if name(dim) != nameof(typeof(dim))
-        print(io, " (type ")
-        printstyled(io, nameof(typeof(dim)); color=:red)
-        print(io, ")")
-    end
+
+function _printdimproperties(io, dim)
+    mode(dim) isa NoIndex && return nothing
     print(io, ": ")
-
-    printstyled(io, "\nval: "; color=:green)
     _printdimval(io, val(dim))
-    printstyled(io, "\nmode: "; color=:yellow)
-    show(io, mode(dim))
-    printstyled(io, "\nmetadata: "; color=:blue)
-    show(io, metadata(dim))
-    printstyled(io, "\ntype: "; color=:cyan)
-    show(io, typeof(dim))
-end
-# short printing version for dimensions
-function Base.show(io::IO, dim::Dimension)
-    printstyled(io, name(dim); color=:red)
-    if name(dim) ≠ nameof(typeof(dim))
-        print(io, " (type ")
-        printstyled(io, nameof(typeof(dim)); color=:red)
+    if !(mode(dim) isa AutoMode)
+        print(io, " (")
+        show(io, MIME"text/plain"(), mode(dim))
         print(io, ")")
     end
-    printdimproperties(io, dim)
-end
-function Base.show(io::IO, dim::Dim)
-    printstyled(io, name(dim); color=:red)
-    printdimproperties(io, dim)
+    return nothing
 end
 
-function printdimproperties(io, dim)
-    if !(mode(dim) isa NoIndex)
-        print(io, ": ")
-        _printdimval(io, val(dim))
-    end
-    print(io, " (", mode(dim), ")")
-end
-
-_printdimval(io, A::AbstractArray) = printlimited(io, A)
+_printdimval(io, A::AbstractArray) = _printlimited(io, A)
 _printdimval(io, A::AbstractRange) = print(io, A)
 _printdimval(io, x) = print(io, x)
 
-function printlimited(io, v::AbstractVector)
+function _printlimited(io, v::AbstractVector)
     s = string(eltype(v))*"["
     if length(v) > 5
         svals = "$(v[1]), $(v[2]), …, $(v[end-1]), $(v[end])"
@@ -83,38 +153,30 @@ function printlimited(io, v::AbstractVector)
     print(io, s*svals*"]")
 end
 
-Base.show(io::IO, mode::IndexMode) = _printmode(io, mode)
-function Base.show(io::IO, mode::AbstractSampled)
-    _printmode(io, mode)
-    _printorder(io, mode)
-    print(io, " ", nameof(typeof(span(mode))))
-    print(io, " ", nameof(typeof(sampling(mode))))
-end
-function Base.show(io::IO, mode::AbstractCategorical)
-    _printmode(io, mode)
-    _printorder(io, mode)
-end
-
-_printmode(io, mode) = printstyled(io, nameof(typeof(mode)); color=:green)
-
-_printorder(io, mode) = print(io, ": ", nameof(typeof(order(mode))))
+_printmode(io, mode) = print(io, nameof(typeof(mode)))
+_printorder(io, mode) = print(io, nameof(typeof(order(mode))))
+_printspan(io, mode) = print(io, nameof(typeof(span(mode))))
+_printsampling(io, mode) = print(io, nameof(typeof(sampling(mode))))
 
 # Thanks to Michael Abbott for the following function
-function custom_show(io::IO, A::AbstractArray{T,0}) where T
-    Base.show(IOContext(io, :compact => true, :limit => true), A)
+function _show_array(io::IO, mime, A::AbstractArray{T,0}) where T
+    Base.show(_ioctx(io, T), mime, A)
 end
-function custom_show(io::IO, A::AbstractArray{T,1}) where T
-    Base.show(IOContext(io, :compact => true, :limit => true), A)
+function _show_array(io::IO, mime, A::AbstractArray{T,1}) where T
+    Base.show(_ioctx(io, T), mime, A)
 end
-function custom_show(io::IO, A::AbstractArray{T,2}) where T
-    Base.print_matrix(IOContext(io, :compact => true, :limit => true), A)
+function _show_array(io::IO, mime, A::AbstractArray{T,2}) where T
+    Base.print_matrix(_ioctx(io, T), A)
 end
-function custom_show(io::IO, A::AbstractArray{T,N}) where {T,N}
+function _show_array(io::IO, mime, A::AbstractArray{T,N}) where {T,N}
     o = ones(Int, N-2)
     frame = A[:, :, o...]
     onestring = join(o, ", ")
     println(io, "[:, :, $(onestring)]")
-    Base.print_matrix(IOContext(io, :compact => true, :limit=>true), frame)
+    Base.print_matrix(_ioctx(io, T), frame)
     print(io, "\n[and ", prod(size(A,d) for d=3:N) - 1," more slices...]")
 end
 
+function _ioctx(io, T)
+    IOContext(io, :compact=>true, :limit=>true, :typeinfo=>T)
+end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -173,7 +173,7 @@ julia> using DimensionalData
 julia> A = [1.0 2.0 3.0; 4.0 5.0 6.0];
 
 julia> dimz = (X([:a, :b]), Y(10.0:10.0:30.0))
-(X: Symbol[a, b] (AutoMode), Y: 10.0:10.0:30.0 (AutoMode))
+(X{Vector{Symbol}, AutoMode{AutoOrder}, NoMetadata}([:a, :b], AutoMode{AutoOrder}(AutoOrder()), NoMetadata()), Y{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}, AutoMode{AutoOrder}, NoMetadata}(10.0:10.0:30.0, AutoMode{AutoOrder}(AutoOrder()), NoMetadata()))
 
 julia> da1 = DimArray(1A, dimz, :one);
 


### PR DESCRIPTION
Cleans up show, makes the display cleaner and prettier. Arrays will look better, and should fit in the screen vertically.

Most methods were for regular show, but this instead switches methods to MIME("text/plain") using `:compact` where required, as suggested in the Julia manual.

