### PR TITLE
bugfix stack changes

### DIFF
--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -78,6 +78,14 @@ function _maybestack(
         rebuild_from_arrays(s, das)
     end
 end
+function _maybestack(
+    s::AbstractDimStack{<:NamedTuple{K}}, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+) where K
+    # Avoid compiling this in the simple cases in the above method
+    Base.invokelatest() do
+        rebuild_from_arrays(s, das)
+    end
+end
 
 """
     Base.eachslice(stack::AbstractDimStack; dims)

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -67,11 +67,12 @@ _firststack(arg1, args...) = _firststack(args...)
 _firststack() = nothing
 
 _maybestack(s::AbstractDimStack{<:NamedTuple{K}}, xs::Tuple) where K = NamedTuple{K}(xs)
+_maybestack(s::AbstractDimStack, xs::Tuple) = NamedTuple{keys(s)}(xs)
 # Without the `@nospecialise` here this method is also compile with the above method
 # on every call to _maybestack. And `rebuild_from_arrays` is expensive to compile.
 function _maybestack(
-    s::AbstractDimStack{<:NamedTuple{K}}, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
-) where K
+    s::AbstractDimStack, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+)
     # Avoid compiling this in the simple cases in the above method
     Base.invokelatest() do
         rebuild_from_arrays(s, das)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -122,29 +122,27 @@ Keywords are simply the fields of the stack object:
 - `layermetadata`
 """
 function rebuild_from_arrays(
-    s::AbstractDimStack{<:NamedTuple{Keys}}, das::Tuple{Vararg{AbstractDimArray}}; 
-    refdims=refdims(s),
-    metadata=DD.metadata(s),
-    data=NamedTuple{Keys}(map(parent, das)),
-    dims=DD.combinedims(collect(das)),
-    layerdims=NamedTuple{Keys}(map(DD.basedims, das)),
-    layermetadata=NamedTuple{Keys}(map(DD.metadata, das)),
+    s::AbstractDimStack{<:NamedTuple{Keys}}, das::Tuple{Vararg{AbstractDimArray}}; kw...
 ) where Keys
-    rebuild(s; data, dims, refdims, layerdims, metadata, layermetadata)
+    rebuild_from_arrays(s, NamedTuple{Keys}(das), kw...)
 end
 function rebuild_from_arrays(
     s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}};
     data=map(parent, das),
     refdims=refdims(s),
     metadata=DD.metadata(s),
-    dims=DD.combinedims(collect(das)),
+    dims=nothing,
     layerdims=map(DD.basedims, das),
     layermetadata=map(DD.metadata, das),
 )
-    Base.invokelatest() do
-        dims = DD.combinedims(collect(das))
+    if isnothing(dims)
+        Base.invokelatest() do
+            dims = DD.combinedims(collect(das))
+        end
+        rebuild(s; data, dims, refdims, layerdims, metadata, layermetadata)
+    else
+        rebuild(s; data, dims, refdims, layerdims, metadata, layermetadata)
     end
-    rebuild(s; data, dims, refdims, layerdims, metadata, layermetadata)
 end
 
 layers(nt::NamedTuple) = nt


### PR DESCRIPTION
Fixes a few bugs I introduced with stack optimisation.

One from rebasing had removed a lot of the performance gains by actually running `combinedims` twice and always having to compile it - I think compile times should be better after this.

The other will help to fix https://github.com/rafaqz/Rasters.jl/issues/409