### PR TITLE
Fix irregular slicespan

### DIFF
--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -471,23 +471,24 @@ function _slicespan(locus::Center, span::Irregular, l::LookupArray, i::StandardI
     last(i)  >= lastindex(l)  ? _maybeflipbounds(l, bounds(span))[2] : (l[last(i) + 1]  + l[last(i)]) / 2
 end
 # Have to special-case date/time so we work with seconds and add to the original
-function _slicespan(locus::Center, span::Irregular, l::LookupArray{<:Dates.AbstractTime}, i::StandardIndices)
+function _slicespan(locus::Center, span::Irregular, l::LookupArray{T}, i::StandardIndices) where T<:Dates.AbstractTime
+    op = T === Date ? div : /
     frst = if first(i) <= firstindex(l)
         _maybeflipbounds(l, bounds(span))[1]
     else
         if isrev(order(l))
-            (l[first(i)] - l[first(i) - 1]) / 2 + l[first(i) - 1]
+            op(l[first(i)] - l[first(i) - 1], 2) + l[first(i) - 1]
         else
-            (l[first(i) - 1] - l[first(i)]) / 2 + l[first(i)] 
+            op(l[first(i) - 1] - l[first(i)], 2) + l[first(i)] 
         end
     end
     lst = if last(i) >= lastindex(l)
         _maybeflipbounds(l, bounds(span))[2]
     else
         if isrev(order(l))
-            (l[last(i)] - l[last(i) + 1]) / 2 + l[last(i) + 1]
+            op(l[last(i)] - l[last(i) + 1], 2) + l[last(i) + 1]
         else
-            (l[last(i) + 1] - l[last(i)]) / 2 + l[last(i)]
+            op(l[last(i) + 1] - l[last(i)], 2) + l[last(i)]
         end
     end
     return (frst, lst)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -331,18 +331,19 @@ end
     end
 end
 
-@testset "indexing irregular" begin
+@testset "indexing irregular with bounds slice" begin
     total_time = 5
-    t1 = Ti([mod1(i, 12) for i in 1:total_time]) # centurial averages with seasonal cycle
-    t2 = Ti([Date(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]) # centurial averages with seasonal cycle
-    t3 = Ti([DateTime(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]) # centurial averages with seasonal cycle
+    t1 = Ti([mod1(i, 12) for i in 1:total_time]; sampling=Intervals()) # centurial averages with seasonal cycle
+    t2 = Ti([Date(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]; sampling=Intervals()) # centurial averages with seasonal cycle
+    t3 = Ti([DateTime(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]; sampling=Intervals()) # centurial averages with seasonal cycle
+    t4 = Ti([DateTime(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]; sampling=Points()) # centurial averages with seasonal cycle
 
     p = reshape([1, 2, 3, 4, 5], 1, 1, 5)
     A1 = DimArray(p, (X, Y, t1))
     A2 = DimArray(p, (X, Y, t2))
     A3 = DimArray(p, (X, Y, t3))
 
-    @test view(A1, Ti(5)) == 5
-    @test view(A2, Ti(5)) == 5
-    @test view(A3, Ti(5)) == 5
+    @test view(A1, Ti(5)) == [5;;]
+    @test view(A2, Ti(5)) == [5;;]
+    @test view(A3, Ti(5)) == [5;;]
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,4 +1,4 @@
-using DimensionalData, Test, BenchmarkTools
+using DimensionalData, Test, BenchmarkTools, Dates, Statistics
 using DimensionalData.LookupArrays, DimensionalData.Dimensions
 
 @testset "dims2indices" begin
@@ -329,4 +329,20 @@ end
         @test s_set[2, 2] === (one=9.0, two=10.0f0, three=11)
         @test_throws ArgumentError s_set[CartesianIndex(2, 2)] = (seven=5, two=6, three=7)
     end
+end
+
+@testset "indexing irregular" begin
+    total_time = 5
+    t1 = Ti([mod1(i, 12) for i in 1:total_time]) # centurial averages with seasonal cycle
+    t2 = Ti([Date(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]) # centurial averages with seasonal cycle
+    t3 = Ti([DateTime(-26000 + ((i-1)÷12)*100, mod1(i, 12), 1) for i in 1:total_time]) # centurial averages with seasonal cycle
+
+    p = reshape([1, 2, 3, 4, 5], 1, 1, 5)
+    A1 = DimArray(p, (X, Y, t1))
+    A2 = DimArray(p, (X, Y, t2))
+    A3 = DimArray(p, (X, Y, t3))
+
+    @test view(A1, Ti(5)) == 5
+    @test view(A2, Ti(5)) == 5
+    @test view(A3, Ti(5)) == 5
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -327,33 +327,61 @@ end
 end
 
 @testset "slicedims" begin
-    @testset "Regular" begin
+    @testset "Regular Points" begin
+        da = DimArray(a, (X(143:2:145), Y(-20:-1:-22)))
+        dimz = dims(da)
         @test slicedims(dimz, (1:2, 3)) == slicedims(dimz, 1:2, 3) == slicedims(dimz, (), (1:2, 3)) ==
             ((X(Sampled(143:2:145, ForwardOrdered(), Regular(2), Points(), NoMetadata())),),
-             (Y(Sampled(-36:-36, ForwardOrdered(), Regular(1), Points(), NoMetadata())),))
+             (Y(Sampled(-22:-1:-22, ReverseOrdered(), Regular(1), Points(), NoMetadata())),))
         @test slicedims(dimz, (Z(),), (1:2, 3)) == slicedims(dimz, (Z(),), 1:2, 3) ==
             ((X(Sampled(143:2:145, ForwardOrdered(), Regular(2), Points(), NoMetadata())),),
-             (Z(), Y(Sampled(-36:-36, ForwardOrdered(), Regular(1), Points(), NoMetadata())),))
+             (Z(), Y(Sampled(-22:-1:-22, ReverseOrdered(), Regular(1), Points(), NoMetadata())),))
         @test slicedims(dimz, 2:2, :) == slicedims(dimz, (), 2:2, :) ==
             ((X(Sampled(145:2:145, ForwardOrdered(), Regular(2), Points(), NoMetadata())),
-              Y(Sampled(-38:-36, ForwardOrdered(), Regular(1), Points(), NoMetadata()))), ())
+              Y(Sampled(-20:-1:-22, ReverseOrdered(), Regular(1), Points(), NoMetadata()))), ())
         @test slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) ==
               slicedims((), 1:2, 3) == slicedims((), (), 1:2, 3) == ((), ())
         @test slicedims(dimz, CartesianIndex(2, 3)) ==
             ((), (X(Sampled(145:2:145, ForwardOrdered(), Regular(2), Points(), NoMetadata())),
-                  Y(Sampled(-36:-36, ForwardOrdered(), Regular(1), Points(), NoMetadata()))),)
+                  Y(Sampled(-22:-1:-22, ReverseOrdered(), Regular(1), Points(), NoMetadata()))),)
     end
 
