### PR TITLE
Fix stack map

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -221,4 +221,5 @@ DimensionalData.flip
 DimensionalData.dimsmatch
 DimensionalData.dimstride
 DimensionalData.refdims_title
+DimensionalData.rebuild_from_arrays
 ```


### PR DESCRIPTION
This PR makes sure that stack metadata is copied to the new stack after `map`, and that additional metadata of inherited types can be copied at the same time by adding a `rebuild_from_arrays` method, that behaves like `rebuild` but gets most fields from the arrays (as returned by `map`).