### PR TITLE
Define Tables.istable on types not instances

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -2,7 +2,7 @@
 
 DimTableSources = Union{AbstractDimStack,AbstractDimArray}
 
-Tables.istable(::DimTableSources) = true
+Tables.istable(::Type{<:DimTableSources}) = true
 Tables.columnaccess(::Type{<:DimTableSources}) = true
 Tables.columns(x::DimTableSources) = DimTable(x)
 

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -21,7 +21,9 @@ da2 = DimArray(fill(2, (3, 2, 3)), dimz; name=:data2)
     @test t[:data] isa DimArrayColumn
     @test length(t[:X]) == length(t[:Y]) == length(t[:test]) == 18
 
-    @test Tables.istable(t) == Tables.istable(da) == Tables.istable(ds) == true
+    @test Tables.istable(typeof(t)) == Tables.istable(t) ==
+          Tables.istable(typeof(da)) == Tables.istable(da) == 
+          Tables.istable(typeof(ds)) == Tables.istable(ds) == true
     @test Tables.columnaccess(t) == Tables.columnaccess(da) == Tables.columnaccess(ds) == true
     @test Tables.rowaccess(t) == Tables.rowaccess(ds) == Tables.rowaccess(ds) == false
     @test Tables.columnnames(t) == Tables.columnnames(da) == Tables.columnnames(ds) == (:X, :Y, :test, :data)


### PR DESCRIPTION
Checking the type only is the performant path in Tables.jl - currently you can't do that with DimensionalData.jl types.