### PR TITLE
run JET, fix bugs

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -147,7 +147,7 @@ const DimTuple = Tuple{<:Dimension,Vararg{<:Dimension}}
 const SymbolTuple = Tuple{Symbol,Vararg{Symbol}}
 const DimTypeTuple = Tuple{<:DimType,Vararg{<:DimType}}
 const VectorOfDim = Vector{<:Union{Dimension,DimType,Symbol}}
-const DimOrDimType = Union{Dimension,DimType,Symbol}
+const DimOrDimType = Union{Dimension,DimType,Symbol,Val{<:Dimension}}
 const AllDims = Union{Symbol,Dimension,DimTuple,SymbolTuple,DimType,DimTypeTuple,VectorOfDim}
 
 # DimensionalData interface methods

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -147,7 +147,7 @@ const DimTuple = Tuple{<:Dimension,Vararg{<:Dimension}}
 const SymbolTuple = Tuple{Symbol,Vararg{Symbol}}
 const DimTypeTuple = Tuple{<:DimType,Vararg{<:DimType}}
 const VectorOfDim = Vector{<:Union{Dimension,DimType,Symbol}}
-const DimOrDimType = Union{Dimension,DimType,Symbol,Val{<:Dimension}}
+const DimOrDimType = Union{Dimension,DimType,Symbol}
 const AllDims = Union{Symbol,Dimension,DimTuple,SymbolTuple,DimType,DimTypeTuple,VectorOfDim}
 
 # DimensionalData interface methods

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -24,7 +24,7 @@ format(dims::Tuple{Vararg{<:Any,N}}, A::AbstractArray{<:Any,N}) where N =
     format(dims, axes(A))
 @noinline format(dims::Tuple{Vararg{<:Any,M}}, A::AbstractArray{<:Any,N}) where {N,M} =
     throw(DimensionMismatch("Array A has $N axes, while the number of dims is $M: $(map(basetypeof, dims))"))
-format(dims::Tuple, axes::Tuple) = map(_format, dims, axes)
+format(dims::Tuple{Vararg{<:Any,N}}, axes::Tuple{Vararg{<:Any,N}}) where N = map(_format, dims, axes)
 
 _format(dimname::Symbol, axis::AbstractRange) = Dim{dimname}(NoLookup(axes(axis, 1)))
 _format(::Type{D}, axis::AbstractRange) where D<:Dimension = D(NoLookup(axes(axis, 1)))

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -43,7 +43,6 @@ All other `Symbol`s `S` will generate `Dim{S}()` dimensions.
 @inline key2dim(t::Tuple) = map(key2dim, t)
 @inline key2dim(s::Symbol) = key2dim(Val{s}())
 # Allow other things to pass through
-@inline key2dim(d::Val{<:Dimension}) = d
 @inline key2dim(d) = d
 
 # key2dim is defined for concrete instances in dimensions.jl
@@ -77,9 +76,10 @@ can be used in `order`.
 
 `f` is `<:` by default, but can be `>:` to sort abstract types by concrete types.
 """
-@inline sortdims(args...) = _call_primitive(_sortdims, MaybeFirst(), args...)
+@inline sortdims(a1, args...) = _call_primitive(_sortdims, MaybeFirst(), a1, args...)
 
-@inline _sortdims(f, tosort, order::Tuple{<:Integer,Vararg}) = map(p -> tosort[p], order)
+@inline _sortdims(f, tosort::Tuple{Vararg{<:Any,N}}, order::Tuple{Vararg{N,<:Integer}}) where N =
+    map(p -> tosort[p], order)
 @inline _sortdims(f, tosort, order) = _sortdims_gen(f, tosort, order)
 
 @generated _sortdims_gen(f, tosort::Tuple, order::Tuple) = begin
@@ -134,7 +134,7 @@ X, Y
 
 ```
 """
-@inline dims(args...) = _call_primitive(_dims, MaybeFirst(), args...)
+@inline dims(a1, args...) = _call_primitive(_dims, MaybeFirst(), a1, args...)
 
 @inline _dims(f, dims, lookup) = _remove_nothing(_sortdims(f, dims, lookup))
 
