### PR TITLE
Fix accidental piracy on empty `map`

### DIFF
--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -47,10 +47,10 @@ Apply function `f` to each layer of the `stacks`.
 If `f` returns `DimArray`s the result will be another `DimStack`.
 Other values will be returned in a `NamedTuple`.
 """
-Base.map(f, s1::AbstractDimStack, s::AbstractDimStack...) = 
-    _maybestack(s[1], map(f, map(NamedTuple, (s1, s...))...))
-Base.map(f, s::Union{AbstractDimStack,NamedTuple}...) =
-    _maybestack(_firststack(s...), map(f, map(NamedTuple, s)...))
+function Base.map(f, s1::Union{AbstractDimStack,NamedTuple}, s::Union{AbstractDimStack,NamedTuple}...)
+    results = map(f, map(NamedTuple, (s1, s...)...))
+    return _maybestack(_firststack(stacks), results)
+end
 
 _maybestack(s::AbstractDimStack, x::NamedTuple) = x
 function _maybestack(

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -47,8 +47,10 @@ Apply function `f` to each layer of the `stacks`.
 If `f` returns `DimArray`s the result will be another `DimStack`.
 Other values will be returned in a `NamedTuple`.
 """
-Base.map(f, s::AbstractDimStack...) = _maybestack(s[1], map(f, map(NamedTuple, s)...))
-Base.map(f, s::Union{AbstractDimStack,NamedTuple}...) = _maybestack(_firststack(s...), map(f, map(NamedTuple, s)...))
+Base.map(f, s1::AbstractDimStack, s::AbstractDimStack...) = 
+    _maybestack(s[1], map(f, map(NamedTuple, (s1, s...))...))
+Base.map(f, s::Union{AbstractDimStack,NamedTuple}...) =
+    _maybestack(_firststack(s...), map(f, map(NamedTuple, s)...))
 
 _maybestack(s::AbstractDimStack, x::NamedTuple) = x
 function _maybestack(


### PR DESCRIPTION
Although maybe the `Union{AbstracDimStack,NamedTuple}` is also technically type piracy?

@sethaxen what do you think? Base has a more specific method:

https://github.com/JuliaLang/julia/blob/a4d6ddd640a87a4e2ade90b258c040bb37010ead/base/namedtuple.jl#L261-L266

The alternative is to just write out the first three or four positions with `AbstractDimStack` in them and ignore the rest, but it feels hacky.

I wish there was a traits interface for choosing what `map` outputs, when you don't want it to be a Vector