### PR TITLE
Make PermutedDimsArray type-inferrable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.24.8"
+version = "0.24.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -201,12 +201,15 @@ for (pkg, fname) in [(:Base, :permutedims), (:Base, :adjoint),
             rebuild(A, $pkg.$fname(parent(A)), (AnonDim(Base.OneTo(1)), dims(A)...))
     end
 end
-for fname in [:permutedims, :PermutedDimsArray]
-    @eval begin
-        @inline function Base.$fname(A::AbstractDimArray, perm)
-            rebuild(A, $fname(parent(A), dimnum(A, Tuple(perm))), sortdims(dims(A), Tuple(perm)))
-        end
-    end
+@inline function Base.permutedims(A::AbstractDimArray, perm)
+    rebuild(A, permutedims(parent(A), dimnum(A, Tuple(perm))), sortdims(dims(A), Tuple(perm)))
+end
+@inline function Base.PermutedDimsArray(A::AbstractDimArray{T,N}, perm) where {T,N}
+    perm_inds = dimnum(A, Tuple(perm))
+    iperm_inds = invperm(perm_inds)
+    data = parent(A)
+    data_perm = PermutedDimsArray{T,N,perm_inds,iperm_inds,typeof(data)}(data)
+    rebuild(A, data_perm, sortdims(dims(A), Tuple(perm)))
 end
 
 # Concatenation

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -268,6 +268,11 @@ end
     dsp = PermutedDimsArray(da, (3, 1, 2))
     @test dsp == PermutedDimsArray(parent(da), (3, 1, 2))
     @test typeof(dsp) <: DimArray
+
+    dims_perm = dims(da, (3, 2, 1))
+    dsp2 = @inferred PermutedDimsArray(da, dims_perm)
+    @test dsp2 == PermutedDimsArray(parent(da), (3, 2, 1))
+    @test typeof(dsp2) <: DimArray
 end
 
 


### PR DESCRIPTION
`PermutedDimsArray` is currently not type-inferrable, likely because `PermutedDimsArray(parent(da), perm)` ends up not being inlined, and since its output type contains `perm` and `invperm(perm)`, this type is not inferrable.

This PR reimplements `PermutedDimsArray` to directly construct the type of the the array, so that when the types of the dimensions are known, then so is the output.