### PR TITLE
Show lookup labels with AbstractDimArray

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -38,9 +38,10 @@ A = DimArray(zeros(3, 5, 12), (y, x, ti))
   X Sampled 2:2:10 ForwardOrdered Regular Points,
   Ti Sampled DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") ForwardOrdered Regular Points
 [:, :, 1]
- 0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0
+       2    4    6    8    10
+  'a'  0.0  0.0  0.0  0.0   0.0
+  'b'  0.0  0.0  0.0  0.0   0.0
+  'c'  0.0  0.0  0.0  0.0   0.0
 [and 11 more slices...]
 ```
 
@@ -57,18 +58,18 @@ x = A[X(2), Y(3)]
 and reference dimensions:
   Y Categorical Char[c] ForwardOrdered,
   X Sampled 4:2:4 ForwardOrdered Regular Points
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
+ 2021-01-01T00:00:00  0.0
+ 2021-02-01T00:00:00  0.0
+ 2021-03-01T00:00:00  0.0
+ 2021-04-01T00:00:00  0.0
+ 2021-05-01T00:00:00  0.0
+ 2021-06-01T00:00:00  0.0
+ 2021-07-01T00:00:00  0.0
+ 2021-08-01T00:00:00  0.0
+ 2021-09-01T00:00:00  0.0
+ 2021-10-01T00:00:00  0.0
+ 2021-11-01T00:00:00  0.0
+ 2021-12-01T00:00:00  0.0
 ```
 
 A `Dimension` can also wrap [`Selector`](@ref).
@@ -83,7 +84,8 @@ x = A[X(Between(3, 4)), Y(At('b'))]
   Ti Sampled DateTime("2021-01-01T00:00:00"):Month(1):DateTime("2021-12-01T00:00:00") ForwardOrdered Regular Points
 and reference dimensions:
   Y Categorical Char[b] ForwardOrdered
- 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+     2021-01-01T00:00:00  …   2021-12-01T00:00:00
+ 4  0.0                                  0.0
 ```
 
 `Dimension` objects may have [`lookup`](@ref) and [`metadata`](@ref) fields

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -255,11 +255,12 @@ A = ones(x, y)
 5×4 DimArray{Float64,2} with dimensions:
   X Sampled 100:-20:20 ReverseOrdered Regular Intervals,
   Y Sampled Int64[1, 4, 7, 10] ForwardOrdered Regular Intervals
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0
+      1    4    7    10
+ 100  1.0  1.0  1.0   1.0
+  80  1.0  1.0  1.0   1.0
+  60  1.0  1.0  1.0   1.0
+  40  1.0  1.0  1.0   1.0
+  20  1.0  1.0  1.0   1.0
 ```
 """
 struct Sampled{T,A<:AbstractVector{T},O,Sp,Sa,M} <: AbstractSampled{T,O,Sp,Sa}

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -403,7 +403,8 @@ A[X(Between(15, 25)), Y(Between(4, 6.5))]
 1×2 DimArray{Int64,2} with dimensions:
   X Sampled 20:10:20 ForwardOrdered Regular Points,
   Y Sampled 5:6 ForwardOrdered Regular Points
- 4  5
+     5  6
+ 20  4  5
 ```
 """
 struct Between{T<:Union{<:AbstractVector{<:Tuple{Any,Any}},Tuple{Any,Any},Nothing}} <: ArraySelector{T}
@@ -643,7 +644,8 @@ A[X(Where(x -> x > 15)), Y(Where(x -> x in (19, 21)))]
 1×2 DimArray{Int64,2} with dimensions:
   X Sampled Int64[20] ForwardOrdered Regular Points,
   Y Sampled Int64[19, 21] ForwardOrdered Regular Points
