### PR TITLE
check dim length in inner constructor

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -347,11 +347,12 @@ function DimArray(f::Function, dim::Dimension; name=Symbol(nameof(f), "(", name(
      DimArray(f.(val(dim)), (dim,); name)
 end
 
-checkdims(A::AbstractArray{<:Any,N}, dims::Tuple) where N =
-    length(dims) == N || _dimlengtherror(N, length(dims))
+checkdims(A::AbstractArray{<:Any,N}, dims::Tuple) where N = checkdims(N, dims)
+checkdims(::Type{<:AbstractArray{<:Any,N}}, dims::Tuple) where N = checkdims(N, dims)
+checkdims(n::Integer, dims::Tuple) = length(dims) == n || _dimlengtherror(n, length(dims))
 
 @noinline _dimlengtherror(na, nd) =
-    throw(ArgumentError("dimensions of the array ($na) do not match number of dimensions ($nd)")) 
+    throw(ArgumentError("axes of the array ($na) do not match number of dimensions ($nd)")) 
 
 """
     rebuild(A::DimArray, data, dims, refdims, name, metadata) => DimArray

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -315,7 +315,7 @@ struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDi
     function DimArray(
         data::A, dims::D, refdims::R, name::Na, metadata::Me
     ) where {D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} where {T,N}
-        checkdims(A, dims)
+        checkdims(data, dims)
         new{T,N,D,R,A,Na,Me}(data, dims, refdims, name, metadata)
     end
 end

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -314,7 +314,7 @@ struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDi
     metadata::Me
     function DimArray(
         data::A, dims::D, refdims::R, name::Na, metadata::Me
-    ) where {D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me,Mi} where {T,N}
+    ) where {D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} where {T,N}
         checkdims(A, dims)
         new{T,N,D,R,A,Na,Me}(data, dims, refdims, name, metadata)
     end

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -312,6 +312,12 @@ struct DimArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me} <: AbstractDi
     refdims::R
     name::Na
     metadata::Me
+    function DimArray(
+        data::A, dims::D, refdims::R, name::Na, metadata::Me
+    ) where {D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me,Mi} where {T,N}
+        checkdims(A, dims)
+        new{T,N,D,R,A,Na,Me}(data, dims, refdims, name, metadata)
+    end
 end
 # 2 arg version
 DimArray(data::AbstractArray, dims; kw...) = DimArray(data, (dims,); kw...)
@@ -340,6 +346,11 @@ the given dimension. Optionally provide a name for the result.
 function DimArray(f::Function, dim::Dimension; name=Symbol(nameof(f), "(", name(dim), ")"))
      DimArray(f.(val(dim)), (dim,); name)
 end
+
+checkdims(A, dims) = length(dims) == ndims(A) || _dimlengtherror(ndims(A), length(dims))
+
+@noinline _dimlengtherror(na, nd) =
+    throw(ArgumentError("dimensions of the array ($na) do not match number of dimensions ($nd)")) 
 
 """
     rebuild(A::DimArray, data, dims, refdims, name, metadata) => DimArray

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -347,7 +347,8 @@ function DimArray(f::Function, dim::Dimension; name=Symbol(nameof(f), "(", name(
      DimArray(f.(val(dim)), (dim,); name)
 end
 
-checkdims(A, dims) = length(dims) == ndims(A) || _dimlengtherror(ndims(A), length(dims))
+checkdims(A::AbstractArray{<:Any,N}, dims::Tuple) where N =
+    length(dims) == N || _dimlengtherror(N, length(dims))
 
 @noinline _dimlengtherror(na, nd) =
     throw(ArgumentError("dimensions of the array ($na) do not match number of dimensions ($nd)")) 

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -60,7 +60,7 @@ The generator has `size` and `axes` equivalent to those of the provided `dims`.
 
 # Examples
 
-```jldoctest; filter = r"┌ Warning.*\n.*"
+```jldoctest; filter = r"┌ Warning.*\\n.*"
 julia> ds = DimStack((
            x=DimArray(randn(2, 3, 4), (X([:x1, :x2]), Y(1:3), Z)),
            y=DimArray(randn(2, 3, 5), (X([:x1, :x2]), Y(1:3), Ti))

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -76,8 +76,6 @@ Z,
 X Categorical{Symbol} Symbol[x1, x2] ForwardOrdered
 
 julia> first(slices)
-┌ Warning: (Z,) dims were not found in object
-└ @ DimensionalData.Dimensions
 DimStack with dimensions:
   Y Sampled{Int64} 1:3 ForwardOrdered Regular Points,
   Ti

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -60,7 +60,7 @@ The generator has `size` and `axes` equivalent to those of the provided `dims`.
 
 # Examples
 
-```jldoctest; filter = r"┌ Warning.*\\n.*"
+```julia
 julia> ds = DimStack((
            x=DimArray(randn(2, 3, 4), (X([:x1, :x2]), Y(1:3), Z)),
            y=DimArray(randn(2, 3, 5), (X([:x1, :x2]), Y(1:3), Ti))

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -60,7 +60,7 @@ The generator has `size` and `axes` equivalent to those of the provided `dims`.
 
 # Examples
 
-```jldoctest; filter = r"┌ Warning:.*\\n.*"
+```jldoctest; filter = r"┌ Warning.*\n.*"
 julia> ds = DimStack((
            x=DimArray(randn(2, 3, 4), (X([:x1, :x2]), Y(1:3), Z)),
            y=DimArray(randn(2, 3, 5), (X([:x1, :x2]), Y(1:3), Ti))

--- a/test/array.jl
+++ b/test/array.jl
@@ -28,6 +28,12 @@ da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
     @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
 end
 
+@testset "rebuild" begin
+    @test rebuild(da2, parent(da2)) === da2
+    @test rebuild(da2; dims=dims(da2)) === da2
+    @test_throws ArgumentError rebuild(da2; dims=dims(da2, (Y,))) === da2
+end
+
 @testset "size and axes" begin
     row_dims = (1, Dim{:row}(), Dim{:row}, :row, dimz2[1])
     for dim in row_dims

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,5 +1,5 @@
 using DimensionalData, Test, Unitful, SparseArrays, Dates, Random
-using DimensionalData: layerdims
+using DimensionalData: layerdims, checkdims
 
 using DimensionalData.LookupArrays, DimensionalData.Dimensions
 
@@ -26,6 +26,13 @@ da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
     checkbounds(da, X(2), Y(1))
     @test_throws BoundsError checkbounds(da, X(10), Y(20))
     @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
+end
+
+@testset "checkdims" begin
+    @test checkdims(da2, dimz2)
+    @test checkdims(typeof(da2), dimz2)
+    @test checkdims(2, dimz2)
+    @test_throws ArgumentError checkdims(3, dimz2)
 end
 
 @testset "rebuild" begin


### PR DESCRIPTION
We need a check besides `format` for dim length that catches errors in `rebuild`. This should be a compile-time check.

Slightly annoying is that an inner constuctor like this needs to be added for all types that extend `AbstractDimArray`. It would be best if we could embed this in the abstract type so `N` has to match the length of the dims tuple... but that's only possible with `NTuple`, which isn't what we have.