### PR TITLE
Remove deprecated Vararg usage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.24.4"
+version = "0.24.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -143,9 +143,9 @@ ConstructionBase.constructorof(d::Type{<:Dimension}) = basetypeof(d)
 Adapt.adapt_structure(to, dim::Dimension) = rebuild(dim; val=Adapt.adapt(to, val(dim)))
 
 const DimType = Type{<:Dimension}
-const DimTuple = Tuple{<:Dimension,Vararg{<:Dimension}}
+const DimTuple = Tuple{Dimension,Vararg{Dimension}}
 const SymbolTuple = Tuple{Symbol,Vararg{Symbol}}
-const DimTypeTuple = Tuple{<:DimType,Vararg{<:DimType}}
+const DimTypeTuple = Tuple{DimType,Vararg{DimType}}
 const VectorOfDim = Vector{<:Union{Dimension,DimType,Symbol}}
 const DimOrDimType = Union{Dimension,DimType,Symbol}
 const AllDims = Union{Symbol,Dimension,DimTuple,SymbolTuple,DimType,DimTypeTuple,VectorOfDim}

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -3,7 +3,7 @@
 # `format` is called on its dimensions
 
 """
-    format(dims, x) => Tuple{Vararg{<:Dimension,N}}
+    format(dims, x) => Tuple{Vararg{Dimension,N}}
 
 Format the passed-in dimension(s) `dims` to match the object `x`.
 
@@ -20,11 +20,11 @@ function format(dims::NamedTuple, A::AbstractArray)
     end
     return format(dims, axes(A))
 end
-format(dims::Tuple{Vararg{<:Any,N}}, A::AbstractArray{<:Any,N}) where N =
+format(dims::Tuple{Vararg{Any,N}}, A::AbstractArray{<:Any,N}) where N =
     format(dims, axes(A))
-@noinline format(dims::Tuple{Vararg{<:Any,M}}, A::AbstractArray{<:Any,N}) where {N,M} =
+@noinline format(dims::Tuple{Vararg{Any,M}}, A::AbstractArray{<:Any,N}) where {N,M} =
     throw(DimensionMismatch("Array A has $N axes, while the number of dims is $M: $(map(basetypeof, dims))"))
-format(dims::Tuple{Vararg{<:Any,N}}, axes::Tuple{Vararg{<:Any,N}}) where N = map(_format, dims, axes)
+format(dims::Tuple{Vararg{Any,N}}, axes::Tuple{Vararg{Any,N}}) where N = map(_format, dims, axes)
 
 _format(dimname::Symbol, axis::AbstractRange) = Dim{dimname}(NoLookup(axes(axis, 1)))
 _format(::Type{D}, axis::AbstractRange) where D<:Dimension = D(NoLookup(axes(axis, 1)))

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -36,7 +36,7 @@ Convert a `Dimension` or `Selector` `I` to indices of `Int`, `AbstractArray` or 
 @inline dims2indices(::Tuple{}, I) = ()
 @inline dims2indices(dims::DimTuple, I) = dims2indices(dims, (I,))
 # Standard array indices are simply returned
-@inline dims2indices(dims::DimTuple, I::Tuple{Vararg{<:StandardIndices}}) = I
+@inline dims2indices(dims::DimTuple, I::Tuple{Vararg{StandardIndices}}) = I
 @inline dims2indices(dims::DimTuple, I::Tuple{<:Extents.Extent}) = dims2indices(dims, _extent_as_intervals(first(I)))
 @inline dims2indices(dims::DimTuple, I::Tuple{<:Touches{<:Extents.Extent}}) = dims2indices(dims, _extent_as_touches(val(first(I))))
 
@@ -95,7 +95,7 @@ end
         isnothing(s) ? Colon() : s
     end
 end
-@inline function unalligned_dims2indices(dims::DimTuple, sel::Tuple{<:Selector,Vararg{<:Selector}})
+@inline function unalligned_dims2indices(dims::DimTuple, sel::Tuple{Selector,Vararg{Selector}})
     LookupArrays.select_unalligned_indices(lookup(dims), sel)
 end
 

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -107,8 +107,8 @@ can be used in `order`.
 end
 
 """
