### PR TITLE
add map for mulltiple stack arguments

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -131,7 +131,7 @@ Apply functrion `f` to each layer of the stack `s`, and rebuild it.
 If `f` returns `DimArray`s the result will be another `DimStack`.
 Other values will be returned in a `NamedTuple`.
 """
-Base.map(f, s::AbstractDimStack) = _maybestack(s, map(f, layers(s)))
+Base.map(f, s::AbstractDimStack...) = _maybestack(s[1], map(f, map(layers, s)...))
 
 _maybestack(s::AbstractDimStack, x::NamedTuple) = x
 function _maybestack(

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -31,6 +31,9 @@ end
     @test values(map(a -> a .* 2, s)) == values(DimStack(2da1, 2da2, 2da3))
     @test dims(map(a -> a .* 2, s)) == dims(DimStack(2da1, 2da2, 2da3))
     @test map(a -> a[1], s) == (one=1.0, two=2.0, three=3.0)
+    @test values(map(a -> a .* 2, s)) == values(DimStack(2da1, 2da2, 2da3))
+    @test map(+, s, s, s) == map(a -> a .* 3, s)
+    @test_throws ArgumentError map(+, s, mixed)
 end
 
 @testset "Methods with no arguments" begin


### PR DESCRIPTION
`map` across multiple stacks, returning a `DimStack` or `NamedTuple`. Essentially works the same as `map` on multiple `NamedTuple`, and will play nice with `NamedTuple` with the same keys.