### PR TITLE
generalise dimwise and rename to broadcast_dims

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,8 +48,8 @@ Utility methods for transforming DimensionalData objects:
 set
 rebuild
 modify
-dimwise
-dimwise!
+broadcast_dims
+broadcast_dims!
 reorder
 Base.cat
 Base.map

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -60,7 +60,7 @@ export dims, refdims, metadata, name, bounds
 export dimnum, hasdim, hasselection, otherdims
 
 # utils
-export set, rebuild, reorder, modify, dimwise, dimwise!
+export set, rebuild, reorder, modify, broadcast_dims, broadcast_dims!
 
 const DD = DimensionalData
 

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -162,6 +162,7 @@ end
 
 dims(dim::Union{Dimension,DimType,Val{<:Dimension}}) = dim
 dims(dims::DimTuple) = dims
+dims(::Tuple{}) = ()
 dims(x) = nothing
 dims(::Nothing) = error("No dims found")
 

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -250,6 +250,8 @@ Base.length(d::Dimension) = length(val(d))
 Base.ndims(d::Dimension) = 0
 Base.ndims(d::Dimension{<:AbstractArray}) = ndims(val(d))
 
+Base.size(dims::DimTuple) = map(length, dims)
+
 @inline Base.getindex(d::Dimension) = val(d)
 for f in (:getindex, :view, :dotview)
     @eval begin

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -467,6 +467,8 @@ function comparedims end
     return a
 end
 
