### PR TITLE
add constructors and `map` for NamedTuple and stacks

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -87,6 +87,12 @@ function Base.Array{T}(x::UndefInitializer, d1::Dimension, dims::Dimension...) w
 end
 Base.Array{T}(x::UndefInitializer, dims::DimTuple; kw...) where T = Array{T}(x, size(dims))
 
+function Base.NamedTuple(A1::AbstractDimArray, As::AbstractDimArray...) 
+    arrays = (A1, As...)
+    keys = map(Symbol ∘ name, arrays)
+    NamedTuple{keys}(arrays)
+end
+
 # undef constructor for all AbstractDimArray 
 (::Type{A})(x::UndefInitializer, dims::Dimension...; kw...) where {A<:AbstractDimArray} = A(x, dims; kw...)
 function (::Type{A})(x::UndefInitializer, dims::DimTuple; kw...) where {A<:AbstractDimArray{T}} where T

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -47,7 +47,8 @@ Apply function `f` to each layer of the `stacks`.
 If `f` returns `DimArray`s the result will be another `DimStack`.
 Other values will be returned in a `NamedTuple`.
 """
-Base.map(f, s::AbstractDimStack...) = _maybestack(s[1], map(f, map(layers, s)...))
+Base.map(f, s::AbstractDimStack...) = _maybestack(s[1], map(f, map(NamedTuple, s)...))
+Base.map(f, s::Union{AbstractDimStack,NamedTuple}...) = _maybestack(_firststack(s...), map(f, map(NamedTuple, s)...))
 
 _maybestack(s::AbstractDimStack, x::NamedTuple) = x
 function _maybestack(
@@ -55,6 +56,10 @@ function _maybestack(
 ) where K
     rebuild_from_arrays(s, das)
 end
+
+_firststack(s::AbstractDimStack, args...) = s
+_firststack(arg1, args...) = _firststack(args...) 
+_firststack() = nothing
 
 """
     Base.cat(stacks::AbstractDimStack...; [keys=keys(stacks[1])], dims)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -62,6 +62,7 @@ end
 function Base.merge(s::AbstractDimStack, pairs) 
     rebuild_from_arrays(s, merge(layers(s), pairs); refdims=())
 end
+Base.NamedTuple(s::AbstractDimStack) = layers(s)
 
 
 function rebuild(

--- a/test/array.jl
+++ b/test/array.jl
@@ -357,6 +357,13 @@ end
     end
 end
 
+@testset "NamedTuple" begin
+    @test NamedTuple(da) == (; test=da)
+    @test NamedTuple(da, da2) == (; test=da, test2=da2)
+    da3 = DimArray(a2, dimz2; refdims=refdimz, name=DimensionalData.Name(:test3))
+    @test NamedTuple(da, da3) == (; test=da, test3=da3)
+end
+
 @testset "ArrayInterface" begin
     @test ArrayInterface.parent_type(da) == Matrix{Int}
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -123,6 +123,7 @@ end
     @test values(map(a -> a .* 2, s)) == values(DimStack(2da1, 2da2, 2da3))
     @test map(+, s, s, s) == map(a -> a .* 3, s)
     @test_throws ArgumentError map(+, s, mixed)
+    @test map((s, a) -> s => a[1], (one="one", two="two", three="three"), s) == (one="one" => 1.0, two="two" => 2.0, three="three" => 3.0)
 end
 
 @testset "methods with no arguments" begin

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -57,6 +57,7 @@ end
     @test axes(mixed, 2) === Base.OneTo(3)
     @test first(s) == da1 # first/last are for the NamedTuple
     @test last(s) == da3
+    @test NamedTuple(s) == (one=da1, two=da2, three=da3)
 end
 
 @testset "similar" begin


### PR DESCRIPTION
As we already have names for arrays and stack layers, this PR lets you do:

```julia
NameTuple(stack)
NamedTuple(da1, da2, da3)
```

As a quick/obvious way to get a `NamedTuple` of `AbstractDimArray` from a `DimStack` or `DimArray` args. `map` will also work over any mix of `NamedTuple` and `AbstractDimStack` if the names are the same.