-    dims(x, query) => Tuple{Vararg{<:Dimension}}
-    dims(x, query...) => Tuple{Vararg{<:Dimension}}
+    dims(x, query) => Tuple{Vararg{Dimension}}
+    dims(x, query...) => Tuple{Vararg{Dimension}}
 
 Get the dimension(s) matching the type(s) of the query dimension.
 
@@ -140,7 +140,7 @@ X, Y
 @inline _dims(f, dims, query) = _remove_nothing(_sortdims(f, dims, query))
 
 """
-    commondims([f], x, query) => Tuple{Vararg{<:Dimension}}
+    commondims([f], x, query) => Tuple{Vararg{Dimension}}
 
 This is basically `dims(x, query)` where the order of the original is kept,
 unlike [`dims`](@ref) where the query tuple determines the order
@@ -251,7 +251,7 @@ false
     map(l -> l in eachindex(dims), query)
 
 """
-    otherdims(x, query) => Tuple{Vararg{<:Dimension,N}}
+    otherdims(x, query) => Tuple{Vararg{Dimension,N}}
 
 Get the dimensions of an object _not_ in `query`.
 
@@ -292,7 +292,7 @@ _rev_op(::typeof(>:)) = <:
 
 """
     setdims(X, newdims) => AbstractArray
-    setdims(::Tuple, newdims) => Tuple{Vararg{<:Dimension,N}}
+    setdims(::Tuple, newdims) => Tuple{Vararg{Dimension,N}}
 
 Replaces the first dim matching `<: basetypeof(newdim)` with newdim,
 and returns a new object or tuple with the dimension updated.
@@ -322,7 +322,7 @@ wrapping: 'a':1:'j'
 
 """
     swapdims(x::T, newdims) => T
-    swapdims(dims::Tuple, newdims) => Tuple{Vararg{<:Dimension}}
+    swapdims(dims::Tuple, newdims) => Tuple{Vararg{Dimension}}
 
 Swap dimensions for the passed in dimensions, in the
 order passed.
@@ -438,7 +438,7 @@ function sliceunalligneddims(f, uI, udims...)
 end
 
 """
-    reducedims(x, dimstoreduce) => Tuple{Vararg{<:Dimension}}
+    reducedims(x, dimstoreduce) => Tuple{Vararg{Dimension}}
 
 Replace the specified dimensions with an index of length 1.
 This is usually to match a new array size where an axis has been
@@ -490,7 +490,7 @@ These are all `Bool` flags:
 function comparedims end
 @inline comparedims(x...; kw...) = comparedims(x; kw...)
 @inline comparedims(A::Tuple; kw...) = comparedims(map(dims, A)...; kw...)
-@inline comparedims(dims::Vararg{<:Tuple{Vararg{<:Dimension}}}; kw...) =
+@inline comparedims(dims::Vararg{Tuple{Vararg{Dimension}}}; kw...) =
     map(d -> comparedims(first(dims), d), dims; kw...) |> first
 
 @inline comparedims(a::DimTupleOrEmpty, ::Nothing; kw...) = a

--- a/src/Dimensions/set.jl
+++ b/src/Dimensions/set.jl
@@ -4,8 +4,8 @@ set(dim::Dimension, x::DimSetters) = _set(dim, x)
 # Convert args/kw to dims and set
 _set(dims_::DimTuple, args::Dimension...; kw...) = _set(dims_, (args..., kwdims(kw)...))
 # Convert pairs to wrapped dims and set
-_set(dims_::DimTuple, p::Pair, ps::Vararg{<:Pair}) = _set(dims_, (p, ps...))
-_set(dims_::DimTuple, ps::Tuple{Vararg{<:Pair}}) = _set(dims_, pairdims(ps...))
+_set(dims_::DimTuple, p::Pair, ps::Vararg{Pair}) = _set(dims_, (p, ps...))
+_set(dims_::DimTuple, ps::Tuple{Vararg{Pair}}) = _set(dims_, pairdims(ps...))
 # Set dims with (possibly unsorted) wrapper vals
 _set(dims::DimTuple, wrappers::DimTuple) = begin
     # Check the dimension types match

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -12,7 +12,7 @@ or a [`Sampled`](@ref) index for [`Points`](@ref) or [`Intervals`](@ref).
 abstract type LookupArray{T,N} <: AbstractArray{T,N} end
 
 
-const LookupArrayTuple = Tuple{<:LookupArray,Vararg{<:LookupArray}}
+const LookupArrayTuple = Tuple{LookupArray,Vararg{LookupArray}}
 
 span(lookup::LookupArray) = NoSpan() 
 sampling(lookup::LookupArray) = NoSampling()

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -40,7 +40,7 @@ abstract type ArraySelector{T} <: Selector{T} end
 
 const SelectorOrInterval = Union{Selector,Interval}
 
-const SelTuple = Tuple{<:SelectorOrInterval,Vararg{<:SelectorOrInterval}}
+const SelTuple = Tuple{SelectorOrInterval,Vararg{SelectorOrInterval}}
 
 """
     At <: IntSelector
