### PR TITLE
Constructor w/ AxisKeys/AxisArrays syntax

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1,5 +1,5 @@
 """
-    AbstracDimArray <: AbstractArray
+    AbstractDimArray <: AbstractArray
 
 Abstract supertype for all "dim" arrays.
 
@@ -38,7 +38,7 @@ metadata(A::AbstractDimArray) = A.metadata
     rebuild(A::AbstractDimArray, data, [dims, refdims, name, metadata]) => AbstractDimArray
     rebuild(A::AbstractDimArray; kw...) => AbstractDimArray
 
-Rebuild and `AbstractDimArray` with some field changes. All types
+Rebuild an `AbstractDimArray` with some field changes. All types
 that inherit from `AbstractDimArray` must define this method if they
 have any additional fields or alternate field order.
 
@@ -161,7 +161,7 @@ moves dimensions to reference dimension `refdims` after reducing operations
 ## Arguments/Fields
 
 - `data`: An `AbstractArray`.
-- `dims`: A `Tuple` or `NamedTuple` of `Dimension`s or a NamedTuple`
+- `dims`: A `Tuple` or `NamedTuple` of `Dimension` objects or indices for each dimension.
 - `name`: A string name for the array. Shows in plots and tables.
 - `refdims`: refence dimensions. Usually set programmatically to track past
     slices and reductions of dimension for labelling and reconstruction.

--- a/src/array.jl
+++ b/src/array.jl
@@ -150,6 +150,7 @@ end
 
     DimArray(data, dims, refdims, name)
     DimArray(data, dims::Tuple; refdims=(), name=NoName(), metadata=NoMetadata())
+    DimArray(data; refdims=(), name=NoName(), metadata=NoMetadata(), dims...)
 
 The main concrete subtype of [`AbstractDimArray`](@ref).
 
@@ -160,7 +161,7 @@ moves dimensions to reference dimension `refdims` after reducing operations
 ## Arguments/Fields
 
 - `data`: An `AbstractArray`.
-- `dims`: A `Tuple` of `Dimension`
+- `dims`: A `Tuple` or `NamedTuple` of `Dimension`s or a NamedTuple`
 - `name`: A string name for the array. Shows in plots and tables.
 - `refdims`: refence dimensions. Usually set programmatically to track past
     slices and reductions of dimension for labelling and reconstruction.
@@ -198,6 +199,13 @@ end
 # All keyword argument version
 function DimArray(; data, dims, refdims=(), name=NoName(), metadata=NoMetadata())
     DimArray(data, formatdims(data, dims), refdims, name, metadata)
+end
+# Constructors using keywords to specify dimension names
+function DimArray(data; refdims=(), name=NoName(), metadata=NoMetadata(), dims...)
+    DimArray(data, formatdims(data, NamedTuple(dims)), refdims, name, metadata)
+end
+function DimArray(; data, refdims=(), name=NoName(), metadata=NoMetadata(), dims...)
+    DimArray(data, formatdims(data, NamedTuple(dims)), refdims, name, metadata)
 end
 # Construct from another AbstractDimArray
 function DimArray(A::AbstractDimArray;


### PR DESCRIPTION
This PR adds a constructor that implements the same syntax as AxisKeys and AxisArrays, which should make switching over from those easier. By AxisKeys/AxisArrays syntax I mean:
`DimArray(data; dim_name = dim)`