### PR TITLE
Add vcat and hcat for AbstractDimArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.24.2"
+version = "0.24.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -226,18 +226,19 @@ function Base._cat(catdim::DimOrDimType, Xin::AbstractDimArray...)
 end
 
 function Base.vcat(As::Union{AbstractDimVector,AbstractDimMatrix}...)
-    A1 = first(As)
-    catdim = vcat(map(Base.Fix2(dims, 1), As)...)
-    newdims = (catdim, otherdims(dims(A1), catdim)...)
-    newA = vcat(map(parent, As)...)
-    rebuild(A1, newA, format(newdims, newA))
+    return _horvcat(Base.splat(vcat), As, Val(1))
 end
 
 function Base.hcat(As::AbstractDimMatrix...)
+    return _horvcat(Base.splat(hcat), As, Val(2))
+end
+
+function _horvcat(f, As, ::Val{I}) where {I}
     A1 = first(As)
-    catdim = vcat(map(Base.Fix2(dims, 2), As)...)
-    newdims = (otherdims(dims(A1), catdim)..., catdim)
-    newA = hcat(map(parent, As)...)
+    catdim = vcat(map(Base.Fix2(dims, I), As)...)
+    noncatdim = only(otherdims(dims(A1), catdim))
+    newdims = Base.setindex((noncatdim, noncatdim), catdim, I)
+    newA = f(map(parent, As))
     rebuild(A1, newA, format(newdims, newA))
 end
 

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -225,6 +225,22 @@ function Base._cat(catdim::DimOrDimType, Xin::AbstractDimArray...)
     Base._cat((catdim,), Xin...)
 end
 
+function Base.vcat(As::Union{AbstractDimVector,AbstractDimMatrix}...)
+    A1 = first(As)
+    catdim = vcat(map(Base.Fix2(dims, 1), As)...)
+    newdims = (catdim, otherdims(dims(A1), catdim)...)
+    newA = vcat(map(parent, As)...)
+    rebuild(A1, newA, format(newdims, newA))
+end
+
+function Base.hcat(As::AbstractDimMatrix...)
+    A1 = first(As)
+    catdim = vcat(map(Base.Fix2(dims, 2), As)...)
+    newdims = (otherdims(dims(A1), catdim)..., catdim)
+    newA = hcat(map(parent, As)...)
+    rebuild(A1, newA, format(newdims, newA))
+end
+
 function Base.vcat(d1::Dimension, ds::Dimension...)
     newlookup = _vcat_lookups(lookup((d1, ds...))...)
     rebuild(d1, newlookup)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -337,6 +337,32 @@ end
     end
 end
 
+@testset "vcat" begin
+    a = [1 2 3; 4 5 6]
+    da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
+    b = [7 8 9; 10 11 12]
+    db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
+    c = [13 14 15; 16 17 18]
+    dc = DimArray(c, (X(8.0:9.0), Y(6.0:8.0)))
+
+    @test @inferred(vcat(da)) == da
+    @test @inferred(vcat(da, db)) == cat(da, db; dims=1)
+    @test @inferred(vcat(da, db, dc)) == cat(da, db, dc; dims=1)
+end
+
+@testset "hcat" begin
+    a = [1 2 3; 4 5 6]
+    da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
+    b = [7 8 9; 10 11 12]
+    db = DimArray(b, (X(4.0:5.0), Y(9.0:11.0)))
+    c = [13 14 15; 16 17 18]
+    dc = DimArray(c, (X(4.0:5.0), Y(12.0:14.0)))
+
+    @test @inferred(hcat(da)) == da
+    @test @inferred(hcat(da, db)) == cat(da, db; dims=2)
+    @test @inferred(hcat(da, db, dc)) == cat(da, db, dc; dims=2)
+end
+
 @testset "unique" begin
     a = [1 1 6; 1 1 6]
     xs = (X, X(), :X)


### PR DESCRIPTION
`hcat` is only implemented for `AbstractDimMatrix`, because otherwise the 2nd column lacks the necessary dimension information.

Fixes #453 