### PR TITLE
Remove 3arg DimArray syntax

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -145,7 +145,7 @@ end
     DimArray <: AbstractDimArray
 
     DimArray(data, dims, refdims, name)
-    DimArray(data, dims::Tuple [, name::Symbol]; refdims=(), metadata=NoMetadata())
+    DimArray(data, dims::Tuple; refdims=(), name=NoName(), metadata=NoMetadata())
 
 The main concrete subtype of [`AbstractDimArray`](@ref).
 
@@ -191,7 +191,6 @@ end
 function DimArray(data::AbstractArray, dims; refdims=(), name=NoName(), metadata=NoMetadata())
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
 end
-@deprecate DimArray(data::AbstractArray, dims, name; kw...) DimArray(data, dims; name=name, kw...)
 # All keyword argument version
 function DimArray(; data, dims, refdims=(), name=NoName(), metadata=NoMetadata())
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
@@ -209,16 +208,15 @@ Apply function `f` across the values of the dimension `dim`
 (using `broadcast`), and return the result as a dimensional array with
 the given dimension. Optionally provide a name for the result.
 """
-function DimArray(f::Function, dim::Dimension, name=Symbol(nameof(f), "(", name(dim), ")"))
+function DimArray(f::Function, dim::Dimension; name=Symbol(nameof(f), "(", name(dim), ")"))
      DimArray(f.(val(dim)), (dim,), name)
 end
 
 """
-    rebuild(A::DimArray, data::AbstractArray, dims::Tuple,
-            refdims::Tuple, name::Symbol, metadata) => DimArray
+    rebuild(A::DimArray, data, dims, refdims, name, metadata) => DimArray
 
 Rebuild a `DimArray` with new fields. Handling partial field
-update is dealth with in `rebuild` for `AbstractDimArray`.
+update is dealt with in `rebuild` for `AbstractDimArray`.
 """
 @inline function rebuild(
     A::DimArray, data::AbstractArray, dims::Tuple, refdims::Tuple, name, metadata

--- a/src/array.jl
+++ b/src/array.jl
@@ -209,7 +209,7 @@ Apply function `f` across the values of the dimension `dim`
 the given dimension. Optionally provide a name for the result.
 """
 function DimArray(f::Function, dim::Dimension; name=Symbol(nameof(f), "(", name(dim), ")"))
