### PR TITLE
fix dimwise for same ndims arrays

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -17,6 +17,12 @@ AbstractDimStack
 DimStack
 ```
 
+## Dimension indindices generator
+
+```julia
+DimIndices
+```
+
 ## Core types
 
 ### Dimensions:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,7 +19,7 @@ DimStack
 
 ## Dimension indindices generator
 
-```julia
+```@docs
 DimIndices
 ```
 

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -52,6 +52,8 @@ export AbstractDimTable, DimTable
 
 export AbstractDimStack, DimStack
 
+export DimIndices
+
 export AbstractMetadata, Metadata, NoMetadata
 
 export AbstractName, Name, NoName
@@ -78,6 +80,7 @@ include("array.jl")
 include("stack.jl")
 include("tables.jl")
 include("selector.jl")
+include("dimindices.jl")
 include("indexing.jl")
 include("primitives.jl")
 include("broadcast.jl")

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -22,6 +22,7 @@ function DimIndices(dims::D) where {D<:Tuple{<:Dimension,Vararg{<:Dimension}}}
     DimIndices{T,N,D}(dims)
 end
 DimIndices(x) = DimIndices(dims(x))
+DimIndices(::Nothing) = throw(ArgumentError("Object has no `dims` method"))
 
 dims(di::DimIndices) = di.dims
 

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -1,0 +1,50 @@
+"""
+    DimIndices <: AbstractArray
+
+    DimIndices(x)
+    DimIndices(dims::Tuple)
+    DimIndices(dims::Dimension)
+
+Like CartesianIndices, but for Dimensions. Behaves as an Array of Tuples
+of Dimensions for all combinations of the axis values of `dims`.
+
+This can be used to view/index into arbitrary dimensions over an array, and
+is especially useful when combined with `otherdims`, ti iterate over the
+indices of unknown dimension.
+"""
+struct DimIndices{T,N,D<:Tuple{<:Dimension,Vararg{<:Dimension}}} <: AbstractArray{T,N}
+    dims::D
+end
+DimIndices(dim::Dimension) = DimIndices((dim,))
+function DimIndices(dims::D) where {D<:Tuple{<:Dimension,Vararg{<:Dimension}}}
+    T = typeof(map(d -> basetypeof(d)(1), dims))
+    N = length(dims)
+    DimIndices{T,N,D}(dims)
+end
+DimIndices(x) = DimIndices(dims(x))
+
+dims(di::DimIndices) = di.dims
+
+Base.size(di::DimIndices) = map(length, dims(di))
+Base.axes(di::DimIndices) = map(d -> axes(d, 1), dims(di))
+
+for f in (:getindex, :view, :dotview)
+    @eval begin
+        @propagate_inbounds Base.$f(A::DimIndices, I::Union{Val,Selector}...) = Base.$f(A, dims2indices(A, I)...)
+        @propagate_inbounds function Base.$f(A::DimIndices, I::Dimension...; kw...)
+            Base.$f(A, dims2indices(A, I..., _kwdims(kw.data)...)...)
+        end
+    end
+end
+
+@propagate_inbounds function Base.getindex(A::DimIndices, i1::Union{Int,Colon,AbstractArray}, I::Union{Int,Colon,AbstractArray}...)
+    ds = map(dims(A), (i1, I...)) do d, i
+        i isa Int ? nothing : basetypeof(d)(d[i])
+    end |> _remove_nothing
+    DimIndices(ds)
+end
+function Base.getindex(di::DimIndices, i1::Int, I::Int...)
+    map(dims(di), (i1, I...)) do d, i
+        basetypeof(d)(getindex(axes(d, 1), i))
+    end
+end

--- a/src/identify.jl
+++ b/src/identify.jl
@@ -27,8 +27,6 @@ identify(mode::AutoMode, dimtype::Type, index::AbstractArray{T}) where T = begin
     end
 end
 identify(mode::AutoMode, dimtype::Type, index::AbstractArray{<:CategoricalEltypes}) =