+const DimTupleOrEmpty = Union{DimTuple,Tuple{}}
+
 """
     combinedims(xs; check=true)
 
@@ -475,13 +477,13 @@ Combine the dimensions of each object in `xs`, in the order they are found.
 function combinedims end
 # @inline combinedims(xs::Tuple) = combinedims(xs...)
 @inline combinedims(xs...; kw...) = combinedims(map(dims, xs)...; kw...)
-@inline combinedims(dt1::DimTuple; kw...) = dt1
-@inline combinedims(dt1::DimTuple, dt2::DimTuple, dimtuples::DimTuple...; kw...) =
+@inline combinedims(dt1::DimTupleOrEmpty; kw...) = dt1
+@inline combinedims(dt1::DimTupleOrEmpty, dt2::DimTupleOrEmpty, dimtuples::DimTupleOrEmpty...; kw...) =
     reduce((dt2, dimtuples...); init=dt1) do dims1, dims2
         _combinedims(dims1, dims2; kw...)
     end
 # Cant use `map` here, tuples may not be the same length
-@inline _combinedims(a::DimTuple, b::DimTuple; check=true, kw...) = begin
+@inline _combinedims(a::DimTupleOrEmpty, b::DimTupleOrEmpty; check=true, kw...) = begin
     if check # Check the matching dims are the same
         common = commondims(a, b)
         comparedims(dims(a, common), dims(b, common); kw...)

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -88,9 +88,9 @@ end
 Base.Array{T}(x::UndefInitializer, dims::DimTuple) where T = Array{T}(x, size(dims))
 
 # undef constructor for all AbstractDimArray 
-(::Type{A})(x::UndefInitializer, dims::Dimension...) where {A<:AbstractDimArray} = A(x, dims)
-function (::Type{A})(x::UndefInitializer, dims::DimTuple) where {A<:AbstractDimArray{T}} where T
-    basetypeof(A)(Array{T}(undef, size(dims)), dims)
+(::Type{A})(x::UndefInitializer, dims::Dimension...; kw...) where {A<:AbstractDimArray} = A(x, dims; kw...)
+function (::Type{A})(x::UndefInitializer, dims::DimTuple; kw...) where {A<:AbstractDimArray{T}} where T
+    basetypeof(A)(Array{T}(undef, size(dims)), dims; kw...)
 end
 
 # Dummy read methods that do nothing.

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -82,8 +82,11 @@ function Base.checkbounds(A::AbstractDimArray, dims::IDim...)
 end
 
 # undef constructor for Array, using dims 
-Base.Array{T}(x::UndefInitializer, dims::DimTuple) where T = Array{T}(x, dims...)
-Base.Array{T}(x::UndefInitializer, dims::Dimension...) where T = Array{T,length(dims)}(x, map(length, dims))
+function Base.Array{T}(x::UndefInitializer, d1::Dimension, dims::Dimension...) where T 
+    Base.Array{T}(x, (d1, dims...))
+end
+Base.Array{T}(x::UndefInitializer, dims::DimTuple) where T = Array{T}(x, size(dims))
+
 # undef constructor for all AbstractDimArray 
 (::Type{A})(x::UndefInitializer, dims::Dimension...) where {A<:AbstractDimArray} = A(x, dims)
 function (::Type{A})(x::UndefInitializer, dims::DimTuple) where {A<:AbstractDimArray{T}} where T

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -29,6 +29,7 @@ data(s::AbstractDimStack) = s.data
 dims(s::AbstractDimStack) = s.dims
 refdims(s::AbstractDimStack) = s.refdims
 metadata(s::AbstractDimStack) = s.metadata
+missingval(s::AbstractDimStack) = map(s, missingval)
 
 
 layerdims(s::AbstractDimStack) = s.layerdims
@@ -47,13 +48,21 @@ Base.:(==)(s1::AbstractDimStack, s2::AbstractDimStack) =
     data(s1) == data(s2) && dims(s1) == dims(s2) && layerdims(s1) == layerdims(s2)
 Base.length(s::AbstractDimStack) = length(keys(s))
 Base.size(s::AbstractDimStack) = map(length, dims(s))
-Base.size(A::AbstractDimStack, dims::DimOrDimType) = size(A, dimnum(A, dims))
-Base.size(A::AbstractDimStack, dims::Integer) = size(A)[dims]
+Base.size(s::AbstractDimStack, dims::DimOrDimType) = size(s, dimnum(s, dims))
+Base.size(s::AbstractDimStack, dims::Integer) = size(s)[dims]
 Base.axes(s::AbstractDimStack) = map(first ∘ axes, dims(s))
-Base.axes(A::AbstractDimStack, dims::DimOrDimType) = axes(A, dimnum(A, dims))
-Base.axes(A::AbstractDimStack, dims::Integer) = axes(A)[dims]
+Base.axes(s::AbstractDimStack, dims::DimOrDimType) = axes(s, dimnum(s, dims))
+Base.axes(s::AbstractDimStack, dims::Integer) = axes(s)[dims]
+Base.similar(s::AbstractDimStack) = map(similar, s) 
 Base.iterate(s::AbstractDimStack, args...) = iterate(layers(s), args...)
 Base.read(s::AbstractDimStack) = map(read, s)
+function Base.merge(stacks::AbstractDimStack...) 
+    rebuild_from_arrays(s1, merge(map(layers, stacks)...); refdims=())
+end
+function Base.merge(s1::AbstractDimStack, pairs) 
+    rebuild_from_arrays(s1, merge(layers(s1), pairs); refdims=())
+end
+
 
 function rebuild(
     s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s),
@@ -217,3 +226,4 @@ function DimStack(data::NamedTuple, dims::Tuple;
 end
 
 @noinline _stack_size_mismatch() = throw(ArgumentError("Arrays must have identical axes. For mixed dimensions, use DimArrays`"))
+

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -29,8 +29,6 @@ data(s::AbstractDimStack) = s.data
 dims(s::AbstractDimStack) = s.dims
 refdims(s::AbstractDimStack) = s.refdims
 metadata(s::AbstractDimStack) = s.metadata
-missingval(s::AbstractDimStack) = map(s, missingval)
-
 
 layerdims(s::AbstractDimStack) = s.layerdims
 layerdims(s::AbstractDimStack, key::Symbol) = dims(s, layerdims(s)[key])

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -53,14 +53,16 @@ Base.size(s::AbstractDimStack, dims::Integer) = size(s)[dims]
 Base.axes(s::AbstractDimStack) = map(first ∘ axes, dims(s))
 Base.axes(s::AbstractDimStack, dims::DimOrDimType) = axes(s, dimnum(s, dims))
 Base.axes(s::AbstractDimStack, dims::Integer) = axes(s)[dims]
-Base.similar(s::AbstractDimStack) = map(similar, s) 
+Base.similar(s::AbstractDimStack, args...) = map(A -> similar(A, args...), s)
+Base.eltype(s::AbstractDimStack, args...) = map(eltype, s)
 Base.iterate(s::AbstractDimStack, args...) = iterate(layers(s), args...)
 Base.read(s::AbstractDimStack) = map(read, s)
-function Base.merge(stacks::AbstractDimStack...) 
-    rebuild_from_arrays(s1, merge(map(layers, stacks)...); refdims=())
+Base.merge(s::AbstractDimStack) = s
+function Base.merge(s1::AbstractDimStack, s2::AbstractDimStack, stacks::AbstractDimStack...) 
+    rebuild_from_arrays(s1, merge(map(layers, (s1, s2, stacks...))...); refdims=())
 end
-function Base.merge(s1::AbstractDimStack, pairs) 
-    rebuild_from_arrays(s1, merge(layers(s1), pairs); refdims=())
+function Base.merge(s::AbstractDimStack, pairs) 
+    rebuild_from_arrays(s, merge(layers(s), pairs); refdims=())
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,7 +93,7 @@ sliced by the dimensions of `B`.
 function broadcast_dims(f, As::AbstractDimArray...)
     dims = combinedims(As...)
     T = Base.Broadcast.combine_eltypes(f, As)
-    dimwise!(f, similar(first(As), T, dims), As...)
+    broadcast_dims!(f, similar(first(As), T, dims), As...)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,14 +77,15 @@ function modify(f, index::AbstractArray)
 end
 
 """