@@ -871,7 +871,7 @@ A[X=All(At(10.0), At(50.0)), Ti=All(1u"s"..10u"s", 90u"s"..100u"s")]
  50.0    3    6    57    60
 ```
 """
-struct All{S<:Tuple{Vararg{<:SelectorOrInterval}}} <: Selector{S}
+struct All{S<:Tuple{Vararg{SelectorOrInterval}}} <: Selector{S}
     selectors::S
 end
 All(args::SelectorOrInterval...) = All(args)
@@ -912,11 +912,11 @@ end
 
 # We use the transformation from the first unalligned dim.
 # In practice the others could be empty.
-function select_unalligned_indices(lookups::LookupArrayTuple, sel::Tuple{<:IntSelector,Vararg{<:IntSelector}})
+function select_unalligned_indices(lookups::LookupArrayTuple, sel::Tuple{IntSelector,Vararg{IntSelector}})
     transformed = transformfunc(lookups[1])(map(val, sel))
     map(_transform2int, lookups, sel, transformed)
 end
-function select_unalligned_indices(lookups::LookupArrayTuple, sel::Tuple{<:Selector,Vararg{<:Selector}})
+function select_unalligned_indices(lookups::LookupArrayTuple, sel::Tuple{Selector,Vararg{Selector}})
     throw(ArgumentError("only `Near`, `At` or `Contains` selectors currently work on `Unalligned` lookups"))
 end
 

--- a/src/LookupArrays/show.jl
+++ b/src/LookupArrays/show.jl
@@ -37,7 +37,7 @@ function show_properties(io::IO, lookup::AbstractCategorical)
     print_order(io, lookup)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", lookups::Tuple{<:LookupArray,Vararg{<:LookupArray}})
+function Base.show(io::IO, mime::MIME"text/plain", lookups::Tuple{LookupArray,Vararg{LookupArray}})
     length(lookups) > 0 || return 0
     ctx = IOContext(io, :compact=>true)
     if all(l -> l isa NoLookup, lookups)

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -119,11 +119,11 @@ Base.similar(A::AbstractDimArray, ::Type{T}) where T =
 # An alternative would be to fill missing dims with `Anon`, and keep existing
 # dims but strip the Lookup? It just seems a little complicated when the methods
 # below using DimTuple work better anyway.
-Base.similar(A::AbstractDimArray, i::Integer, I::Vararg{<:Integer}) =
+Base.similar(A::AbstractDimArray, i::Integer, I::Vararg{Integer}) =
     similar(A, eltype(A), (i, I...))
 Base.similar(A::AbstractDimArray, I::Tuple{Int,Vararg{Int}}) = 
     similar(A, eltype(A), I)
-Base.similar(A::AbstractDimArray, ::Type{T}, i::Integer, I::Vararg{<:Integer}) where T =
+Base.similar(A::AbstractDimArray, ::Type{T}, i::Integer, I::Vararg{Integer}) where T =
     similar(A, T, (i, I...))
 Base.similar(A::AbstractDimArray, ::Type{T}, I::Tuple{Int,Vararg{Int}}) where T =
     similar(parent(A), T, I)
@@ -299,7 +299,7 @@ end
 
 """
     Base.fill(x, dims::Dimension...; kw...) => DimArray
-    Base.fill(x, dims::Tuple{Vararg{<:Dimension}}; kw...) => DimArray
+    Base.fill(x, dims::Tuple{Vararg{Dimension}}; kw...) => DimArray
 
 Create a [`DimArray`](@ref) with a fill value of `x`.
 
@@ -325,8 +325,8 @@ Base.fill
 
 """
     Base.rand(x, dims::Dimension...; kw...) => DimArray
-    Base.rand(x, dims::Tuple{Vararg{<:Dimension}}; kw...) => DimArray
-    Base.rand(r::AbstractRNG, x, dims::Tuple{Vararg{<:Dimension}}; kw...) => DimArray
+    Base.rand(x, dims::Tuple{Vararg{Dimension}}; kw...) => DimArray
+    Base.rand(r::AbstractRNG, x, dims::Tuple{Vararg{Dimension}}; kw...) => DimArray
     Base.rand(r::AbstractRNG, x, dims::Dimension...; kw...) => DimArray
 
 Create a [`DimArray`](@ref) of random values.

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -40,10 +40,10 @@ This can be used to view/index into arbitrary dimensions over an array, and
 is especially useful when combined with `otherdims`, to iterate over the
 indices of unknown dimension.
 """
-struct DimIndices{T,N,D<:Tuple{Vararg{<:Dimension}}} <: AbstractDimIndices{T,N}
+struct DimIndices{T,N,D<:Tuple{Vararg{Dimension}}} <: AbstractDimIndices{T,N}
     dims::D
 end
-function DimIndices(dims::D) where {D<:Tuple{Vararg{<:Dimension}}}
+function DimIndices(dims::D) where {D<:Tuple{Vararg{Dimension}}}
     T = typeof(map(d -> rebuild(d, 1), dims))
     N = length(dims)
     dims = N > 0 ? _format(dims) : dims
@@ -119,7 +119,7 @@ Like `CartesianIndices`, but for the lookup values of Dimensions. Behaves as an
 `Array` of `Tuple` of `Dimension(At(lookupvalue))` for all combinations of the
 lookup values of `dims`.
 """
-struct DimKeys{T,N,D<:Tuple{<:Dimension,Vararg{<:Dimension}},S} <: AbstractDimIndices{T,N}
+struct DimKeys{T,N,D<:Tuple{Dimension,Vararg{Dimension}},S} <: AbstractDimIndices{T,N}
     dims::D
     selectors::S
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -24,7 +24,7 @@ The arguments required are defined for the abstract type that has a `rebuild` me
 function rebuild end
 
 """
-    dims(x, [dims::Tuple]) => Tuple{Vararg{<:Dimension}}
+    dims(x, [dims::Tuple]) => Tuple{Vararg{Dimension}}
     dims(x, dim) => Dimension
 
 Return a tuple of `Dimension`s for an object, in the order that matches
@@ -37,7 +37,7 @@ The default is to return `nothing`.
 function dims end
 
 """
-    refdims(x, [dims::Tuple]) => Tuple{Vararg{<:Dimension}}
+    refdims(x, [dims::Tuple]) => Tuple{Vararg{Dimension}}
     refdims(x, dim) => Dimension
 
 Reference dimensions for an array that is a slice or view of another
@@ -73,9 +73,9 @@ function val end
 # Dimension.
 
 """
-    index(x) => Tuple{Vararg{<:AbstractArray}}
-    index(x, dims::Tuple) => Tuple{Vararg{<:AbstractArray}}
-    index(dims::Tuple) => Tuple{Vararg{<:AbstractArray}}}
+    index(x) => Tuple{Vararg{AbstractArray}}
+    index(x, dims::Tuple) => Tuple{Vararg{AbstractArray}}
+    index(dims::Tuple) => Tuple{Vararg{AbstractArray}}}
     index(x, dim) => AbstractArray
     index(dim::Dimension) => AbstractArray
 
@@ -91,8 +91,8 @@ function index end
 
 """
     lookup(x::Dimension) => LookupArray
-    lookup(x, [dims::Tuple]) => Tuple{Vararg{<:LookupArray}}
-    lookup(x::Tuple) => Tuple{Vararg{<:LookupArray}}
+    lookup(x, [dims::Tuple]) => Tuple{Vararg{LookupArray}}
+    lookup(x::Tuple) => Tuple{Vararg{LookupArray}}
     lookup(x, dim) => LookupArray
 
 Returns the [`LookupArray`](@ref) of a dimension. This dictates
@@ -160,8 +160,8 @@ or `Symbols` for `Dim{Symbol}`.
 function label end
 
 """
-    bounds(xs, [dims::Tuple]) => Tuple{Vararg{<:Tuple{T,T}}}
-    bounds(xs::Tuple) => Tuple{Vararg{<:Tuple{T,T}}}
+    bounds(xs, [dims::Tuple]) => Tuple{Vararg{Tuple{T,T}}}
+    bounds(xs::Tuple) => Tuple{Vararg{Tuple{T,T}}}
     bounds(x, dim) => Tuple{T,T}
     bounds(dim::Union{Dimension,LookupArray}) => Tuple{T,T}
 
@@ -188,7 +188,7 @@ function order end
 """
     sampling(x, [dims::Tuple]) => Tuple
     sampling(x, dim) => Sampling
-    sampling(xs::Tuple) => Tuple{Vararg{<:Sampling}}
+    sampling(xs::Tuple) => Tuple{Vararg{Sampling}}
     sampling(x:Union{Dimension,LookupArray}) => Sampling
 
 Return the [`Sampling`](@ref) for each dimension.
@@ -201,7 +201,7 @@ function sampling end
 """
     span(x, [dims::Tuple]) => Tuple
     span(x, dim) => Span
-    span(xs::Tuple) => Tuple{Vararg{<:Span,N}}
+    span(xs::Tuple) => Tuple{Vararg{Span,N}}
     span(x::Union{Dimension,LookupArray}) => Span
 
 Return the [`Span`](@ref) for each dimension.
@@ -214,7 +214,7 @@ function span end
 """
     locus(x, [dims::Tuple]) => Tuple
     locus(x, dim) => Locus
-    locus(xs::Tuple) => Tuple{Vararg{<:Locus,N}}
+    locus(xs::Tuple) => Tuple{Vararg{Locus,N}}
     locus(x::Union{Dimension,LookupArray}) => Locus
 
 Return the [`Locus`](@ref) for each dimension.

--- a/src/set.jl
+++ b/src/set.jl
@@ -4,7 +4,7 @@ const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
     set(x, val)
     set(x, args::Pairs...) => x with updated field/s
     set(x, args...; kw...) => x with updated field/s
-    set(x, args::Tuple{Vararg{<:Dimension}}; kw...) => x with updated field/s
+    set(x, args::Tuple{Vararg{Dimension}}; kw...) => x with updated field/s
 
     set(dim::Dimension, index::AbstractArray) => Dimension
     set(dim::Dimension, lookup::LookupArray) => Dimension

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -94,7 +94,7 @@ end
 
 _maybestack(s::AbstractDimStack, x::NamedTuple) = x
 function _maybestack(
-    s::AbstractDimStack, das::NamedTuple{K,<:Tuple{Vararg{<:AbstractDimArray}}}
+    s::AbstractDimStack, das::NamedTuple{K,<:Tuple{Vararg{AbstractDimArray}}}
 ) where K
     rebuild_from_arrays(s, das)
 end

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -104,7 +104,7 @@ function rebuildsliced(f::Function, s::AbstractDimStack, layers, I)
 end
 
 """
-    rebuild_from_arrays(s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}}; kw...)
+    rebuild_from_arrays(s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}}; kw...)
 
 Rebuild an `AbstractDimStack` from a `NamedTuple` of `AbstractDimArray`
 and an existing stack.
@@ -121,12 +121,12 @@ Keywords are simply the fields of the stack object:
 - `layermetadata`
 """
 function rebuild_from_arrays(
-    s::AbstractDimStack{<:NamedTuple{Keys}}, das::Tuple{Vararg{<:AbstractDimArray}}; kw...
+    s::AbstractDimStack{<:NamedTuple{Keys}}, das::Tuple{Vararg{AbstractDimArray}}; kw...
 ) where Keys
     rebuild_from_arrays(s, NamedTuple{Keys}(das); kw...)
 end
 function rebuild_from_arrays(
-    s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}};
+    s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}};
     refdims=refdims(s),
     metadata=DD.metadata(s),
     data=map(parent, das),
@@ -153,8 +153,8 @@ end
     DimStack <: AbstractDimStack
 
     DimStack(data::AbstractDimArray...)
-    DimStack(data::Tuple{Vararg{<:AbstractDimArray}})
-    DimStack(data::NamedTuple{Keys,Vararg{<:AbstractDimArray}})
+    DimStack(data::Tuple{Vararg{AbstractDimArray}})
+    DimStack(data::NamedTuple{Keys,Vararg{AbstractDimArray}})
     DimStack(data::NamedTuple, dims::DimTuple; metadata=NoMetadata())
 
 DimStack holds multiple objects sharing some dimensions, in a `NamedTuple`.
@@ -234,10 +234,10 @@ struct DimStack{L,D<:Tuple,R<:Tuple,LD<:NamedTuple,M,LM<:NamedTuple} <: Abstract
     layermetadata::LM
 end
 DimStack(das::AbstractDimArray...; kw...) = DimStack(das; kw...)
-function DimStack(das::Tuple{Vararg{<:AbstractDimArray}}; kw...)
+function DimStack(das::Tuple{Vararg{AbstractDimArray}}; kw...)
     DimStack(NamedTuple{uniquekeys(das)}(das); kw...)
 end
-function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractDimArray}}};
+function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}};
     data=map(parent, das), dims=combinedims(das...), layerdims=map(basedims, das),
     refdims=(), metadata=NoMetadata(), layermetadata=map(DD.metadata, das)
 )
@@ -253,4 +253,3 @@ function DimStack(data::NamedTuple, dims::Tuple;
 end
 
 @noinline _stack_size_mismatch() = throw(ArgumentError("Arrays must have identical axes. For mixed dimensions, use DimArrays`"))
