### PR TITLE
Dimkeys

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ DimStack
 
 ```@docs
 DimIndices
+DimKeys
 ```
 
 ## Core types

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -7,20 +7,26 @@ module DimensionalData
     read(path, String)
 end DimensionalData
 
+# Standard lib
+using Dates,
+      LinearAlgebra,
+      Random,
+      Statistics,
+      SparseArrays
+
 using Base.Broadcast: Broadcasted, BroadcastStyle, DefaultArrayStyle, AbstractArrayStyle,
       Unknown
 
-using Adapt,
-      ConstructionBase,
-      Dates,
-      LinearAlgebra,
-      Random,
-      RecipesBase,
-      Statistics,
-      SparseArrays,
-      Tables
-
 using Base: tail, OneTo, @propagate_inbounds
+      
+# Ecosystem
+import Adapt, 
+       ConstructionBase, 
+       RecipesBase,
+       Tables
+
+using RecipesBase: @recipe
+
 
 
 export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim,
@@ -99,10 +105,14 @@ const DimensionalArray = DimArray
 const AbstractDimDataset = AbstractDimStack
 const DimDataset = DimStack
 
-precompile(DimArray, (Array{Int,1}, typeof(X())))
-precompile(DimArray, (Array{Int,2}, Tuple{typeof(X()), typeof(Y())}))
-precompile(DimArray, (Array{Float64,1}, typeof(X())))
-precompile(DimArray, (Array{Float64,2}, Tuple{typeof(X()), typeof(Y())}))
-precompile(DimArray, (Array{Float64,3}, Tuple{typeof(X()), typeof(Y())}))
+function _precompile()
+    precompile(DimArray, (Array{Int,1}, typeof(X())))
+    precompile(DimArray, (Array{Int,2}, Tuple{typeof(X()), typeof(Y())}))
+    precompile(DimArray, (Array{Float64,1}, typeof(X())))
+    precompile(DimArray, (Array{Float64,2}, Tuple{typeof(X()), typeof(Y())}))
+    precompile(DimArray, (Array{Float64,3}, Tuple{typeof(X()), typeof(Y()), typeof(Z())}))
+end
+
+_precompile()
 
 end

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -58,7 +58,7 @@ export AbstractDimTable, DimTable
 
 export AbstractDimStack, DimStack
 
-export DimIndices
+export DimIndices, DimKeys
 
 export AbstractMetadata, Metadata, NoMetadata
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -131,11 +131,11 @@ Base.copy!(dst::SparseArrays.SparseVector, src::AbstractDimArray{T,1}) where T =
 
 function Adapt.adapt_structure(to, A::AbstractDimArray)
     rebuild(A,
-        data=adapt(to, parent(A)),
-        dims=adapt(to, dims(A)),
-        refdims=adapt(to, refdims(A)),
+        data=Adapt.adapt(to, parent(A)),
+        dims=Adapt.adapt(to, dims(A)),
+        refdims=Adapt.adapt(to, refdims(A)),
         name=Name(name(A)),
-        metadata=adapt(to, metadata(A)),
+        metadata=Adapt.adapt(to, metadata(A)),
     )
 end
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -145,8 +145,13 @@ month, hour, second etc., not the central point as is more common with spatial d
 abstract type TimeDim{T,Mo,Me} <: IndependentDim{T,Mo,Me} end
 
 ConstructionBase.constructorof(d::Type{<:Dimension}) = basetypeof(d)
-Adapt.adapt_structure(to, dim::Dimension) =
-    rebuild(dim, adapt(to, val(dim)), adapt(to, mode(dim)), adapt(to, metadata(dim)))
+function Adapt.adapt_structure(to, dim::Dimension)
+    rebuild(dim; 
+        val=Adapt.adapt(to, val(dim)), 
+        mode=Adapt.adapt(to, mode(dim)), 
+        metadata=Adapt.adapt(to, metadata(dim))
+    )
+end
 
 const DimType = Type{<:Dimension}
 const DimTuple = Tuple{<:Dimension,Vararg{<:Dimension}}
@@ -166,7 +171,7 @@ Rebuild dim with fields from `dim`, and new fields passed in.
 function rebuild(
     dim::D, val, mode::IndexMode=mode(dim), metadata=metadata(dim)
 ) where D <: Dimension