@@ -165,7 +165,7 @@ julia> commondims(A, Ti)
 
 ```
 """
-@inline commondims(args...) = _call_primitive(_commondims, AlwaysTuple(), args...)
+@inline commondims(a1, args...) = _call_primitive(_commondims, AlwaysTuple(), a1, args...)
 
 _commondims(f, ds, lookup) = _dims(f, ds, _dims(_flip_subtype(f), lookup, ds))
 
@@ -196,9 +196,9 @@ julia> dimnum(A, Y)
 2
 ```
 """
-@inline function dimnum(args...)
-    all(hasdim(args...)) || _errorextradims()
-    _call_primitive(_dimnum, MaybeFirst(), args...)
+@inline function dimnum(a1, args...)
+    all(hasdim((a1, args...))) || _errorextradims()
+    _call_primitive(_dimnum, MaybeFirst(), a1, args...)
 end
 
 @inline function _dimnum(f::Function, ds::Tuple, lookups::Tuple{Vararg{Int}})
@@ -241,7 +241,7 @@ julia> hasdim(A, Ti)
 false
 ```
 """
-@inline hasdim(args...) = _call_primitive(_hasdim, MaybeFirst(), args...)
+@inline hasdim(a1, args...) = _call_primitive(_hasdim, MaybeFirst(), a1, args...)
 
 @inline _hasdim(f, dims, lookup) =
     map(d -> !(d isa Nothing), _sortdims(f, _commondims(f, dims, lookup), lookup))
