### PR TITLE
Performance tweaks

### DIFF
--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -113,7 +113,7 @@ _unwrapdim(x) = x
     LookupArrays.selectindices(val(dim), val(seldim))
 
 function _extent_as_selectors(extent::Extents.Extent{Keys}) where Keys
-    map(Keys, values(extent)) do k, v
-        rebuild(key2dim(k), LookupArrays.Interval(v...))
+    map(map(key2dim, Keys), values(extent)) do k, v
+        rebuild(k, LookupArrays.Interval(v...))
     end    
 end

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -388,7 +388,7 @@ function slicedims end
 
 @inline function _slicedims(f, dims::Tuple, refdims::Tuple, I::Tuple)
     # Unnaligned may need grouped slicing
-    newdims, newrefdims = if any(d -> lookup(d) isa Unaligned, dims)
+    newdims, newrefdims = if any(map(d -> lookup(d) isa Unaligned, dims))
         # Separate out unalligned dims
         udims = _unalligned_dims(dims)
         odims = otherdims(dims, udims)
@@ -403,6 +403,7 @@ function slicedims end
     end
     return newdims, (refdims..., newrefdims...)
 end
+
 @inline _slicedims(f, dims::Tuple, refdims::Tuple, I::Tuple{}) = dims, refdims
 @inline _slicedims(f, dims::DimTuple, I::Tuple{}) = dims, ()
 @inline _slicedims(f, dims::DimTuple, I::Tuple) = begin

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -213,7 +213,9 @@ function Base._cat(catdims::Tuple, Xin::AbstractDimArray...)
     cat_dnums = (inserted_dnums..., appended_dnums...)
 
     newrefdims = otherdims(refdims(A1), newcatdims)
-    newA = Base._cat(cat_dnums, map(data, Xin)...)
+    T = Base.promote_eltypeof(Xin...)
+    data = map(parent, Xin)
+    newA = Base._cat_t(cat_dnums, T, data...)
     rebuild(A1, newA, format(newdims, newA), newrefdims)
 end
 function Base._cat(catdim::DimType, Xin::AbstractDimArray...)


### PR DESCRIPTION
A few performance tweaks from profiling.
- single argument map is better over constant prop
- `any` is awful over tuples, `any(map(...` is better
- `_cat` stopped inferring. `_cat_t` infers.