### PR TITLE
add setindex and improve merge for stacks

### DIFF
--- a/test/stack.jl
+++ b/test/stack.jl
@@ -3,7 +3,7 @@ using DimensionalData, Test, LinearAlgebra, Statistics
 using DimensionalData: data
 using DimensionalData: Sampled, Categorical, AutoLookup, NoLookup, Transformed,
     Regular, Irregular, Points, Intervals, Start, Center, End,
-    Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Unordered
+    Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Unordered, layers
 
 A = [1.0 2.0 3.0;
      4.0 5.0 6.0]
@@ -74,10 +74,22 @@ end
 end
 
 @testset "merge" begin
+    @test layers(s) === (; s...)
+    @test layers(s) === (; one=da1, s[(:two,)]..., (three=da3,)...)
+    @test layers(s) === (; (one=da1,)..., two=da2, s[(:three,)]...)
+    @test s === merge(s[(:one,:two)], (three=da3,))
+    @test s === merge(s[(:one,)], (two=da2, three=da3))
     @test merge(mixed) === mixed
     @test keys(merge(mixed, s)) == (:one, :two, :extradim, :three)
     @test keys(merge(s, mixed)) == (:one, :two, :three, :extradim)
     @test keys(merge(s, (:new=>da4,))) == (:one, :two, :three, :new)
+end
+
+@testset "setindex" begin
+    s12 = DimStack((da1, da2))
+    @test s === Base.setindex(s12, da3, :three)
+    s423 = DimStack((one=da4, two=da2, three=da3))
+    @test s === Base.setindex(s423, da1, :one)
 end
 
 @testset "copy and friends" begin


### PR DESCRIPTION
@Lincoln-Hannah this is an example of incremental improvements to the syntax without changing any structure or adding macros.

This lets you merge `AbstractDimStack` and `NamedTuple` of `AbstractDimArray` and get a new `AbstrackDimStack` back.

```julia
# Merge a stack with new layers in another stack or NamedTuple
new_stack = merge(oldstack, (new1=dimarray, new2=dimarrary))
# Or use `NamedTuple` merge
new_stack = DimStack((; oldstack..., new1=dimarray, new2=dimarray))
```

And for your example in #410 :
```julia
Base.setindex(s, 4s[:one], :four)
```

They are still a bit clunky to use. But these are the kinds of simple Base methods I would hope to build a better syntax on top of. So Base julia `NamedTuple` methods do all the real work, we just wrap it.
