### PR TITLE
allow zero dimensional arrays in tables

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -35,7 +35,7 @@ include("Dimensions/Dimensions.jl")
 
 using .Dimensions
 using .Dimensions.LookupArrays
-using .Dimensions: StandardIndices, DimOrDimType, DimTuple, DimType, AllDims
+using .Dimensions: StandardIndices, DimOrDimType, DimTuple, DimTupleOrEmpty, DimType, AllDims
 import .LookupArrays: metadata, set, _set, rebuild, basetypeof, 
     order, span, sampling, locus, val, index, bounds, hasselection, units, SelectorOrInterval
 import .Dimensions: dims, refdims, name, lookup, dimstride, kwdims, hasdim, label, _astuple

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -76,7 +76,7 @@ struct DimArrayColumn{T,A<:AbstractDimArray{T},DS,DL,L} <: AbstractVector{T}
     dimlengths::DL
     length::L
 end
-function DimArrayColumn(A::AbstractDimArray{T}, alldims::DimTuple) where T
+function DimArrayColumn(A::AbstractDimArray{T}, alldims::DimTupleOrEmpty) where T
     # This is the apparent stride for indexing purposes,
     # it is not always the real array stride
     dimstrides = map(d -> dimstride(alldims, d), dims(A))

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -132,3 +132,11 @@ end
     @test dims(ds) == dims(da)
     @test lookup(ds) == lookup(dims(da))
 end
+
+@testset "zero dimension tables" begin
+    a = DimArray(fill(1), (); name=:a);
+    b = DimArray(fill(2), (); name=:b);
+    ds = DimStack((a, b))
+    @test Tables.columntable(a) == (a = [1],)
+    @test Tables.columntable(ds) == (a = [1], b = [2])
+end


### PR DESCRIPTION
Fixes #424

@sethaxen this just uses your `DimTupleOrEmpty` union instead of `DimTuple` as a type check. There may be a few more places that need this treatment.

Sorry you're hitting all of these at once, and thanks for the clear issues. 