### PR TITLE
fix slicing of bounds

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -14,8 +14,7 @@ for (m, f) in ((:Base, :sum), (:Base, :prod), (:Base, :maximum), (:Base, :minimu
     @eval begin
         # Base methods
         $m.$f(A::AbstractDimArray; dims=:, kw...) = $_f(A::AbstractDimArray, dims; kw...)
-        $m.$f(f, A::AbstractDimArray; dims=:, kw...) =
-            $_f(f, A::AbstractDimArray, dims; kw...)
+        $m.$f(f, A::AbstractDimArray; dims=:, kw...) = $_f(f, A::AbstractDimArray, dims; kw...)
         # Local dispatch methods
         # - Return a reduced DimArray
         $_f(A::AbstractDimArray, dims; kw...) =
@@ -23,9 +22,8 @@ for (m, f) in ((:Base, :sum), (:Base, :prod), (:Base, :maximum), (:Base, :minimu
         $_f(f, A::AbstractDimArray, dims; kw...) =
             rebuild(A, $m.$f(f, parent(A); dims=dimnum(A, _astuple(dims)), kw...), reducedims(A, dims))
         # - Return a scalar
-        $_f(A::AbstractDimArray, dims::Colon; kw...) = $m.$f(parent(A); kw...)
-        $_f(f, A::AbstractDimArray, dims::Colon; kw...) =
-            $m.$f(f, parent(A); dims=dims, kw...)
+        $_f(A::AbstractDimArray, dims::Colon; kw...) = $m.$f(parent(A); dims, kw...)
+        $_f(f, A::AbstractDimArray, dims::Colon; kw...) = $m.$f(f, parent(A); dims, kw...)
     end
 end
 # With no function arg version

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -549,16 +549,16 @@ _slicemode(::Intervals, ::Union{Irregular,Explicit}, mode::AbstractSampled, inde
 end
 
 _slicespan(m::IndexMode, index, i) =
-    _slicespan(span(m), m, index, _maybeflip(indexorder(m), index, i))
+    _slicespan(span(m), m, index, _maybeflipindex(relation(m), index, i))
 _slicespan(span::Explicit, m::IndexMode, index, i::Int) = Explicit(val(span)[:, i])
 _slicespan(span::Explicit, m::IndexMode, index, i::AbstractArray) = Explicit(val(span)[:, i])
 _slicespan(span::Irregular, m::IndexMode, index, i) =
-    Irregular(_slicespan(locus(m), span, index, i))
-_slicespan(locus::Start, span::Irregular, index, i) =
-    index[first(i)], last(i) >= lastindex(index) ? bounds(span)[2] : index[last(i) + 1]
-_slicespan(locus::End, span::Irregular, index, i) =
-    first(i) <= firstindex(index) ? bounds(span)[1] : index[first(i) - 1], index[last(i)]
-_slicespan(locus::Center, span::Irregular, index, i) =
+    Irregular(_maybeflipbounds(m, _slicespan(locus(m), span, m, index, i)))
+_slicespan(locus::Start, span::Irregular, m, index, i) =
+    index[first(i)], last(i) >= lastindex(index) ? _maybeflipbounds(m, bounds(span))[2] : index[last(i) + 1]
+_slicespan(locus::End, span::Irregular, m, index, i) =
+    first(i) <= firstindex(index) ? _maybeflipbounds(m, bounds(span))[1] : index[first(i) - 1], index[last(i)]
+_slicespan(locus::Center, span::Irregular, m, index, i) =
     first(i) <= firstindex(index) ? bounds(span)[1] : (index[first(i) - 1] + index[first(i)]) / 2,
     last(i)  >= lastindex(index)  ? bounds(span)[2] : (index[last(i) + 1]  + index[last(i)]) / 2
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -389,12 +389,11 @@ end
 @inline _slicedims(f, ::NoIndex, d::Dimension{<:Val}, i::AbstractArray) =
     (rebuild(d, f(val(d), relate(d, i))),), ()
 
-@inline relate(d::Dimension, i) = _maybeflip(relation(d), d, i)
+@inline relate(d::Dimension, i) = _maybeflipindex(relation(d), d, i)
 
-@inline _maybeflip(::Union{ForwardRelation,ForwardIndex}, d, i) = i
-@inline _maybeflip(::Union{ReverseRelation,ReverseIndex}, d, i::Integer) =
-    lastindex(d) - i + 1
-@inline _maybeflip(::Union{ReverseRelation,ReverseIndex}, d, i::AbstractArray) =
+@inline _maybeflipindex(::ForwardRelation, d, i) = i
+@inline _maybeflipindex(::ReverseRelation, d, i::Integer) = lastindex(d) - i + 1
+@inline _maybeflipindex(::ReverseRelation, d, i::AbstractArray) =
     reverse(lastindex(d) .- i .+ 1)
 
 """

--- a/test/mode.jl
+++ b/test/mode.jl
@@ -47,16 +47,6 @@ end
         Ordered(ReverseIndex(), ReverseArray(), ForwardRelation())
 end
 
-@testset "slicebounds" begin
-    index = [10.0, 20.0, 30.0, 40.0, 50.0]
-    span_ = Irregular(10.0, 60.0)
-    @test _slicespan(Start(), span_, index, 2:3) == (20.0, 40.0)
-    span_ = Irregular(0.0, 50.0)
-    @test _slicespan(End(), span_, index, 2:3) == (10.0, 30.0)
-    span_ = Irregular(0.5, 55.0)
-    @test _slicespan(Center(), span_, index, 2:3) == (15.0, 35.0)
-end
-
 @testset "_slicemode" begin
     ind = [10.0, 20.0, 30.0, 40.0, 50.0]
 
@@ -69,11 +59,13 @@ end
     end
 
     @testset "Irregular reverse" begin
-        mode_ = Sampled(order=Ordered(index=ReverseIndex()), span=Irregular(10.0, 60.0),
+        revind = [50.0, 40.0, 30.0, 20.0, 10.0]
+        mode_ = Sampled(order=Ordered(index=ReverseIndex()), span=Irregular(0.0, 50.0),
                         sampling=Intervals(Start()))
-        mode_ = Sampled(Ordered(index=ReverseIndex()), Irregular(10.0, 60.0), Intervals(Start()))
-        @test _bounds(_slicemode(mode_, ind, 1:5), X(ind)) == (10.0, 60.0)
-        @test _bounds(_slicemode(mode_, ind, 1:3), X(ind)) == (30.0, 60.0)
+        mode_ = Sampled(Ordered(index=ReverseIndex()), Irregular(0.0, 50.0), Intervals(Start()))
+        @test _bounds(_slicemode(mode_, revind, 1:5), X(revind)) == (0.0, 50.0)
+        @test _bounds(_slicemode(mode_, revind, 1:2), X(revind)) == (30.0, 50.0)
+        @test _bounds(_slicemode(mode_, revind, 1:3), X(revind)) == (20.0, 50.0)
     end
 
     @testset "Irregular with no bounds" begin


### PR DESCRIPTION
Irregular span with a reverse index had the wrong bounds after slicing previously.

Includes minor fixes to stack methods.