- 4  6
+     19  21
+ 20   4   6
 ```
 """
 struct Where{T} <: ArraySelector{T}
@@ -679,8 +681,9 @@ A[X=All(At(10.0), At(50.0)), Ti=All(1u"s"..10u"s", 90u"s"..100u"s")]
 2×4 DimArray{Int64,2} with dimensions:
   X Sampled Float64[10.0, 50.0] ForwardOrdered Regular Points,
   Ti Sampled Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}[1 s, 6 s, 91 s, 96 s] ForwardOrdered Regular Points
- 1  2  19  20
- 3  6  57  60
+       1 s  6 s  91 s  96 s
+ 10.0    1    2    19    20
+ 50.0    3    6    57    60
 ```
 """
 struct All{S<:Tuple{Vararg{<:SelectorOrInterval}}} <: Selector{S}

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -79,10 +79,10 @@ function Base.print_matrix(io::IO, A::AbstractDimArray)
         f1, f2 = firstindex(A, 1), firstindex(A, 2)
         l1, l2 = lastindex(A, 1), lastindex(A, 2)
         s1, s2 = size(A)
-        itop    = s1 < h  ? (f1:l1)     : (f1:((h ÷ 2)) + f1 - 1)
-        ibottom = s1 < h  ? (f1:f1 - 1) : s1 - (h ÷ 2) + f1 - 1:s1 + f1 - 1
-        ileft   = s2 < wn ? (f2:l2)     : (f2:(wn ÷ 2)) + f2 - 1
-        iright  = s2 < wn ? (f2:f2 - 1) : s2 - (wn ÷ 2) + f2:s2 + f2 - 1
+        itop    = s1 < h  ? (f1:l1)     : (f1:h ÷ 2 + f1 - 1)
+        ibottom = s1 < h  ? (f1:f1 - 1) : (s1 - h ÷ 2 + f1 - 1:s1 + f1 - 1)
+        ileft   = s2 < wn ? (f2:l2)     : (f2:wn ÷ 2 + f2 - 1)
+        iright  = s2 < wn ? (f2:f2 - 1) : (s2 - wn ÷ 2 + f2:s2 + f2 - 1)
 
         topleft = collect(A[itop, ileft])
         bottomleft = collect(A[ibottom, ileft])

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -30,27 +30,27 @@ end
 # Semi-interface methods for adding addional `show` text
 # for AbstractDimArray/AbstractDimStack subtypes
 # TODO actually document in the interface
-show_after(io::IO, mime, A::AbstractDimArray) = print_array(io, mime, parent(A))
+show_after(io::IO, mime, A::AbstractDimArray) = print_array(io, mime, A)
 
 # Showing the array is optional for AbstractDimArray
 # `print_array` must be called from `show_after`.
-function print_array(io::IO, mime, A::AbstractArray{T,0}) where T
+function print_array(io::IO, mime, A::AbstractDimArray{T,0}) where T
     print(_print_array_ctx(io, T), "\n", A[])
 end
-function print_array(io::IO, mime, A::AbstractArray{T,1}) where T
+function print_array(io::IO, mime, A::AbstractDimArray{T,1}) where T
     Base.print_matrix(_print_array_ctx(io, T), A)
 end
-function print_array(io::IO, mime, A::AbstractArray{T,2}) where T
+function print_array(io::IO, mime, A::AbstractDimArray{T,2}) where T
     Base.print_matrix(_print_array_ctx(io, T), A)
 end
-function print_array(io::IO, mime, A::AbstractArray{T,N}) where {T,N}
-    o = ones(Int, N-2)
-    frame = A[:, :, o...]
+function print_array(io::IO, mime, A::AbstractDimArray{T,N}) where {T,N}
+    o = ntuple(x -> 1, N-2)
+    frame = view(A, :, :, o...)
     onestring = join(o, ", ")
     println(io, "[:, :, $(onestring)]")
     Base.print_matrix(_print_array_ctx(io, T), frame)
     nremaining = prod(size(A, d) for d=3:N) - 1
-    nremaining > 0 && print(io, "\n[and ", nremaining," more slices...]")
+    nremaining > 0 && printstyled(io, "\n[and ", nremaining," more slices...]"; color=:light_black)
 end
 
 function _print_array_ctx(io, T)
@@ -63,3 +63,63 @@ function print_name(io::IO, name)
     end
 end
 
+# Labelled matrix printing is modified from AxisKeys.jl, thanks @mcabbot
+function Base.print_matrix(io::IO, A::AbstractDimArray)
+    h, w = displaysize(io)
+    wn = w ÷ 3 # integers take 3 columns each when printed, floats more
+
+    A_dims = if ndims(A) == 1
+        itop =    size(A,1) < h ? (firstindex(A,1):lastindex(A,1)) : (1:(h÷2))
+        ibottom = size(A,1) < h ? (1:0)                            : size(A,1)-(h÷2):size(A,1)
+        labels = vcat(ShowWith.(lookup(A, 1)[itop]), ShowWith.(lookup(A, 1))[ibottom])
+        vals = vcat(parent(A)[itop], parent(A)[ibottom])
+        hcat(labels, vals)
+    else
+        itop    = size(A, 1) < h  ? (firstindex(A,1):lastindex(A,1)) : (1:(h÷2))
+        ibottom = size(A, 1) < h  ? (1:0)                            : size(A,1)-(h÷2):size(A,1)
+        ileft   = size(A, 2) < wn ? (firstindex(A,2):lastindex(A,2)) : (1:(wn÷2))
+        iright  = size(A, 2) < wn ? (1:0)                            : size(A,2)-(wn÷2)+1:size(A,2)
+
+        topleft = collect(A[itop, ileft])
+        bottomleft = collect(A[ibottom, ileft])
+        if !(lookup(A, 1) isa NoLookup)
+            topleft = hcat(ShowWith.(lookup(A,1)[itop]), topleft)
+            bottomleft = hcat(ShowWith.(lookup(A, 1)[ibottom]), bottomleft)
+        end
+
+        leftblock = vcat(topleft, bottomleft)
+        rightblock = vcat(collect(A[itop, iright]), collect(A[ibottom, iright]))
+        bottomblock = hcat(leftblock, rightblock)
+
+        if lookup(A, 2) isa NoLookup
+            bottomblock
+        else
+            toplabels = ShowWith.(dims(A, 2))[ileft], ShowWith.(dims(A, 2))[iright]
+            toprow = if lookup(A, 1) isa NoLookup
+                vcat(toplabels...)
+            else
+                vcat(ShowWith(0, hide=true), toplabels...)
+            end |> permutedims
+            vcat(toprow, bottomblock)
+        end
+    end
+    Base.print_matrix(io, A_dims)
+end
+
+struct ShowWith{T,NT} <: AbstractString
+    val::T
+    hide::Bool
+    nt::NT
+    function ShowWith(val; hide::Bool=false, kw...)
+        new{typeof(val),typeof(values(kw))}(val, hide, values(kw))
+    end
+end
+function Base.show(io::IO, x::ShowWith; kw...)
+    s = sprint(show, x.val; context=io, kw...)
+    s1 = x.hide ? " "^length(s) : s
+    printstyled(io, s1; color=:light_black, x.nt...)
+end
+Base.alignment(io::IO, x::ShowWith) = Base.alignment(io, x.val)
+Base.length(x::ShowWith) = length(string(x.val))
+Base.ncodeunits(x::ShowWith) = ncodeunits(string(x.val))
+Base.print(io::IO, x::ShowWith) = printstyled(io, string(x.val); x.nt...)

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -69,16 +69,20 @@ function Base.print_matrix(io::IO, A::AbstractDimArray)
     wn = w ÷ 3 # integers take 3 columns each when printed, floats more
 
     A_dims = if ndims(A) == 1
-        itop =    size(A,1) < h ? (firstindex(A,1):lastindex(A,1)) : (1:(h÷2))
-        ibottom = size(A,1) < h ? (1:0)                            : size(A,1)-(h÷2):size(A,1)
+        f1, l1, s1 = firstindex(A, 1), lastindex(A, 1), size(A, 1)
+        itop =    s1 < h ? (f1:l1) : (1:(h ÷ 2))
+        ibottom = s1 < h ? (1:0)   : s1-(h ÷ 2):s1
         labels = vcat(ShowWith.(lookup(A, 1)[itop]), ShowWith.(lookup(A, 1))[ibottom])
         vals = vcat(parent(A)[itop], parent(A)[ibottom])
         hcat(labels, vals)
     else
-        itop    = size(A, 1) < h  ? (firstindex(A,1):lastindex(A,1)) : (1:(h÷2))
-        ibottom = size(A, 1) < h  ? (1:0)                            : size(A,1)-(h÷2):size(A,1)
-        ileft   = size(A, 2) < wn ? (firstindex(A,2):lastindex(A,2)) : (1:(wn÷2))
-        iright  = size(A, 2) < wn ? (1:0)                            : size(A,2)-(wn÷2)+1:size(A,2)
+        f1, f2 = firstindex(A, 1), firstindex(A, 2)
+        l1, l2 = lastindex(A, 1), lastindex(A, 2)
+        s1, s2 = size(A)
+        itop    = s1 < h  ? (f1:l1)     : (f1:((h ÷ 2)) + f1 - 1)
+        ibottom = s1 < h  ? (f1:f1 - 1) : s1 - (h ÷ 2) + f1 - 1:s1 + f1 - 1
+        ileft   = s2 < wn ? (f2:l2)     : (f2:(wn ÷ 2)) + f2 - 1
+        iright  = s2 < wn ? (f2:f2 - 1) : s2 - (wn ÷ 2) + f2:s2 + f2 - 1
 
         topleft = collect(A[itop, ileft])
         bottomleft = collect(A[ibottom, ileft])
@@ -94,7 +98,7 @@ function Base.print_matrix(io::IO, A::AbstractDimArray)
         if lookup(A, 2) isa NoLookup
             bottomblock
         else
-            toplabels = ShowWith.(dims(A, 2))[ileft], ShowWith.(dims(A, 2))[iright]
+            toplabels = ShowWith.(lookup(A, 2))[ileft], ShowWith.(lookup(A, 2))[iright]
             toprow = if lookup(A, 1) isa NoLookup
                 vcat(toplabels...)
             else

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -119,7 +119,7 @@ struct ShowWith{T,NT} <: AbstractString
     end
 end
 function Base.show(io::IO, x::ShowWith; kw...)
-    s = sprint(show, x.val; context=io, kw...)
+    s = sprint(show, MIME"text/plain"(), x.val; context=io, kw...)
     s1 = x.hide ? " "^length(s) : s
     printstyled(io, s1; color=:light_black, x.nt...)
 end

--- a/src/set.jl
+++ b/src/set.jl
@@ -42,9 +42,10 @@ julia> set(da, ones(3, 4))
 3×4 DimArray{Float64,2} with dimensions:
   Dim{:custom} Sampled 10.0:10.0:30.0 ForwardOrdered Regular Points,
   Z Sampled -20.0:10.0:10.0 ForwardOrdered Regular Points
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0
- 1.0  1.0  1.0  1.0 
+       -20.0  -10.0  0.0  10.0
+ 10.0    1.0    1.0  1.0   1.0
+ 20.0    1.0    1.0  1.0   1.0
+ 30.0    1.0    1.0  1.0   1.0 
 ```
 
 Change the `Dimension` wrapper type:
@@ -54,9 +55,10 @@ julia> set(da, :Z => Ti, :custom => Z)
 3×4 DimArray{Float64,2} with dimensions:
   Z Sampled 10.0:10.0:30.0 ForwardOrdered Regular Points,
   Ti Sampled -20.0:10.0:10.0 ForwardOrdered Regular Points
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0 
+       -20.0  -10.0  0.0  10.0
+ 10.0    0.0    0.0  0.0   0.0
+ 20.0    0.0    0.0  0.0   0.0
+ 30.0    0.0    0.0  0.0   0.0 
 ```
 
 Change the lookup `Vector`:
@@ -66,9 +68,10 @@ julia> set(da, Z => [:a, :b, :c, :d], :custom => [4, 5, 6])
 3×4 DimArray{Float64,2} with dimensions:
   Dim{:custom} Sampled Int64[4, 5, 6] ForwardOrdered Regular Points,
   Z Sampled Symbol[a, b, c, d] ForwardOrdered Regular Points
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
+     :a   :b   :c   :d
+ 4  0.0  0.0  0.0  0.0
+ 5  0.0  0.0  0.0  0.0
+ 6  0.0  0.0  0.0  0.0
 ```
 
 Change the `LookupArray` type:
@@ -78,9 +81,9 @@ julia> set(da, Z=DD.NoLookup(), custom=DD.Sampled())
 3×4 DimArray{Float64,2} with dimensions:
   Dim{:custom} Sampled 10.0:10.0:30.0 ForwardOrdered Regular Points,
   Z
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
+ 10.0  0.0  0.0  0.0  0.0
+ 20.0  0.0  0.0  0.0  0.0
+ 30.0  0.0  0.0  0.0  0.0
 ```
 
 Change the `Sampling` trait:
@@ -90,9 +93,10 @@ julia> set(da, :custom => DD.Irregular(10, 12), Z => DD.Regular(9.9))
 3×4 DimArray{Float64,2} with dimensions:
   Dim{:custom} Sampled 10.0:10.0:30.0 ForwardOrdered Irregular Points,
   Z Sampled -20.0:10.0:10.0 ForwardOrdered Regular Points
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0
+       -20.0  -10.0  0.0  10.0
+ 10.0    0.0    0.0  0.0   0.0
+ 20.0    0.0    0.0  0.0   0.0
+ 30.0    0.0    0.0  0.0   0.0
 ```
 """
 function set end

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -41,6 +41,17 @@ using DimensionalData.LookupArrays, DimensionalData.Dimensions
     @test TestDim(Sampled(5.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))[At(6.0)] == 6.0
 end
 
