### PR TITLE
Fixes for broadcasting with 0-dim DimArrays

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -458,6 +458,8 @@ cell step, sampling type and order.
 @inline _reducedims(dim::Dimension, ::Nothing) = dim
 @inline _reducedims(dim::Dimension, ::DimOrDimType) = rebuild(dim, reducelookup(lookup(dim)))
 
+const DimTupleOrEmpty = Union{DimTuple,Tuple{}}
+
 """
     comparedims(A::AbstractDimArray...; kw...)
     comparedims(A::Tuple...; kw...)
@@ -512,8 +514,6 @@ function comparedims end
     length && Base.length(a) != Base.length(b) && _dimsizeerror(a, b)
     return a
 end
-
-const DimTupleOrEmpty = Union{DimTuple,Tuple{}}
 
 """
     combinedims(xs; check=true)

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -488,8 +488,8 @@ function comparedims end
 @inline comparedims(dims::Vararg{<:Tuple{Vararg{<:Dimension}}}; kw...) =
     map(d -> comparedims(first(dims), d), dims; kw...) |> first
 
-@inline comparedims(a::DimTuple, ::Nothing; kw...) = a
-@inline comparedims(::Nothing, b::DimTuple; kw...) = b
+@inline comparedims(a::DimTupleOrEmpty, ::Nothing; kw...) = a
+@inline comparedims(::Nothing, b::DimTupleOrEmpty; kw...) = b
 @inline comparedims(::Nothing, ::Nothing; kw...) = nothing
 # Cant use `map` here, tuples may not be the same length
 @inline comparedims(a::DimTuple, b::DimTuple; kw...) =

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -134,6 +134,8 @@ Base.similar(A::AbstractDimArray, ::Type{T}, D::Dimension...) where T =
     Base.similar(A, T, D) 
 Base.similar(A::AbstractDimArray, ::Type{T}, D::DimTuple) where T =
     rebuild(A; data=similar(parent(A), T, size(D)), dims=deepcopy(D), refdims=(), metadata=NoMetadata())
+Base.similar(A::AbstractDimArray, ::Type{T}, D::Tuple{}) where T =
+    rebuild(A; data=similar(parent(A), T, ()), dims=(), refdims=(), metadata=NoMetadata())
 
 # Keep the same type in `similar`
 _noname(A::AbstractDimArray) = _noname(name(A))

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -37,7 +37,7 @@ function Broadcast.copy(bc::Broadcasted{DimensionalStyle{S}}) where S
     _dims = _broadcasted_dims(bc)
     A = _firstdimarray(bc)
     data = copy(_unwrap_broadcasted(bc))
-    return if A isa Nothing || _dims isa Nothing
+    return if A isa Nothing || _dims isa Nothing || ndims(A) == 0
         data
     else
         rebuild(A, data, _dims, refdims(A), Symbol(""))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -121,6 +121,14 @@ end
     @test A == [1.0 1.0; 2.0 2.0; 7.0 7.0]
 end
 
+@testset "0-dimensional array broadcasting" begin
+    x = DimArray(fill(3), ())
+    y = DimArray(fill(4), ())
+    @test @inferred(x .- y) === -1
+    @test !(x ≈ y)
+    @test x ≈ x
+end
+
 # @testset "Competing Wrappers" begin
 #     da = DimArray(ones(4), X)
 #     ta = TrackedArray(5 * ones(4))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -124,9 +124,12 @@ end
 @testset "0-dimensional array broadcasting" begin
     x = DimArray(fill(3), ())
     y = DimArray(fill(4), ())
+    z = fill(3)
     @test @inferred(x .- y) === -1
     @test !(x ≈ y)
     @test x ≈ x
+    @test @inferred(x .+ z) === 6
+    @test @inferred(z .+ x) === 6
 end
 
 # @testset "Competing Wrappers" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -137,6 +137,13 @@ end
 
     @test_throws DimensionMismatch broadcast_dims!(+, db1, zeros(Z(3)))
     @test broadcast_dims(+, db1, ones(Z(3))) == [2.0 2.0 2.0; 3.0 3.0 3.0; 4.0 4.0 4.0]
+
+    @testset "works with 0-dimensional arrays" begin
+        da4 = DimArray(fill(4), ())
+        @test broadcast_dims(+, da4, da4) == DimArray(fill(8), ())
+        @test broadcast_dims(*, da4, da3) == parent(da4) .* parent(da3)
+        @test dims(broadcast_dims(*, da4, da3)) == dims(da3)
+    end
 end
 
 @testset "shiftlocus" begin
@@ -196,7 +203,7 @@ end
                                                         3.5 2.5 1.5]
     end
     @testset "Explicit span" begin
-        dim = X(Sampled(1.0:3.0, ForwardOrdered(), 
+        dim = X(Sampled(1.0:3.0, ForwardOrdered(),
                 Explicit([0.0 1.0 2.0; 1.0 2.0 3.0]), Intervals(End()), NoMetadata()))
         @test Dimensions.dim2boundsmatrix(dim) == [0.0 1.0 2.0
                                                         1.0 2.0 3.0]


### PR DESCRIPTION
This PR fixes #421 by enabling broadcast and `broadcast_dims` for 0-dimensional `DimArray`s.