### PR TITLE
Improve performance of At for Regular Ordered lookup array

### DIFF
--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -126,7 +126,7 @@ function at(
     x = unwrap(selval)
     i = searchsortedlast(lookup, x)
     # Try the current index
-    if i == firstindex(lookup)
+    if i == firstindex(lookup) - 1
         i1 = i + 1
         if checkbounds(Bool, lookup, i1) && _is_at(x, lookup[i1], atol)
             return i1

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -112,7 +112,7 @@ function at(
     x = unwrap(selval)
     Δ = step(span)
     i, remainder = divrem(x - first(lookup), Δ)
-    i += 1
+    i += firstindex(lookup)
     if remainder == 0 && checkbounds(Bool, lookup, i)
         return i
     else
@@ -126,7 +126,7 @@ function at(
     x = unwrap(selval)
     i = searchsortedlast(lookup, x)
     # Try the current index
-    if i == 0
+    if i == firstindex(lookup)
         i1 = i + 1
         if checkbounds(Bool, lookup, i1) && _is_at(x, lookup[i1], atol)
             return i1

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -106,7 +106,7 @@ function at(lookup::LookupArray, sel::At; kw...)
     at(order(lookup), span(lookup), lookup, val(sel), atol(sel), rtol(sel); kw...)
 end
 function at(
-    ::Ordered, span::Regular, lookup::LookupArray{<:Union{Integer,Dates.TimeType}}, selval, atol::Nothing, rtol::Nothing;
+    ::Ordered, span::Regular, lookup::LookupArray{<:Integer}, selval, atol::Nothing, rtol::Nothing;
     err=_True()
 )
     x = unwrap(selval)

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -1,4 +1,5 @@
 using OffsetArrays, ImageFiltering, ImageTransformations, ArrayInterfaceCore, DimensionalData, Test
+using DimensionalData.LookupArrays
 
 @testset "ArrayInterface" begin
     a = [1 2; 3 4]
@@ -24,6 +25,13 @@ end
         @test oda[Near(105), At(:a)] == oa[-1, 5] == 1
         @test oda[At(200), At(:a)] == oa[0, 5] == 3
         @test oda[Between(100, 250), At(:a)] == oa[-1:0, 5] == [1, 3]
+    end
+    @testset "And when sampling is Regular" begin
+        odimz_r = (X(OffsetArray(100:100:300, -1:1); span=Regular(100)), Y(OffsetArray([1.0, 2.0, 3.0, 4.0], 5:8); span=Regular(1)))
+        oda_r = DimArray(oa, odimz_r)
+        @test oda_r[At(100), At(1.0)] == oa[-1, 5] == 1
+        @test oda_r[At(200), At(3.0)] == oa[0, 7] == 5
+        @test oda_r[Between(100, 250), At(1)] == oa[-1:0, 5] == [1, 3]
     end
     @testset "Subsetting reverts to a regular array and dims" begin
         @test axes(oda[0:1, 7:8]) == (1:2, 1:2)

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -22,6 +22,7 @@ end
         @test axes(oda) == (-1:1, 5:8)
         @test oda[-1, 5] == oa[-1, 5] == 1
         @test oda[Near(105), At(:a)] == oa[-1, 5] == 1
+        @test oda[At(200), At(:a)] == oa[0, 5] == 3
         @test oda[Between(100, 250), At(:a)] == oa[-1:0, 5] == [1, 3]
     end
     @testset "Subsetting reverts to a regular array and dims" begin


### PR DESCRIPTION
Improve performance of At for Regular Ordered lookup array by using step information directly.

```julia
julia> using BenchmarkTools, DimensionalData

julia> A = DimArray([1,2,3,4,5], X(3:7))
5-element DimArray{Int64,1} with dimensions:
  X Sampled{Int64} 3:7 ForwardOrdered Regular Points
 3  1
 4  2
 5  3
 6  4
 7  5

# master
julia> @btime $A[X=At(7)]
  4.500 ns (0 allocations: 0 bytes)
5

# this PR
julia> @btime $A[X=At(7)]          
  3.100 ns (0 allocations: 0 bytes)
5

# Reference
julia> @btime $A[X=5]
  2.600 ns (0 allocations: 0 bytes)
5                                  
```