### PR TITLE
Build docs on latest Julia release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,15 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        version: ['1.6', '1']
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: ${{ matrix.version }}
       - run: |
           julia --project=docs -e '
             using Pkg
@@ -49,4 +53,5 @@ jobs:
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_DOCS: ${{ matrix.version == '1' }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ using Documenter, DimensionalData, CoordinateTransformations, Dates, Unitful
 using DimensionalData.LookupArrays, DimensionalData.Dimensions
 
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
+DEPLOY_DOCS = get(ENV, "DEPLOY_DOCS", "$CI") == "true"
 
 docsetup = quote 
     using DimensionalData, Random, Dates
@@ -27,7 +28,7 @@ makedocs(
     strict=true,
 )
 
-if CI
+if DEPLOY_DOCS
     deploydocs(
         repo = "github.com/rafaqz/DimensionalData.jl.git",
         target = "build",


### PR DESCRIPTION
Currently the docs are being built on the LTS. This PR changes to build the docs for the latest Julia release.