-    brodadcast_dims(f, A::AbstractDimArray{T,N}, B::AbstractDimArray{T2,M}) => AbstractDimArray{T3,N}
+    brodadcast_dims(f, sources::AbstractDimArray...) => AbstractDimArray
 
-Dimension-wise application of function `f` to `A` and `B`.
+Broadcast function `f` over the `AbstractDimArray`s in `sources`, permuting and reshaping
+dimensions to match where required. The result will contain all the dimensions in 
+all passed in arrays in the order in which they are found.
 
 ## Arguments
 
-- `a`: `AbstractDimArray` to broacast from, along dimensions not in `b`.
-- `b`: `AbstractDimArray` to broadcast from all dimensions. Dimensions must be a subset of a.
+- `sources`: `AbstractDimArrays` to broadcast over with `f`.
 
 This is like broadcasting over every slice of `A` if it is
 sliced by the dimensions of `B`.
@@ -96,18 +97,18 @@ function broadcast_dims(f, As::AbstractDimArray...)
 end
 
 """
-    brodadcast_dims!(f, dest::AbstractDimArray{T1,N}, A::AbstractDimArray{T2,N}, B::AbstractDimArray) => dest
+    brodadcast_dims!(f, dest::AbstractDimArray, sources::AbstractDimArray...) => dest
 
-Dimension-wise application of function `f`.
+Broadcast function `f` over the `AbstractDimArray`s in `sources`, writing to `dest`. 
+`sources` are permuting and reshaping dimensions to match where required.
+
+The result will contain all the dimensions in all passed in arrays, in the order in
+which they are found.
 
 ## Arguments
 
-- `dest`: `AbstractDimArray` to update
-- `A`: `AbstractDimArray` to broacast from, along dimensions not in `b`.
-- `B`: `AbstractDimArray` to broadcast from all dimensions. Dimensions must be a subset of a.
-
-This is like broadcasting over every slice of `A` if it is
-sliced by the dimensions of `B`, and storing the value in `dest`.
+- `dest`: `AbstractDimArray` to update.
+- `sources`: `AbstractDimArrays` to broadcast over with `f`.
 """
 function broadcast_dims!(f, dest::AbstractDimArray{<:Any,N}, As::AbstractDimArray...) where {N}
     As = map(As) do A

--- a/test/array.jl
+++ b/test/array.jl
@@ -18,6 +18,14 @@ da = @test_nowarn DimArray(a, dimz; refdims=refdimz, name=:test, metadata=ameta)
 val(dims(da, 1)) |> typeof
 da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
 
+@testset "checkbounds" begin
+    @test checkbounds(Bool, da, X(2), Y(1)) == true
+    @test checkbounds(Bool, da, X(10), Y(1)) == false
+    checkbounds(da, X(2), Y(1))
+    @test_throws BoundsError checkbounds(da, X(10), Y(20))
+    @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
+end
+
 @testset "size and axes" begin
     row_dims = (1, Dim{:row}(), Dim{:row}, :row, dimz2[1])
     for dim in row_dims
@@ -284,6 +292,18 @@ end
     @test eltype(da) <: Bool
     @test all(==(false), da) 
     @test dims(da) == (Ti(Sampled(Date(2001):Year(1):Date(2004), ForwardOrdered(), Regular(Year(1)), Points(), NoMetadata())),)
+end
+
+@testset "undef Array constructor" begin
+    A = Array{Bool}(undef, dimz...)
+    @test eltype(A) === Bool
+    @test size(A) === size(da)
+    @test A isa Array
+    A = DimArray{Int}(undef, dimz...)
+    @test eltype(A) === Int
+    @test size(A) === size(da)
+    @test A isa DimArray
+    @test dims(A) === dims(da)
 end
 
 @testset "rand constructors" begin