-

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -23,7 +23,7 @@ Tables.schema(s::AbstractDimStack) = Tables.schema(DimTable(s))
 """
     DimColumn{T,D<:Dimension} <: AbstractVector{T}
 
-    DimColumn(dim::Dimension, dims::Tuple{Vararg{<:DimTuple}})
+    DimColumn(dim::Dimension, dims::Tuple{Vararg{DimTuple}})
     DimColumn(dim::DimColumn, length::Int, dimstride::Int)
 
 A table column based on a `Dimension` and it's relationship with other
@@ -140,7 +140,7 @@ end
 DimTable{K}(stack::S, dimcolumns::DC, strides::SD) where {K,S,DC,SD} = 
     DimTable{K,S,DC,SD}(stack, dimcolumns, strides)
 DimTable(A::AbstractDimArray, As::AbstractDimArray...) = DimTable((A, As...))
-function DimTable(As::Tuple{<:AbstractDimArray,Vararg{<:AbstractDimArray}}...)
+function DimTable(As::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}...)
     DimTable(DimStack(As...))
 end
 function DimTable(s::AbstractDimStack)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,8 +12,8 @@ If no axis reversal is required the same objects will be returned, without alloc
 """
 function reorder end
 
-reorder(x, p::Pair, ps::Vararg{<:Pair}) = reorder(x, (p, ps...))
-reorder(x, ps::Tuple{Vararg{<:Pair}}) = reorder(x, Dimensions.pairdims(ps...))
+reorder(x, p::Pair, ps::Vararg{Pair}) = reorder(x, (p, ps...))
+reorder(x, ps::Tuple{Vararg{Pair}}) = reorder(x, Dimensions.pairdims(ps...))
 # Reorder specific dims.
 reorder(x, dimwrappers::Tuple) = _reorder(x, dimwrappers)
 # Reorder all dims.