+@testset "dim tuple methods" begin
+    ds = (X(20:30), Y(1.0:4.0))
+    @test axes(ds) == (Base.OneTo(11), Base.OneTo(4))
+    @test axes(ds, 1) == Base.OneTo(11)
+    @test axes(ds, Y) == Base.OneTo(4)
+    @test size(ds) == (11, 4)
+    @test size(ds, 1) == 11
+    @test size(ds, Y) == 4
+    checkbounds(ds)[1, 2]
+end
+
 @testset "format" begin
     A = [1 2 3; 4 5 6]
     @test format((X, Y), A) == (X(NoLookup(Base.OneTo(2))), Y(NoLookup(Base.OneTo(3))))
@@ -58,6 +69,8 @@ end
      @test format((X(Sampled(Base.OneTo(2); order=ForwardOrdered(), span=Regular(), sampling=Points())), Y), A) == 
         (X(Sampled(Base.OneTo(2), ForwardOrdered(), Regular(1), Points(), NoMetadata())), 
          Y(NoLookup(Base.OneTo(3))))
+     @test format((X(Sampled(LinRange(2, 1, 0); span=Regular(1.0)), 1.0:0.0) == 
+        (X(Sampled(Base.OneTo(2), ForwardOrdered(), Regular(1), Points(), NoMetadata()))) 
 end
 
 @testset "Val" begin

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -41,17 +41,6 @@ using DimensionalData.LookupArrays, DimensionalData.Dimensions
     @test TestDim(Sampled(5.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))[At(6.0)] == 6.0
 end
 
-@testset "dim tuple methods" begin
-    ds = (X(20:30), Y(1.0:4.0))
-    @test axes(ds) == (Base.OneTo(11), Base.OneTo(4))
-    @test axes(ds, 1) == Base.OneTo(11)
-    @test axes(ds, Y) == Base.OneTo(4)
-    @test size(ds) == (11, 4)
-    @test size(ds, 1) == 11
-    @test size(ds, Y) == 4
-    checkbounds(ds)[1, 2]
-end
-
 @testset "format" begin
     A = [1 2 3; 4 5 6]
     @test format((X, Y), A) == (X(NoLookup(Base.OneTo(2))), Y(NoLookup(Base.OneTo(3))))
@@ -69,8 +58,6 @@ end
      @test format((X(Sampled(Base.OneTo(2); order=ForwardOrdered(), span=Regular(), sampling=Points())), Y), A) == 
         (X(Sampled(Base.OneTo(2), ForwardOrdered(), Regular(1), Points(), NoMetadata())), 
          Y(NoLookup(Base.OneTo(3))))
-     @test format((X(Sampled(LinRange(2, 1, 0); span=Regular(1.0)), 1.0:0.0) == 
-        (X(Sampled(Base.OneTo(2), ForwardOrdered(), Regular(1), Points(), NoMetadata()))) 
 end
 
 @testset "Val" begin

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -23,7 +23,7 @@ using OffsetArrays, ImageFiltering, ImageTransformations, DimensionalData
     end
     @testset "show" begin
         s = sprint(show, MIME("text/plain"), oda)
-        @test occursin(":a", sv)
+        @test occursin(":a", s)
     end
 end
 

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -21,6 +21,10 @@ using OffsetArrays, ImageFiltering, ImageTransformations, DimensionalData
         @test axes(oda[0:1, 7:8]) == (1:2, 1:2)
         @test axes.(dims(oda[0:1, 7:8])) == ((1:2,), (1:2,))
     end
+    @testset "show" begin
+        s = sprint(show, MIME("text/plain"), oda)
+        @test occursin(":a", sv)
+    end
 end
 
 @testset "ImageFiltering and ImageTransformations" begin


### PR DESCRIPTION
Closes #318

@Datseris @ParadaCarleton seeing you both expressed interest in #318, do you want to try this out and see how you like the style? It uses the `:light_black` color for labels which I think is minimally intrusive when you just want to look at the array, besides the slight loss of screen space.

It has a few problems - the labels use `Base.alignment` which means they try and align with the other array values. Which is a bit of a hack, they should just sit in whatever space the array values fill - but things get much trickier to do that.

The other downside is that array types with specific `Base.print_matrix` methods don't use those methods - a `SparseArray` isprinted with regular zeros instead of a dot for empty values.

The github output loses colors so looks a lot worse than in the REPL, but to demonstrate:

```julia
julia> rand( X(200.0:1:400), Y('a':'z'), Z(5))
201×26×5 DimArray{Float64,3} with dimensions:
  X Sampled 200.0:1.0:400.0 ForwardOrdered Regular Points,
  Y Categorical 'a':1:'z' ForwardOrdered,
  Z
[:, :, 1]
         'a'       'b'        'c'         'd'      …   'w'         'x'       'y'        'z'
 200.0  0.673935  0.141439   0.955314    0.717369     0.740125    0.955894  0.826375   0.44628
 201.0  0.712164  0.481134   0.542074    0.67757      0.617952    0.282931  0.540955   0.450101
 202.0  0.648451  0.650928   0.408938    0.150393     0.342722    0.775194  0.414076   0.860255
 203.0  0.936581  0.469827   0.441755    0.243855     0.856957    0.583006  0.741963   0.839532
 204.0  0.353114  0.0873615  0.446055    0.678356  …  0.592797    0.305778  0.881453   0.129537
 205.0  0.914772  0.399673   0.00789701  0.22394      0.161127    0.849938  0.0727497  0.90776
   ⋮                                               ⋱                        ⋮
 395.0  0.993582  0.987368   0.711423    0.949472     0.00607777  0.699784  0.0920469  0.802377
 396.0  0.855686  0.887951   0.683934    0.720047  …  0.639821    0.671521  0.200358   0.371284
 397.0  0.27446   0.404087   0.783541    0.198848     0.275439    0.084968  0.886439   0.248281
 398.0  0.542105  0.206849   0.622234    0.425789     0.451899    0.96857   0.71085    0.430552
 399.0  0.662324  0.336501   0.608798    0.320062     0.0179621   0.814293  0.91817    0.667375
 400.0  0.456497  0.634181   0.687159    0.717509     0.670711    0.365766  0.313009   0.856011
[and 4 more slices...]
```