--- a/test/array.jl
+++ b/test/array.jl
@@ -323,6 +323,11 @@ end
     da = rand(MersenneTwister(), Float32, X([:a, :b]), Y(3))
     @test size(da) == (2, 3)
     @test eltype(da) <: Float32
+    da = rand(MersenneTwister(), 1:2, X([:a, :b]), Y(3))
+    @test eltype(da) <: Int
+    @test size(da) == (2, 3)
+    @test maximum(da) in (1, 2)
+    @test minimum(da) in (1, 2)
 end
 
 @testset "OffsetArray" begin

--- a/test/array.jl
+++ b/test/array.jl
@@ -93,36 +93,66 @@ end
 end
 
 @testset "similar" begin
-    da_sim = similar(da2)
-    @test eltype(da_sim) == eltype(da2)
-    @test size(da_sim) == size(da2)
-    @test dims(da_sim) == dims(da2)
-    @test refdims(da_sim) == refdims(da2)
+    @testset "similar with no args" begin
+        da_sim = similar(da2)
+        @test eltype(da_sim) == eltype(da2)
+        @test size(da_sim) == size(da2)
+        @test dims(da_sim) == dims(da2)
+        @test refdims(da_sim) == refdims(da2)
+    end
 
-    da_float = similar(da2, Float64)
-    @test eltype(da_float) == Float64
-    @test size(da_float) == size(da2)
-    @test dims(da_float) == dims(da2)
-    @test refdims(da_float) == refdims(da2)
+    @testset "similar with a type" begin
+        da_float = similar(da2, Float64)
+        @test eltype(da_float) == Float64
+        @test size(da_float) == size(da2)
+        @test dims(da_float) == dims(da2)
+        @test refdims(da_float) == refdims(da2)
+    end
 
-    # Changing the axis size removes dims.
-    # TODO we can keep dims, but with NoLookup?
-    da_size_float = similar(da2, Float64, (10, 10))
-    @test eltype(da_size_float) == Float64
-    @test size(da_size_float) == (10, 10)
-    @test typeof(da_size_float) <: Array{Float64,2}
-    da_size_float_splat = similar(da2, Float64, 10, 10)
-    @test size(da_size_float_splat) == (10, 10)
-    @test typeof(da_size_float_splat)  <: Array{Float64,2}
+    @testset "similar with a size" begin
+        # Changing the axis size removes dims.
+        # TODO we can keep dims, but with NoLookup?
+        da_size = similar(da2, (5, 5))
+        @test eltype(da_size) == Int
+        @test size(da_size) == (5, 5)
+        da_size_splat = similar(da2, 5, 5)
+        @test eltype(da_size_splat) == Int
+        @test size(da_size_splat) == (5, 5)
+        da_size_float = similar(da2, Float64, (10, 10))
+        @test eltype(da_size_float) == Float64
+        @test size(da_size_float) == (10, 10)
+        @test typeof(da_size_float) <: Array{Float64,2}
+        da_size_float_splat = similar(da2, Float64, 10, 10)
+        @test size(da_size_float_splat) == (10, 10)
+        @test typeof(da_size_float_splat)  <: Array{Float64,2}
+    end
 
-    sda = DimArray(sprand(Float64, 10, 10, 0.5), (X, Y))
-    sparse_size_int = similar(sda, Int64, (5, 5))
-    @test eltype(sparse_size_int) == Int64 != eltype(sda)
-    @test size(sparse_size_int) == (5, 5)
-    @test sparse_size_int isa SparseMatrixCSC
+    @testset "similar with sparse arrays" begin
+        sda = DimArray(sprand(Float64, 10, 10, 0.5), (X, Y))
+        sparse_size_int = similar(sda, Int64, (5, 5))
+        @test eltype(sparse_size_int) == Int64 != eltype(sda)
+        @test size(sparse_size_int) == (5, 5)
+        @test sparse_size_int isa SparseMatrixCSC
+    end
 
-    @test dims(da_float) == dims(da2)
-    @test refdims(da_float) == refdims(da2)
+    @testset "similar with dims" begin
+        da_sim_dims = similar(da2, dims(da))
+        da_sim_dims_splat = similar(da2, dims(da))
+        for A in (da_sim_dims, da_sim_dims_splat)
+            @test eltype(A) == eltype(da2)
+            @test size(A) == size(da)
+            @test dims(A) == dims(da)
+            @test refdims(A) == ()
+        end
+        da_sim_type_dims = similar(da2, Bool, dims(da))
+        da_sim_type_dims_splat = similar(da2, Bool, dims(da)...)
+        for A in (da_sim_type_dims, da_sim_type_dims_splat)
+            @test eltype(A) == Bool
+            @test size(A) == size(da)
+            @test dims(A) == dims(da)
+            @test refdims(A) == ()
+        end
+    end
 end
 
 @testset "replace" begin

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -40,6 +40,7 @@ end
 @testset "low level base methods" begin
     @test keys(data(s)) == (:one, :two, :three)
     @test keys(data(mixed)) == (:one, :two, :extradim)