-    constructorof(D)(val, mode, metadata)
+    ConstructionBase.constructorof(D)(val, mode, metadata)
 end
 
 dims(dim::Union{Dimension,DimType,Val{<:Dimension}}) = dim

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -1,3 +1,29 @@
+
+abstract type AbstractDimIndices{T,N} <: AbstractArray{T,N} end
+
+dims(di::AbstractDimIndices) = di.dims
+
+Base.size(di::AbstractDimIndices) = map(length, dims(di))
+Base.axes(di::AbstractDimIndices) = map(d -> axes(d, 1), dims(di))
+
+for f in (:getindex, :view, :dotview)
+    @eval begin
+        @propagate_inbounds Base.$f(A::AbstractDimIndices, I::Union{Val,Selector}...) = Base.$f(A, dims2indices(A, I)...)
+        @propagate_inbounds function Base.$f(A::AbstractDimIndices, I::Dimension...; kw...)
+            Base.$f(A, dims2indices(A, I..., _kwdims(kw.data)...)...)
+        end
+    end
+end
+
+@propagate_inbounds function Base.getindex(
+    A::DI, i1::Union{Int,Colon,AbstractArray}, I::Union{Int,Colon,AbstractArray}...
+) where DI<:AbstractDimIndices
+    ds = map(dims(A), (i1, I...)) do d, i
+        i isa Int ? nothing : basetypeof(d)(d[i])
+    end |> _remove_nothing
+    basetypeof(DI)(ds)
+end
+
 """
     DimIndices <: AbstractArray
 
@@ -5,14 +31,14 @@
     DimIndices(dims::Tuple)
     DimIndices(dims::Dimension)
 
-Like CartesianIndices, but for Dimensions. Behaves as an Array of Tuples
-of Dimensions for all combinations of the axis values of `dims`.
+Like CartesianIndices, but for Dimensions. Behaves as an `Array` of `Tuple`
+of `Dimension(i)` for all combinations of the axis indices of `dims`.
 
 This can be used to view/index into arbitrary dimensions over an array, and
-is especially useful when combined with `otherdims`, ti iterate over the
+is especially useful when combined with `otherdims`, to iterate over the
 indices of unknown dimension.
 """
-struct DimIndices{T,N,D<:Tuple{<:Dimension,Vararg{<:Dimension}}} <: AbstractArray{T,N}
+struct DimIndices{T,N,D<:Tuple{<:Dimension,Vararg{<:Dimension}}} <: AbstractDimIndices{T,N}
     dims::D
 end
 DimIndices(dim::Dimension) = DimIndices((dim,))
@@ -24,28 +50,37 @@ end
 DimIndices(x) = DimIndices(dims(x))
 DimIndices(::Nothing) = throw(ArgumentError("Object has no `dims` method"))
 
-dims(di::DimIndices) = di.dims
-
-Base.size(di::DimIndices) = map(length, dims(di))
-Base.axes(di::DimIndices) = map(d -> axes(d, 1), dims(di))
-
-for f in (:getindex, :view, :dotview)
-    @eval begin
-        @propagate_inbounds Base.$f(A::DimIndices, I::Union{Val,Selector}...) = Base.$f(A, dims2indices(A, I)...)
-        @propagate_inbounds function Base.$f(A::DimIndices, I::Dimension...; kw...)
-            Base.$f(A, dims2indices(A, I..., _kwdims(kw.data)...)...)
-        end
+function Base.getindex(di::DimIndices, i1::Int, I::Int...)
+    map(dims(di), (i1, I...)) do d, i
+        basetypeof(d)(axes(d, 1)[i])
     end
 end
 
-@propagate_inbounds function Base.getindex(A::DimIndices, i1::Union{Int,Colon,AbstractArray}, I::Union{Int,Colon,AbstractArray}...)
-    ds = map(dims(A), (i1, I...)) do d, i
-        i isa Int ? nothing : basetypeof(d)(d[i])
-    end |> _remove_nothing
-    DimIndices(ds)
+"""
+    DimKeys <: AbstractArray
+
+    DimKeys(x)
+    DimKeys(dims::Tuple)
+    DimKeys(dims::Dimension)
+
+Like CartesianIndices, but for the key values of Dimensions. Behaves as an 
+`Array` of `Tuple` of `Dimension(At(keyvalue))` for all combinations of the 
+axis values of `dims`.
+"""
+struct DimKeys{T,N,D<:Tuple{<:Dimension,Vararg{<:Dimension}}} <: AbstractDimIndices{T,N}
+    dims::D
 end