-     DimArray(f.(val(dim)), (dim,), name)
+     DimArray(f.(val(dim)), (dim,); name)
 end
 
 """

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -280,11 +280,11 @@ julia> dimz = (X([:a, :b]), Y(10.0:10.0:30.0))
   X: Symbol[a, b],
   Y: 10.0:10.0:30.0
 
-julia> da1 = DimArray(1A, dimz, :one);
+julia> da1 = DimArray(1A, dimz; name=:one);
 
-julia> da2 = DimArray(2A, dimz, :two);
+julia> da2 = DimArray(2A, dimz; name=:two);
 
-julia> da3 = DimArray(3A, dimz, :three);
+julia> da3 = DimArray(3A, dimz; name=:three);
 
 julia> s = DimStack(da1, da2, da3);
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -12,8 +12,8 @@ ameta = Metadata(:meta => "da")
 dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=xmeta),
         Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=ymeta))
 refdimz = (Ti(1:1),)
-da = @test_nowarn DimArray(a, dimz, :test; refdims=refdimz, metadata=ameta)
-da2 = DimArray(a2, dimz2, :test2; refdims=refdimz)
+da = @test_nowarn DimArray(a, dimz; refdims=refdimz, name=:test, metadata=ameta)
+da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
 
 @testset "size and axes" begin
     @test size(da2, Dim{:row}) == 3

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -41,7 +41,7 @@ end
     dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=xmeta),
             Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=ymeta))
     refdimz = (Ti(1:1),)
-    da = @test_nowarn DimArray(a, dimz, :test; refdims=refdimz, metadata=ameta)
+    da = @test_nowarn DimArray(a, dimz; refdims=refdimz, name=:test, metadata=ameta)
 
     @testset "getindex for single integers returns values" begin
         @test da[X(1), Y(2)] == 2
@@ -210,7 +210,7 @@ end
     end
 
     dimz2 = (Dim{:row}((10, 30)), Dim{:column}((-20, 10)))
-    da2 = DimArray(a2, dimz2, :test2; refdims=refdimz)
+    da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
 
     @testset "mode step is updated when indexed with a range" begin
         @test step.(mode(da2)) == (10.0, 10.0)
@@ -263,9 +263,9 @@ end
     A = [1.0 2.0 3.0;
          4.0 5.0 6.0]
     dimz = (X([:a, :b]), Y(10.0:10.0:30.0))
-    da1 = DimArray(A, dimz, :one)
-    da2 = DimArray(Float32.(2A), dimz, :two)
-    da3 = DimArray(Int.(3A), dimz, :three)
+    da1 = DimArray(A, dimz; name=:one)
+    da2 = DimArray(Float32.(2A), dimz; name=:two)
+    da3 = DimArray(Int.(3A), dimz; name=:three)
 
     s = DimStack((da1, da2, da3))
 

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -3,10 +3,10 @@ import Distributions
 
 A1 = rand(Distributions.Normal(), 20)
 ref = (Ti(1, Sampled(Ordered(), Regular(Day(1)), Points())),)
-da1_regular = DimArray(A1, X(1:50:1000), :Normal; refdims=ref)
-da1_noindex = DimArray(A1, X(), :Normal; refdims=ref)
-da1_categorical = DimArray(A1, X('A':'T'), :Normal; refdims=ref)
-da1_z = DimArray(A1, Z(1:50:1000), :Normal; refdims=ref)
+da1_regular = DimArray(A1, X(1:50:1000); name=:Normal, refdims=ref)
+da1_noindex = DimArray(A1, X(); name=:Normal, refdims=ref)
+da1_categorical = DimArray(A1, X('A':'T'); name=:Normal, refdims=ref)
+da1_z = DimArray(A1, Z(1:50:1000); name=:Normal, refdims=ref)
 
 # For manual testing
 da1 = da1_z
@@ -41,15 +41,15 @@ for da in (da1_regular, da1_noindex, da1_categorical, da1_z)
 end
 
 A2 = rand(Distributions.Normal(), 40, 20)
-da2_regular = DimArray(A2, (X(1:10:400), Y(1:5:100)), :Normal)
-da2_noindex = DimArray(A2, (X(), Y()), :Normal)
-da2_ni_r = DimArray(A2, (X(), Y(1:5:100)), :Normal)
-da2_r_ni = DimArray(A2, (X(1:10:400), Y()), :Normal)
-da2_c_c = DimArray(A2, (X('A':'h'), Y('a':'t')), :Normal)
-da2_XY = DimArray(A2, (X(1:10:400), Y(1:5:100)), :Normal)
-da2_YX = DimArray(A2, (Y(1:10:400), X(1:5:100)), :Normal)
-da2_ZY = DimArray(A2, (Z(1:10:400), Y(1:5:100)), :Normal)
-da2_XTi = DimArray(A2, (X(1:10:400), Ti(1:5:100)), :Normal)
+da2_regular = DimArray(A2, (X(1:10:400), Y(1:5:100)); name=:Normal)
+da2_noindex = DimArray(A2, (X(), Y()); name=:Normal)
+da2_ni_r = DimArray(A2, (X(), Y(1:5:100)); name=:Normal)
+da2_r_ni = DimArray(A2, (X(1:10:400), Y()); name=:Normal)
+da2_c_c = DimArray(A2, (X('A':'h'), Y('a':'t')); name=:Normal)
+da2_XY = DimArray(A2, (X(1:10:400), Y(1:5:100)); name=:Normal)
+da2_YX = DimArray(A2, (Y(1:10:400), X(1:5:100)); name=:Normal)
+da2_ZY = DimArray(A2, (Z(1:10:400), Y(1:5:100)); name=:Normal)
+da2_XTi = DimArray(A2, (X(1:10:400), Ti(1:5:100)); name=:Normal)
 
 # For manual testing
 da2 = da2_XTi

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -431,7 +431,7 @@ end
 
 @testset "dimstride" begin
     dimz = (X(), Y(), Dim{:test}())
-    da = DimArray(ones(3, 2, 3), dimz, :data)
+    da = DimArray(ones(3, 2, 3), dimz; name=:data)
     @test dimstride(da, X()) == 1
     @test dimstride(da, Y()) == 3
     @test dimstride(da, Dim{:test}()) == 6

--- a/test/set.jl
+++ b/test/set.jl
@@ -4,15 +4,15 @@ using DimensionalData: _set, AutoSampling
 a = [1 2; 3 4]
 dimz = (X((143.0, 145.0); mode=Sampled(order=Ordered()), metadata=Metadata(Dict(:meta => "X"))),
         Y((-38.0, -36.0); mode=Sampled(order=Ordered()), metadata=Metadata(Dict(:meta => "Y"))))
-da = DimArray(a, dimz, :test)
+da = DimArray(a, dimz; name=:test)
 
 a2 = [1 2 3 4
       3 4 5 6
       4 5 6 7]
 dimz2 = (Dim{:row}(10.0:10.0:30.0), Dim{:column}(-2:1.0:1.0))
-da2 = DimArray(a2, dimz2, :test2)
+da2 = DimArray(a2, dimz2; name=:test2)
 
-s = DimStack(da2, DimArray(2a2, dimz2, :test3))
+s = DimStack(da2, DimArray(2a2, dimz2; name=:test3))
 
 @testset " Array fields" begin
     @test name(set(da2, :newname)) == :newname

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -4,10 +4,10 @@ A = [1.0 2.0 3.0;
      4.0 5.0 6.0]
 x, y, z = X([:a, :b]), Y(10.0:10.0:30.0), Z()
 dimz = x, y
-da1 = DimArray(A, (x, y), :one)
-da2 = DimArray(Float32.(2A), (x, y), :two)
-da3 = DimArray(Int.(3A), (x, y), :three)
-da4 = DimArray(cat(4A, 5A, 6A, 7A; dims=3), (x, y, z), :extradim)
+da1 = DimArray(A, (x, y); name=:one)
+da2 = DimArray(Float32.(2A), (x, y); name=:two)
+da3 = DimArray(Int.(3A), (x, y); name=:three)
+da4 = DimArray(cat(4A, 5A, 6A, 7A; dims=3), (x, y, z); name=:extradim)
 
 s = DimStack((da1, da2, da3))
 mixed = DimStack((da1, da2, da4))

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -6,8 +6,8 @@ x = X([:a, :b, :c])
 y = Y([10.0, 20.0])
 d = Dim{:test}(1.0:1.0:3.0)
 dimz = x, y, d
-da = DimArray(ones(3, 2, 3), dimz, :data)
-da2 = DimArray(fill(2, (3, 2, 3)), dimz, :data2)
+da = DimArray(ones(3, 2, 3), dimz; name=:data)
+da2 = DimArray(fill(2, (3, 2, 3)), dimz; name=:data2)
 
 @testset "DimArray Tables interface" begin
     ds = DimStack(da)
@@ -96,8 +96,8 @@ end
 end
 
 @testset "Mixed size" begin
-    da1 = DimArray(reshape(11:28, (3, 2, 3)), (x, y, d), :data1)
-    da2 = DimArray(reshape(1.0:6.0, (2, 3)), (y, d), :data2)
+    da1 = DimArray(reshape(11:28, (3, 2, 3)), (x, y, d); name=:data1)
+    da2 = DimArray(reshape(1.0:6.0, (2, 3)), (y, d); name=:data2)
     ds = DimStack(da1, da2)
     @time t = DimTable(ds)
     @time df = DataFrame(t; copycols=true)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,7 +17,7 @@ using DimensionalData: flip, shiftlocus, maybeshiftlocus
     end
 
     A = [1 2 3; 4 5 6]
-    da = DimArray(A, (X(10:10:20), Y(300:-100:100)), :test)
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)); name=:test)
     s = DimStack(da)
 
     reva = reverse(ArrayOrder, da; dims=Y)
@@ -50,7 +50,7 @@ using DimensionalData: flip, shiftlocus, maybeshiftlocus
 
     @testset "Val index" begin
         dav = DimArray(A, (X(Val((10, 20)); mode=Sampled(order=Ordered())), 
-                           Y(Val((300, 200, 100)); mode=Sampled(order=Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())))), :test)
+                           Y(Val((300, 200, 100)); mode=Sampled(order=Ordered(ReverseIndex(), ForwardArray(), ForwardRelation())))); name=:test)
         revdav = reverse(IndexOrder, dav; dims=(X, Y))
         @test val(revdav) == (Val((20, 10)), Val((100, 200, 300)))
     end
@@ -68,9 +68,9 @@ using DimensionalData: flip, shiftlocus, maybeshiftlocus
 
     @testset "stack" begin
         dimz = (X([:a, :b]), Y(10.0:10.0:30.0))
-        da1 = DimArray(A, dimz, :one)
-        da2 = DimArray(Float32.(2A), dimz, :two)
-        da3 = DimArray(Int.(3A), dimz, :three)
+        da1 = DimArray(A, dimz; name=:one)
+        da2 = DimArray(Float32.(2A), dimz; name=:two)
+        da3 = DimArray(Int.(3A), dimz; name=:three)
 
         s = DimStack((da1, da2, da3))
         rev_s = reverse(s; dims=X) 
@@ -82,7 +82,7 @@ end
 
 @testset "reorder" begin
     A = [1 2 3; 4 5 6]
-    da = DimArray(A, (X(10:10:20), Y(300:-100:100)), :test)
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)); name=:test)
     s = DimStack(da)
 
     reoa = reorder(da, ReverseArray())
@@ -120,7 +120,7 @@ end
 
 @testset "flip" begin
     A = [1 2 3; 4 5 6]
-    da = DimArray(A, (X(10:10:20), Y(300:-100:100)), :test)
+    da = DimArray(A, (X(10:10:20), Y(300:-100:100)); name=:test)
     fda = flip(IndexOrder, da; dims=(X, Y))
     @test indexorder(fda) == (ReverseIndex(), ForwardIndex())
     fda = flip(Relation, da, Y)
@@ -140,8 +140,8 @@ end
         @test_throws ErrorException modify(A -> A[1, :], da)
     end
     @testset "dataset" begin
-        da1 = DimArray(A, dimz, :da1)
-        da2 = DimArray(2A, dimz, :da2)
+        da1 = DimArray(A, dimz; name=:da1)
+        da2 = DimArray(2A, dimz; name=:da2)
         s = DimStack(da1, da2)
         ms = modify(A -> A .> 3, s)
         @test data(ms) == (da1=[false false false; true true true],


### PR DESCRIPTION
This PR remove `DimArray(A, (X, Y), :name)` syntax in favour of `DimArray(A, (X, Y); name= :name)` that also already worked.

This reduces the number of constructors - it seems to have confused some people that this worked.

@Datseris since you added this just letting you know it will be gone as of the next minor version, although it's been depreciated for a while.