+    @test eltype(mixed) === (one=Float64, two=Float32, extradim=Float64)
     @test haskey(s, :one) == true
     @test haskey(s, :zero) == false
     @test length(s) == 3 # length is as for NamedTuple
@@ -49,8 +50,26 @@ end
     @test axes(mixed) === (Base.OneTo(2), Base.OneTo(3), Base.OneTo(4))
     @test axes(mixed, X) === Base.OneTo(2)
     @test axes(mixed, 2) === Base.OneTo(3)
-    @test first(s) == da1
+    @test first(s) == da1 # first/last are for the NamedTuple
     @test last(s) == da3
+end
+
+@testset "similar" begin
+    @test all(map(similar(mixed), mixed) do s, m
+        dims(s) === dims(m) && eltype(s) === eltype(m)
+    end)
+    @test all(map(==(Int), eltype(similar(s, Int))))
+    st2 = similar(mixed, Bool, x, y)
+    @test dims(st2) === (x, y)
+    @test dims(st2[:one]) === (x, y)
+    @test all(map(==(Bool), eltype(st2)))
+end
+
+@testset "merge" begin
+    @test merge(mixed) === mixed
+    @test keys(merge(mixed, s)) == (:one, :two, :extradim, :three)
+    @test keys(merge(s, mixed)) == (:one, :two, :three, :extradim)
+    @test keys(merge(s, (:new=>da4,))) == (:one, :two, :three, :new)
 end
 
 @testset "copy and friends" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -106,28 +106,27 @@ end
     end
 end
 
-@testset "dimwise" begin
+@testset "broadcast_dims" begin
     A2 = [1 2 3; 4 5 6]
     B1 = [1, 2, 3]
     da2 = DimArray(A2, (X([20, 30]), Y([:a, :b, :c])))
     db1 = DimArray(B1, (Y([:a, :b, :c]),))
-    dc1 = dimwise(+, db1, db1)
+    dc1 = broadcast_dims(+, db1, db1)
     @test dc1 == [2, 4, 6]
-    dc2 = dimwise(+, da2, db1)
+    dc2 = broadcast_dims(+, da2, db1)
     @test dc2 == [2 4 6; 5 7 9]
-    dc4 = dimwise(+, da2, db1)
+    dc4 = broadcast_dims(+, da2, db1)
 
     A3 = cat([1 2 3; 4 5 6], [11 12 13; 14 15 16]; dims=3)
     da3 = DimArray(A3, (X, Y, Z))
     db2 = DimArray(A2, (X, Y))
-    dc3 = dimwise(+, da3, db2)
+    dc3 = broadcast_dims(+, da3, db2)
     @test dc3 == cat([2 4 6; 8 10 12], [12 14 16; 18 20 22]; dims=3)
-    dc3 = dimwise!(+, da3, da3, db2)
 
     A3 = cat([1 2 3; 4 5 6], [11 12 13; 14 15 16]; dims=3)
     da3 = DimArray(A3, (X([20, 30]), Y([:a, :b, :c]), Z(10:10:20)))
     db1 = DimArray(B1, (Y([:a, :b, :c]),))
-    dc3 = dimwise(+, da3, db1)
+    dc3 = broadcast_dims(+, da3, db1)
     @test dc3 == cat([2 4 6; 5 7 9], [12 14 16; 15 17 19]; dims=3)
 
     @testset "works with permuted dims" begin
@@ -136,6 +135,8 @@ end
         @test dc3p == cat([2 4 6; 8 10 12], [12 14 16; 18 20 22]; dims=3)
     end
 
+    @test_throws DimensionMismatch broadcast_dims!(+, db1, zeros(Z(3)))
+    @test broadcast_dims(+, db1, ones(Z(3))) == [2.0 2.0 2.0; 3.0 3.0 3.0; 4.0 4.0 4.0]
 end
 
 @testset "shiftlocus" begin


### PR DESCRIPTION
This should now allow broadcasting any `AbstractDimArray` to any others, regardless of dimension order - they are permuted and/or reshaped where required. Also renames to the hopefully more discoverable `broadcast_dims`

Closes #343 

@ParadaCarleton I think you were looking for this at one point?