@@ -273,7 +273,7 @@ julia> otherdims(A, (Y, Z))
 X
 ```
 """
-@inline otherdims(args...) = _call_primitive(_otherdims_presort, AlwaysTuple(), args...)
+@inline otherdims(a1, args...) = _call_primitive(_otherdims_presort, AlwaysTuple(), a1, args...)
 
 @inline _otherdims_presort(f, ds, lookup) = _otherdims(f, ds, _sortdims(_rev_op(f), lookup, ds))
 # Work with a sorted lookup where the missing dims are `nothing`
@@ -565,18 +565,20 @@ struct AlwaysTuple end
 # Call the function f with stardardised args
 # This looks like HELL, but it removes this complexity
 # from every other method and makes sure they all behave the same way.
-@inline _call_primitive(f::Function, t, args...) = _call_primitive(f, t, <:, _wraparg(args...)...)
-@inline _call_primitive(f::Function, t, op::Function, args...) = _call_primitive1(f, t, op, _wraparg(args...)...)
+@inline _call_primitive(f::Function, t, a1, a2, args...) =
+    _call_primitive(f, t, <:, _wraparg(a1, a2, args...)...)
+@inline _call_primitive(f::Function, t, op::Function, a1, a2, args...) =
+    _call_primitive1(f, t, op, _wraparg(a1, a2, args...)...)
 
 @inline _call_primitive1(f, t, op::Function, x, l1, l2, ls...) = _call_primitive1(f, t, op, x, (l1, l2, ls...))
-@inline _call_primitive1(f, t, op::Function, x, lookup) = _call_primitive1(f, t, op, dims(x), lookup)
-@inline _call_primitive1(f, t, op::Function, x::Nothing, lookup) = _dimsnotdefinederror()
-@inline _call_primitive1(f, t, op::Function, d::Tuple, lookup) = _call_primitive1(f, t, op, d, dims(lookup))
-@inline _call_primitive1(f, t::AlwaysTuple, op::Function, d::Tuple, lookup::Union{Dimension,DimType,Val,Integer}) =
-    _call_primitive1(f, t, op, d, (lookup,))
-@inline _call_primitive1(f, t::MaybeFirst, op::Function, d::Tuple, lookup::Union{Dimension,DimType,Val,Integer}) =
-    _call_primitive1(f, t, op, d, (lookup,)) |> _maybefirst
-@inline _call_primitive1(f, t, op::Function, d::Tuple, lookup::Tuple) = map(unwrap, f(op, d, lookup))
+@inline _call_primitive1(f, t, op::Function, x, query) = _call_primitive1(f, t, op, dims(x), query)
+@inline _call_primitive1(f, t, op::Function, x::Nothing, query) = _dimsnotdefinederror()
+@inline _call_primitive1(f, t, op::Function, d::Tuple, query) = _call_primitive1(f, t, op, d, dims(query))
+@inline _call_primitive1(f, t::AlwaysTuple, op::Function, d::Tuple, query::Union{Dimension,DimType,Val,Integer}) =
+    _call_primitive1(f, t, op, d, (query,))
+@inline _call_primitive1(f, t::MaybeFirst, op::Function, d::Tuple, query::Union{Dimension,DimType,Val,Integer}) =
+    _call_primitive1(f, t, op, d, (query,)) |> _maybefirst
+@inline _call_primitive1(f, t, op::Function, d::Tuple, query::Tuple) = map(unwrap, f(op, d, query))
 
 
 _maybefirst(xs::Tuple) = first(xs)

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -78,8 +78,7 @@ can be used in `order`.
 """
 @inline sortdims(a1, args...) = _call_primitive(_sortdims, MaybeFirst(), a1, args...)
 
-@inline _sortdims(f, tosort::Tuple{Vararg{<:Any,N}}, order::Tuple{Vararg{N,<:Integer}}) where N =
-    map(p -> tosort[p], order)
+@inline _sortdims(f, tosort, order::Tuple{<:Integer,Vararg}) =map(p -> tosort[p], order)
 @inline _sortdims(f, tosort, order) = _sortdims_gen(f, tosort, order)
 
 @generated _sortdims_gen(f, tosort::Tuple, order::Tuple) = begin

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -424,7 +424,7 @@ function Transformed(f, dim; metadata=NoMetadata())
 end
 
 function rebuild(l::Transformed; 
-    data=data(l), f=f(l), dim=dim(l), metadata=metadata(l)
+    data=parent(l), f=f(l), dim=dim(l), metadata=metadata(l)
 )
     Transformed(data, f, dim, metadata)
 end

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -762,7 +762,7 @@ function _inbounds(i::Int, lookup::LookupArray)
 end
 
 _sorttuple(sel::Between) = _sorttuple(val(sel))
-_sorttuple((a, b)) = a < b ? (a, b) : (b, a)
+_sorttuple((a, b)::Tuple{<:Any,<:Any}) = a < b ? (a, b) : (b, a)
 
 _lt(::Locus) = (<)
 _lt(::End) = (<=)

--- a/src/LookupArrays/show.jl
+++ b/src/LookupArrays/show.jl
@@ -90,5 +90,5 @@ function print_index(io, mime, v::AbstractVector, nchars=0)
     else
         join((string(va) for va in v), ", ")
     end
-    printstyled(io, string(eltype(v)) * "[" * vals * "]"; color=:cyan)
+    printstyled(io, string(eltype(v), "[", vals, "]"); color=:cyan)
 end

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -52,8 +52,9 @@ This method can also be used with keyword arguments in place of regular argument
     rebuild(A, data, dims, refdims, name, metadata(A))
 end
 
-@inline rebuildsliced(args...) = rebuildsliced(getindex, args...)
-@inline rebuildsliced(f::Function, A, data, I, name=name(A)) = rebuild(A, data, slicedims(f, A, I)..., name)
+@inline rebuildsliced(A::AbstractDimArray, args...) = rebuildsliced(getindex, A, args...)
+@inline rebuildsliced(f::Function, A::AbstractDimArray, data::AbstractArray, I::Tuple, name=name(A)) =
+    rebuild(A, data, slicedims(f, A, I)..., name)
 
 for func in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :bounds, :locus)
     @eval ($func)(A::AbstractDimArray, args...) = ($func)(dims(A), args...)

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -176,11 +176,11 @@ for fname in [:permutedims, :PermutedDimsArray]
 end
 
 # Concatenation
-function Base._cat(catdims::Union{Int,Base.Dims}, Xin::AbstractDimArray...)
-    Base._cat(dims(first(Xin), catdims), Xin...)
+function Base._cat(catdims::Union{Int,Base.Dims}, A1::AbstractDimArray, As::AbstractDimArray...)
+    Base._cat(dims(A1, catdims), A1, As...)
 end
-function Base._cat(catdims::Tuple, Xin::AbstractDimArray...)
-    A1 = first(Xin)
+function Base._cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
+    Xin = (A1, As...)
     comparedims(map(x -> otherdims(x, catdims), Xin)...)
     newcatdims = map(catdims) do catdim
         if all(x -> hasdim(x, catdim), Xin)
@@ -225,9 +225,9 @@ function Base._cat(catdim::DimOrDimType, Xin::AbstractDimArray...)
     Base._cat((catdim,), Xin...)
 end
 
-function Base.vcat(dims::Dimension...)
-    newlookup = _vcat_lookups(lookup(dims)...)
-    rebuild(dims[1], newlookup)
+function Base.vcat(d1::Dimension, ds::Dimension...)
+    newlookup = _vcat_lookups(lookup((d1, ds...))...)
+    rebuild(d1, newlookup)
 end
 
 # LookupArrays may need adjustment for `cat`

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -13,28 +13,28 @@ end
 
 @recipe function f(::DimensionalPlot, A::AbstractArray)
     A_fwd = reorder(A, ForwardOrdered())
-    sertype = get(plotattributes, :seriestype, :none)
-    if !(sertype in [:marginalhist])
+    sertype = get(plotattributes, :seriestype, :none)::Symbol
+    if !(sertype in (:marginalhist,))
         :title --> refdims_title(A_fwd)
     end
     if ndims(A) > 2
         parent(A)
-    elseif sertype in [:heatmap, :contour, :volume, :marginalhist,
-                       :surface, :contour3d, :wireframe, :scatter3d]
+    elseif sertype in (:heatmap, :contour, :volume, :marginalhist,
+                       :surface, :contour3d, :wireframe, :scatter3d)
         HeatMapLike(), A_fwd
-    elseif sertype in [:histogram, :stephist, :density, :barhist, :scatterhist, :ea_histogram]
+    elseif sertype in (:histogram, :stephist, :density, :barhist, :scatterhist, :ea_histogram)
         HistogramLike(), A_fwd
-    elseif sertype in [:hline]
+    elseif sertype in (:hline,)
         :yguide --> label(A_fwd)
         parent(A_fwd)
-    elseif sertype in [:vline, :andrews]
+    elseif sertype in (:vline, :andrews)
         :xguide --> label(A_fwd)
         parent(A_fwd)
-    elseif sertype in [:violin, :dotplot, :boxplot]
+    elseif sertype in (:violin, :dotplot, :boxplot)
         ViolinLike(), A_fwd
-    elseif sertype in [:plot, :histogram2d, :none, :line, :path, :shape, :steppre, 
+    elseif sertype in (:plot, :histogram2d, :none, :line, :path, :shape, :steppre, 
                        :steppost, :sticks, :scatter, :hexbin, :barbins, :scatterbins, 
-                       :stepbins, :bins2d, :bar]
+                       :stepbins, :bins2d, :bar)
         SeriesLike(), A_fwd
     else
         parent(A_fwd)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,7 +1,9 @@
-using DimensionalData, Dates, Test, BenchmarkTools
+using DimensionalData, Dates, Test , BenchmarkTools
 using DimensionalData.LookupArrays, DimensionalData.Dimensions
 
 using .Dimensions: _call_primitive, _wraparg, _reducedims, AlwaysTuple, MaybeFirst
+
+@dim Tst
 
 @testset "dimsmatch" begin
     @test (@inferred dimsmatch(Y(), Y())) == true
@@ -25,8 +27,6 @@ using .Dimensions: _call_primitive, _wraparg, _reducedims, AlwaysTuple, MaybeFir
     @test (@ballocated dimsmatch(ZDim, Dimension)) == 0
     @test (@ballocated dimsmatch((Z(), ZDim), (ZDim, XDim))) == 0
 end
-
-@dim Tst
 
 @testset "key2dim" begin
     @test key2dim(:test) == Dim{:test}()
@@ -200,6 +200,7 @@ end
 end
 
 @testset "dimnum" begin
+    dims(da)
     @test dimnum(da, Y()) == dimnum(da, 2) == 2
     @test (@ballocated dimnum($da, Y())) == 0
     @test dimnum(da, X) == 1

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1079,6 +1079,7 @@ end
     end
 
     da = DimArray(reshape(a, 3, 4, 1), dimz)
+    view(da, :, :, 1)
 
     @testset "Indexing with array dims indexes the array as usual" begin
         da2 = da[1:3, 1:1, 1:1]


### PR DESCRIPTION
Nearly all of these are fixing cases where I had used `args...` allowing no argument variants of methods that would then go on to error. Now they will error at the top level.

Remaining plotting bug is fixed in #414. There is also an issue with Tables.jl iterating over `nothing` when the schema is empty.