@@ -152,10 +152,10 @@ end
 
 # Get a tuple of unique keys for DimArrays. If they have the same
 # name we call them layerI.
-function uniquekeys(das::Tuple{AbstractDimArray,Vararg{<:AbstractDimArray}})
+function uniquekeys(das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}})
     uniquekeys(Symbol.(map(name, das)))
 end
-function uniquekeys(keys::Tuple{Symbol,Vararg{<:Symbol}})
+function uniquekeys(keys::Tuple{Symbol,Vararg{Symbol}})
     ids = ntuple(x -> x, length(keys))
     map(keys, ids) do k, id
         count(k1 -> k == k1, keys) > 1 ? Symbol(:layer, id) : k


### PR DESCRIPTION
On main, if we load the package using `julia --depwarn=yes`, we get 50 deprecation warnings reading:

```julia
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
```

Running with `--depwarn=error`, we can pinpoint that the problem seems to be the syntax `Vararg{<:T}`. It seems instead one should use `Vararg{T}`. Similarly, `Tuple{<:T,Vararg{<:T}}` is apparently unnecessary. e.g.

```julia
julia> (1, 2) isa Tuple{Integer,Vararg{Integer}}
true

julia> (Int32(1), false) isa Tuple{Integer,Vararg{Integer}}
true
```

This PR removes all problematic lines, so that no more of these deprecation warnings are made.