-function Base.getindex(di::DimIndices, i1::Int, I::Int...)
+DimKeys(dim::Dimension) = DimKeys((dim,))
+function DimKeys(dims::D) where {D<:Tuple{<:Dimension,Vararg{<:Dimension}}}
+    T = typeof(map(d -> basetypeof(d)(At(first(d))), dims))
+    N = length(dims)
+    DimKeys{T,N,D}(dims)
+end
+DimKeys(x) = DimKeys(dims(x))
+DimKeys(::Nothing) = throw(ArgumentError("Object has no `dims` method"))
+
+function Base.getindex(di::DimKeys, i1::Int, I::Int...)
     map(dims(di), (i1, I...)) do d, i
-        basetypeof(d)(getindex(axes(d, 1), i))
+        basetypeof(d)(At(d[i])) # At selector with the value at i
     end
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -321,3 +321,17 @@ Base.diff(A::AbstractDimArray; dims) = _diff(A, dimnum(A, dims))
     r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)
     rebuildsliced(A, diff(parent(A); dims=dimnum(A, dims)), r0)
 end
+
+# Forward `replace` to parent objects
+function Base._replace!(new::Base.Callable, res::AbstractDimArray, A::AbstractDimArray, count::Int) 
+    Base._replace!(new, parent(res), parent(A), count) 
+    return res
+end
+function Base._replace!(new::Base.Callable, res::AbstractArray, A::AbstractDimArray, count::Int) 
+    Base._replace!(new, res, parent(A), count) 
+    return res
+end
+function Base._replace!(new::Base.Callable, res::AbstractDimArray, A::AbstractArray, count::Int) 
+    Base._replace!(new, parent(res), A, count) 
+    return res
+end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -513,7 +513,7 @@ function comparedims end
     type=true, length=true, mode=false, val=false, metadata=false
 )
     type && basetypeof(a) != basetypeof(b) && _dimsmismatcherror(a, b)
-    mode && DD.mode(a) != DD.mode(b) && _modeerror(a, b)
+    mode && typeof(DD.mode(a)) != typeof(DD.mode(b)) && _modeerror(a, b)
     length && Base.length(a) != Base.length(b) && _dimsizeerror(a, b)
     val && DD.val(a) != DD.val(b) && _valerror(a, b)
     metadata && DD.metadata(a) != DD.metadata(b) && _metadataerror(a, b)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -83,7 +83,7 @@ function layers(s::AbstractDimStack{<:NamedTuple{Keys}}) where Keys
 end
 
 
-Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> adapt(to, A), s)
+Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> Adapt.adapt(to, A), s)
 
 # Dipatch on Tuple of Dimension, and map
 for func in (:index, :mode, :metadata, :sampling, :span, :bounds, :locus, :order)

--- a/test/dimindices.jl
+++ b/test/dimindices.jl
@@ -8,3 +8,9 @@ di[4, 3] == (X(4), Y(3))
 @test map(ds -> A[ds...], di[X(At(7.0))]) == [fill(0.0, 4) for i in 1:3]
 @test_throws ArgumentError DimIndices(zeros(2, 2))
 
+di = DimKeys(A)
+di[4, 3] == (X(At(7.0)), Y(At(12.0)))
+@test di[X(1)] == [(Y(At(10.0)),), (Y(At(11.0)),), (Y(At(12.0)),)]
+@test map(ds -> A[ds...] + 2, di) == fill(2.0, 4, 3)
+@test map(ds -> A[ds...], di[X(At(7.0))]) == [fill(0.0, 4) for i in 1:3]
+@test_throws ArgumentError DimIndices(zeros(2, 2))

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful, Combinatorics, Dates
-using DimensionalData: between, at, near, contains, sel2indices
+using DimensionalData: between, at, near, contains, sel2indices, hasselection
 
 a = [1 2  3  4
      5 6  7  8
@@ -20,6 +20,13 @@ A = DimArray([1 2 3; 4 5 6], dims_)
         startfwdrev = Ti(11.0:30.0;      mode=Sampled(Ordered(ForwardIndex(),ForwardArray(),ReverseRelation()), Regular(1), Intervals(Start())))
         startrevfwd = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ForwardRelation()), Regular(-1), Intervals(Start())))
         startrevrev = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ReverseRelation()), Regular(-1), Intervals(Start())))
