### PR TITLE
fix mapslices dimensions

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -95,4 +95,10 @@ const DimensionalArray = DimArray
 const AbstractDimDataset = AbstractDimStack
 const DimDataset = DimStack
 
+precompile(DimArray, (Array{Int,1}, typeof(X())))
+precompile(DimArray, (Array{Int,2}, Tuple{typeof(X()), typeof(Y())}))
+precompile(DimArray, (Array{Float64,1}, typeof(X())))
+precompile(DimArray, (Array{Float64,2}, Tuple{typeof(X()), typeof(Y())}))
+precompile(DimArray, (Array{Float64,3}, Tuple{typeof(X()), typeof(Y())}))
+
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -96,8 +96,8 @@ end
 
 function Base.mapslices(f, A::AbstractDimArray; dims=1, kw...)
     dimnums = dimnum(A, _astuple(dims))
-    _data = mapslices(f, parent(A); dims=dimnums, kw...)
-    rebuild(A, _data, reducedims(A, DimensionalData.dims(A, dimnums)))
+    data = mapslices(f, parent(A); dims=dimnums, kw...)
+    rebuild(A, data)
 end
 
 # This is copied from base as we can't efficiently wrap this function

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -81,10 +81,12 @@ flip(ot::Type{<:SubOrder}, o::Order) = _set(o, reverse(ot, o))
 Reorder every dims index/array/relation to `order`, or reorder index for
 the the given dimension(s) to the `Order` they wrap.
 
-Reorderind `Relation` will reverse the array, not the dimension index.
+Reordering `Relation` will reverse the array, not the dimension index.
 
 `order` can be an [`Order`](@ref), a single [`Dimension`](@ref)
 or a `Tuple` of `Dimension`.
+
+If no axis reversal is required the same objects will be returned, without allocation.
 """
 function reorder end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -256,13 +256,13 @@ end
     a = [1 2 3 4
          3 4 5 6
          5 6 7 8]
-    da = DimArray(a, (Y((10, 30); mode=Sampled(sampling=Intervals())), 
-                              Ti(1:4; mode=Sampled(sampling=Intervals()))))
+    da = DimArray(a, (Y(10:10:30; mode=Sampled(sampling=Intervals())), 
+                      Ti(1:4; mode=Sampled(sampling=Intervals()))))
     ms = mapslices(sum, da; dims=Y)
     @test ms == [9 12 15 18]
-    @test typeof(dims(ms)) == 
-    typeof((Y([10.0]; mode=Sampled(Ordered(), Regular(30.0), Intervals(Center()))),
-            Ti(1:4; mode=Sampled(Ordered(), Regular(1), Intervals(Start())))))
+    @test dims(ms) == 
+            (Y(10:10:30; mode=Sampled(Ordered(), Regular(10), Intervals(Center()))),
+             Ti(1:4; mode=Sampled(Ordered(), Regular(1), Intervals(Start()))))
     @test refdims(ms) == ()
     ms = mapslices(sum, da; dims=Ti)
     @test parent(ms) == [10 18 26]'


### PR DESCRIPTION
Fixes bug with returned dimensions from `mapslices`

Closes #280