### PR TITLE
Allow broadcast over different sized dims when one has length of one

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -494,11 +494,11 @@ function comparedims end
 @inline comparedims(a::Dimension, b::AnonDim; kw...) = a
 @inline comparedims(a::AnonDim, b::Dimension; kw...) = b
 @inline function comparedims(a::Dimension, b::Dimension;
-    type=true, valuetype=false, length=true, ignore_length_one=false, value=false,
+    type=true, valtype=false, length=true, ignore_length_one=false, val=false,
 )
     type && basetypeof(a) != basetypeof(b) && _dimsmismatcherror(a, b)
-    valuetype && typeof(parent(a)) != typeof(parent(b)) && _valuetypeerror(a, b)
-    value && parent(a) != parent(b) && _valueerror(a, b)
+    valtype && typeof(parent(a)) != typeof(parent(b)) && _valtypeerror(a, b)
+    val && parent(a) != parent(b) && _valerror(a, b)
     if ignore_length_one && (Base.length(a) == 1 || Base.length(b) == 1)
         @show Base.length(b)
         return Base.length(b) == 1 ? a : b
@@ -628,8 +628,8 @@ _astuple(x) = (x,)
 @noinline _dimsnotdefinederror() = throw(ArgumentError("Object does not define a `dims` method"))
 @noinline _dimsmismatcherror(a, b) = throw(DimensionMismatch("$(basetypeof(a)) and $(basetypeof(b)) for dims on the same axis"))
 @noinline _dimsizeerror(a, b) = throw(DimensionMismatch("Found both lengths $(length(a)) and $(length(b)) for $(basetypeof(a))"))
-@noinline _valuetypeerror(a, b) = throw(DimensionMismatch("Mode $((a)) and $(lookup(b)) do not match"))
+@noinline _valtypeerror(a, b) = throw(DimensionMismatch("Mode $((a)) and $(lookup(b)) do not match"))
 @noinline _metadataerror(a, b) = throw(DimensionMismatch("Metadata $(metadata(a)) and $(madata(b)) do not match"))
-@noinline _valueerror(a, b) = throw(DimensionMismatch("Dimension index $(parent(a)) and $(parent(b)) do not match"))
+@noinline _valerror(a, b) = throw(DimensionMismatch("Dimension index $(parent(a)) and $(parent(b)) do not match"))
 @noinline _warnextradims(extradims) = @warn "$(map(basetypeof, extradims)) dims were not found in object"
 @noinline _errorextradims() = throw(ArgumentError("Some dims were not found in object"))

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -45,7 +45,7 @@ function Broadcast.copy(bc::Broadcasted{DimensionalStyle{S}}) where S
 end
 
 function Base.copyto!(dest::AbstractArray, bc::Broadcasted{DimensionalStyle{S}}) where S
-    _dims = comparedims(dims(dest), _broadcasted_dims(bc))
+    _dims = comparedims(dims(dest), _broadcasted_dims(bc); ignore_length_one=true)
     copyto!(dest, _unwrap_broadcasted(bc))
     A = _firstdimarray(bc)
     if A isa Nothing || _dims isa Nothing
@@ -55,7 +55,7 @@ function Base.copyto!(dest::AbstractArray, bc::Broadcasted{DimensionalStyle{S}})
     end
 end
 function Base.copyto!(dest::AbstractDimArray, bc::Broadcasted{DimensionalStyle{S}}) where S
-    _dims = comparedims(dims(dest), _broadcasted_dims(bc))
+    _dims = comparedims(dims(dest), _broadcasted_dims(bc); ignore_length_one=true)
     copyto!(parent(dest), _unwrap_broadcasted(bc))
     A = _firstdimarray(bc)
     if A isa Nothing || _dims isa Nothing
@@ -97,6 +97,6 @@ _firstdimarray(x::Tuple{}) = nothing
 
 # Make sure all arrays have the same dims, and return them
 _broadcasted_dims(bc::Broadcasted) = _broadcasted_dims(bc.args...)
-_broadcasted_dims(a, bs...) = comparedims(_broadcasted_dims(a), _broadcasted_dims(bs...))
+_broadcasted_dims(a, bs...) = comparedims(_broadcasted_dims(a), _broadcasted_dims(bs...); ignore_length_one=true)
 _broadcasted_dims(a::AbstractDimArray) = dims(a)
 _broadcasted_dims(a) = nothing

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -4,7 +4,7 @@ using DimensionalData: NoLookup
 
 # Tests taken from NamedDims. Thanks @oxinabox
 
-da = DimArray(ones(3), X)
+da = ones(X(3))
 @test Base.BroadcastStyle(typeof(da)) isa DimensionalData.DimensionalStyle
 
 @testset "standard case" begin
@@ -12,6 +12,11 @@ da = DimArray(ones(3), X)
     @test dims(da .+ da) == dims(da)
     @test da .+ da .+ da == 3ones(3)
     @test dims(da .+ da .+ da) == dims(da)
+end
+
+@testset "broadcast over length one dimension" begin
+    da2 = DimArray((1:4) * (1:2:8)', (X, Y))
+    @test da2 .* da2[:, 1:1] == [1, 4, 9, 16] * (1:2:8)'
 end
 
 @testset "in place" begin


### PR DESCRIPTION
Closes #401 

@sethaxen this also makes a few name changes to the keyword arguments of `comparedims` and adds them to the docs. Probably they should all be tested too...