-    order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))
-identify(mode::AutoMode, dimtype::Type, index::AbstractArray{<:CategoricalEltypes}) =
     order(mode) isa AutoOrder ? Categorical(_orderof(index)) : Categorical(order(mode))
 identify(mode::AutoMode, dimtype::Type, index::Val) =
     order(mode) isa AutoOrder ? Categorical(Unordered()) : Categorical(order(mode))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -30,7 +30,7 @@ for f in (:getindex, :view, :dotview)
         # Except 1D DimArrays
         @propagate_inbounds Base.$f(A::AbstractDimArray{<:Any, 1}, i::Union{Colon,AbstractVector{<:Integer}}) =
             rebuildsliced(Base.$f, A, Base.$f(parent(A), i), (i,))
-        # Dimension indexing. Allows indexing with A[somedim=25.0] for Dim{:somedim}
+        # Dimension indexing. Allows indexing with A[somedim=At(25.0)] for Dim{:somedim}
         @propagate_inbounds Base.$f(A::AbstractDimArray, args::Dimension...; kw...) =
             Base.$f(A, dims2indices(A, (args..., _kwdims(kw.data)...))...)
         # Standard indices

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -204,28 +204,11 @@ function dimwise!(
     if length(od) == 0
         dest .= f.(a, b)
     else
-        map(dimwise_generators(od)) do D
+        map(DimIndices(od)) do D
             dest[D...] .= f.(a[D...], b)
         end
     end
     return dest
-end
-
-# Single dimension generator
-function dimwise_generators(dims::Tuple{<:Dimension})
-    ((basetypeof(dims[1])(i),) for i in axes(dims[1], 1))
-end
-# Multi dimensional generators
-function dimwise_generators(dims::Tuple)
-    baseds = basedims(dims)
-    # Get the axes of the dims to iterate over
-    dimaxes = map(d -> axes(d, 1), dims)
-    # Make an iterator over all axes
-    proditr = Base.Iterators.ProductIterator(dimaxes)
-    # Wrap the produced index I in dimensions as it is generated
-    Base.Generator(proditr) do I
-        map((D, i) -> rebuild(D, i), baseds, I)
-    end
 end
 
 """

--- a/test/dimindices.jl
+++ b/test/dimindices.jl
@@ -1,0 +1,9 @@
+using DimensionalData, Test
+
+A = zeros(X(4.0:7.0), Y(10.0:12.0))
+di = DimIndices(A)
+di[4, 3] == (X(4), Y(3))
+@test di[X(1)] == [(Y(1),), (Y(2),), (Y(3),)]
+@test map(ds -> A[ds...] + 2, di) == fill(2.0, 4, 3)
+@test map(ds -> A[ds...], di[X(At(7.0))]) == [fill(0.0, 4) for i in 1:3]
+

--- a/test/dimindices.jl
+++ b/test/dimindices.jl
@@ -6,4 +6,5 @@ di[4, 3] == (X(4), Y(3))
 @test di[X(1)] == [(Y(1),), (Y(2),), (Y(3),)]
 @test map(ds -> A[ds...] + 2, di) == fill(2.0, 4, 3)
 @test map(ds -> A[ds...], di[X(At(7.0))]) == [fill(0.0, 4) for i in 1:3]
+@test_throws ArgumentError DimIndices(zeros(2, 2))
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -166,14 +166,18 @@ end
     B1 = [1, 2, 3]
     da2 = DimArray(A2, (X([20, 30]), Y([:a, :b, :c])))
     db1 = DimArray(B1, (Y([:a, :b, :c]),))
+    dc1 = dimwise(+, db1, db1)
+    @test dc1 == [2, 4, 6]
     dc2 = dimwise(+, da2, db1)
     @test dc2 == [2 4 6; 5 7 9]
+    dc4 = dimwise(+, da2, db1)
 
     A3 = cat([1 2 3; 4 5 6], [11 12 13; 14 15 16]; dims=3)
     da3 = DimArray(A3, (X, Y, Z))
     db2 = DimArray(A2, (X, Y))
     dc3 = dimwise(+, da3, db2)
     @test dc3 == cat([2 4 6; 8 10 12], [12 14 16; 18 20 22]; dims=3)
+    dc3 = dimwise!(+, da3, da3, db2)
 
     A3 = cat([1 2 3; 4 5 6], [11 12 13; 14 15 16]; dims=3)
     da3 = DimArray(A3, (X([20, 30]), Y([:a, :b, :c]), Z(10:10:20)))


### PR DESCRIPTION
Fixes `dimwise` and adds the `DimIndices` object to generalised the previous `dimwise_generators` method.