-    @testset "Irregular" begin
+    @testset "Regular Intervals" begin
+        irreg = DimArray(a, (X(Sampled([140.0, 142.0], ForwardOrdered(), Regular(2.0), Intervals(Start()), NoMetadata())),
+                             Y(Sampled([30.0, 20.0, 10.0], ReverseOrdered(), Regular(-10.0), Intervals(Center()), NoMetadata())), ))
+        irreg_dimz = dims(irreg)
+        @test slicedims(irreg, (1:2, 3)) == slicedims(irreg, 1:2, 3) ==
+            ((X(Sampled([140.0, 142.0], ForwardOrdered(), Regular(2.0), Intervals(Start()), NoMetadata())),),
+                 (Y(Sampled([10.0], ReverseOrdered(), Regular(-10.0), Intervals(Center()), NoMetadata())),))
+        @test slicedims(irreg, (2:2, 1:2)) == slicedims(irreg, 2:2, 1:2) ==
+            ((X(Sampled([142.0], ForwardOrdered(), Regular(2.0), Intervals(Start()), NoMetadata())),
+              Y(Sampled([30.0, 20.0], ReverseOrdered(), Regular(-10.0), Intervals(Center()), NoMetadata()))), ())
+        @test slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ())
+    end
+
+    @testset "Irregular Points" begin
+        irreg = DimArray(a, (X(Sampled([140.0, 142.0], ForwardOrdered(), Irregular(), Points(), NoMetadata())),
+                             Y(Sampled([40.0, 20.0, 10.0], ReverseOrdered(), Irregular(), Points(), NoMetadata())), ))
+        irreg_dimz = dims(irreg)
+        @test slicedims(irreg, (1:2, 3)) == slicedims(irreg, 1:2, 3) ==
+        ((X(Sampled([140.0, 142.0], ForwardOrdered(), Irregular(nothing, nothing), Points(), NoMetadata())),),
+         (Y(Sampled([10.0], ReverseOrdered(), Irregular(nothing, nothing), Points(), NoMetadata())),))
+        @test slicedims(irreg, (2:2, 1:2)) == slicedims(irreg, 2:2, 1:2) ==
+        ((X(Sampled([142.0], ForwardOrdered(), Irregular(nothing, nothing), Points(), NoMetadata())),
+          Y(Sampled([40.0, 20.0], ReverseOrdered(), Irregular(nothing, nothing), Points(), NoMetadata()))), ())
+        @test slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ())
+    end
+
+    @testset "Irregular Intervals" begin
         irreg = DimArray(a, (X(Sampled([140.0, 142.0], ForwardOrdered(), Irregular(140.0, 144.0), Intervals(Start()), NoMetadata())),
-                             Y(Sampled([10.0, 20.0, 40.0], ForwardOrdered(), Irregular(0.0, 60.0), Intervals(Center()), NoMetadata())), ))
+                             Y(Sampled([40.0, 20.0, 10.0], ReverseOrdered(), Irregular(0.0, 60.0), Intervals(Center()), NoMetadata())), ))
         irreg_dimz = dims(irreg)
         @test slicedims(irreg, (1:2, 3)) == slicedims(irreg, 1:2, 3) ==
             ((X(Sampled([140.0, 142.0], ForwardOrdered(), Irregular(140.0, 144.0), Intervals(Start()), NoMetadata())),),
-                 (Y(Sampled([40.0], ForwardOrdered(), Irregular(30.0, 60.0), Intervals(Center()), NoMetadata())),))
+                 (Y(Sampled([10.0], ReverseOrdered(), Irregular(30.0, 60.0), Intervals(Center()), NoMetadata())),))
         @test slicedims(irreg, (2:2, 1:2)) == slicedims(irreg, 2:2, 1:2) ==
             ((X(Sampled([142.0], ForwardOrdered(), Irregular(142.0, 144.0), Intervals(Start()), NoMetadata())),
-              Y(Sampled([10.0, 20.0], ForwardOrdered(), Irregular(0.0, 30.0), Intervals(Center()), NoMetadata()))), ())
+              Y(Sampled([40.0, 20.0], ReverseOrdered(), Irregular(0.0, 30.0), Intervals(Center()), NoMetadata()))), ())
         @test slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ())
     end
 


### PR DESCRIPTION
Fixes errors with slicing bounds for `Intervals` and `Dates`, and bypasses this completely for `Points`.

closes #361