+
+        cases = (startfwdfwd, startrevfwd, startfwdrev, startrevrev)
+        @test all(map(d -> hasselection(d, At(30.0)), cases))
+        @test all(map(d -> !hasselection(d, At(31.0)), cases))
+        @test all(map(d -> hasselection(d, Contains(12.8)), cases))
+        @test all(map(d -> !hasselection(d, Contains(400.0)), cases))
+        @test all(map(d -> hasselection(d, Near(0.0)), cases))
 
         @testset "Any at" begin
             @test at(startfwdfwd, At(30)) == 20

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -9,7 +9,6 @@ dims_ = X(10:10:20; mode=Sampled(sampling=Intervals())),
         Y(5:7; mode=Sampled(sampling=Intervals()))
 A = DimArray([1 2 3; 4 5 6], dims_)
 
-
 @testset "selector primitives" begin
 
     @testset "Regular Intervals with range" begin
@@ -21,18 +20,19 @@ A = DimArray([1 2 3; 4 5 6], dims_)
         startrevfwd = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ForwardRelation()), Regular(-1), Intervals(Start())))
         startrevrev = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ReverseRelation()), Regular(-1), Intervals(Start())))
 
-        cases = (startfwdfwd, startrevfwd, startfwdrev, startrevrev)
-        @test all(map(d -> hasselection(d, At(30.0)), cases))
-        @test all(map(d -> !hasselection(d, At(31.0)), cases))
-        @test all(map(d -> hasselection(d, Contains(12.8)), cases))
-        @test all(map(d -> !hasselection(d, Contains(400.0)), cases))
-        @test all(map(d -> hasselection(d, Near(0.0)), cases))
-
         @testset "Any at" begin
             @test at(startfwdfwd, At(30)) == 20
             @test at(startrevfwd, At(30)) == 1
             @test at(startfwdrev, At(30)) == 1
             @test at(startrevrev, At(30)) == 20
+            @test at(startfwdfwd, At(29.9; atol=0.2)) == 20
+            @test at(startrevfwd, At(29.9; atol=0.2)) == 1
+            @test at(startfwdrev, At(29.9; atol=0.2)) == 1
+            @test at(startrevrev, At(29.9; atol=0.2)) == 20
+            @test at(startfwdfwd, At(30.1; atol=0.2)) == 20
+            @test at(startrevfwd, At(30.1; atol=0.2)) == 1
+            @test at(startfwdrev, At(30.1; atol=0.2)) == 1
+            @test at(startrevrev, At(30.1; atol=0.2)) == 20
         end
 
         @testset "Start between" begin
@@ -850,3 +850,23 @@ end
 end
 
 
+
+@testset "hasselection" begin
+    @test hasselection(A, X(At(20)))
+    @test hasselection(dims(A, X), X(At(20)))
+    @test hasselection(dims(A, X), At(19; atol=2))
+    @test hasselection(A, (Y(At(7)),))
+    @test hasselection(A, (X(At(10)), Y(At(7))))
+
+    startfwdfwd = Ti(11.0:30.0;      mode=Sampled(Ordered(ForwardIndex(),ForwardArray(),ForwardRelation()), Regular(1), Intervals(Start())))
+    startfwdrev = Ti(11.0:30.0;      mode=Sampled(Ordered(ForwardIndex(),ForwardArray(),ReverseRelation()), Regular(1), Intervals(Start())))
+    startrevfwd = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ForwardRelation()), Regular(-1), Intervals(Start())))
+    startrevrev = Ti(30.0:-1.0:11.0; mode=Sampled(Ordered(ReverseIndex(),ForwardArray(),ReverseRelation()), Regular(-1), Intervals(Start())))
+
+    cases = (startfwdfwd, startrevfwd, startfwdrev, startrevrev)
+    @test all(map(d -> hasselection(d, At(30.0)), cases))
+    @test all(map(d -> !hasselection(d, At(31.0)), cases))
+    @test all(map(d -> hasselection(d, Contains(12.8)), cases))
+    @test all(map(d -> !hasselection(d, Contains(400.0)), cases))
+    @test all(map(d -> hasselection(d, Near(0.0)), cases))
+end


### PR DESCRIPTION
Adds `DimKeys` which is like `DimIndices` but holds `Dim(At(keyvalue))` instead of `Dim(i)`.

Useful for broadcasting with selectors.