### PR TITLE
add JuMP extension, update package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,16 @@ version = "0.24.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
@@ -22,19 +22,22 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Adapt = "2, 3.0"
-ArrayInterfaceCore = "0.1"
+ArrayInterface = "7"
 ConstructionBase = "1"
 Extents = "0.1"
 IntervalSets = "0.5, 0.6, 0.7"
 IteratorInterfaceExtensions = "1"
 RecipesBase = "0.7, 0.8, 1"
-SnoopPrecompile = "1.0.3"
 TableTraits = "1"
 Tables = "1"
-julia = "1.5"
+julia = "1.6"
+
+[extensions]
+DimensionalDataJuMPExt = "JuMP"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
@@ -52,4 +55,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "Combinatorics", "CoordinateTransformations", "DataFrames", "Distributions", "Documenter", "ImageFiltering", "ImageTransformations", "OffsetArrays", "Plots", "Random", "SafeTestsets", "StatsPlots", "Test", "Unitful"]
+test = ["Aqua", "ArrayInterface", "BenchmarkTools", "Combinatorics", "CoordinateTransformations", "DataFrames", "Distributions", "Documenter", "ImageFiltering", "ImageTransformations", "JuMP", "OffsetArrays", "Plots", "Random", "SafeTestsets", "StatsPlots", "Test", "Unitful"]
+
+[weakdeps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/ext/DimensionalDataJuMPExt.jl
+++ b/ext/DimensionalDataJuMPExt.jl
@@ -1,0 +1,32 @@
+module DimensionalDataJuMPExt
+using DimensionalData,JuMP
+
+function JuMP.Containers.container(
+    f::Function, 
+    indices::JuMP.Containers.VectorizedProductIterator,
+    c::Type{DimensionalData.DimArray},
+    names,
+)   
+    for i in names
+        if i isa Symbol && !Base.isidentifier(i) #a symbol was created automatically by JuMP.
+            throw(ArgumentError("Cannot build DimArray. invalid indices."))
+        end
+    end
+    dims = NamedTuple(i => j for (i, j) in zip(names, indices.prod.iterators))
+    return DimensionalData.DimArray(map(i -> f(i...), indices), dims)
+end
+
+#error on weird iterators, TODO?
+function JuMP.Containers.container(
+    f::Function, 
+    indices::JuMP.Containers.NestedIterator,
+    c::Type{DimensionalData.DimArray},
+    names,
+)
+    throw(MethodError(JuMP.Containers.container,(f,indices,c)))
+end
+
+
+
+
+end #module

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -21,12 +21,12 @@ using Base: tail, OneTo, @propagate_inbounds
       
 # Ecosystem
 import Adapt, 
-       ArrayInterfaceCore,
+       ArrayInterface,
        ConstructionBase, 
        Extents,
        IteratorInterfaceExtensions,
        RecipesBase,
-       SnoopPrecompile,
+       PrecompileTools,
        TableTraits,
        Tables
 

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -251,7 +251,7 @@ for (d, s) in ((:AbstractDimArray, :AbstractDimArray),
 end
 Base.copy!(dst::SparseArrays.SparseVector, src::AbstractDimArray{T,1}) where T = copy!(dst, parent(src))
 
-ArrayInterfaceCore.parent_type(::Type{<:AbstractDimArray{T,N,D,A}}) where {T,N,D,A} = A
+ArrayInterface.parent_type(::Type{<:AbstractDimArray{T,N,D,A}}) where {T,N,D,A} = A
 
 function Adapt.adapt_structure(to, A::AbstractDimArray)
     rebuild(A,

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,5 @@
 
-SnoopPrecompile.@precompile_all_calls begin
+PrecompileTools.@compile_workload begin
     buffer = IOContext(IOBuffer(), :color=>true)
     for f in (zeros, ones, falses, trues, rand)
         x, y, z = X([:a, :b]), Y(10.0:10.0:30.0), Z()

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -1,11 +1,11 @@
-using OffsetArrays, ImageFiltering, ImageTransformations, ArrayInterfaceCore, DimensionalData, Test
+using OffsetArrays, ImageFiltering, ImageTransformations, ArrayInterface, DimensionalData, Test
 using DimensionalData.LookupArrays
 
 @testset "ArrayInterface" begin
     a = [1 2; 3 4]
     dimz = X(143.0:2.0:145.0), Y(-38.0:2.0:-36.0)
     da = DimArray(a, dimz)
-    @test ArrayInterfaceCore.parent_type(typeof(da)) == Matrix{Int}
+    @test ArrayInterface.parent_type(typeof(da)) == Matrix{Int}
 end
 
 @testset "OffsetArray" begin

--- a/test/jump.jl
+++ b/test/jump.jl
@@ -1,0 +1,10 @@
+if isdefined(Base,:get_extension)
+using JuMP
+@testset "JuMP integration" begin 
+    model = JuMP.Model();
+    @test @variable(model, x[i=2:4, j=["a", "b"]], container = DimArray) isa DimArray
+    @test_throws ArgumentError @variable(model, z[i=1:3, j=i:2], container = DimArray)
+    @test_throws ArgumentError @variable(model, w[1:3, j=1:2], container = DimArray)
+end
+
+end


### PR DESCRIPTION
based on https://github.com/jump-dev/JuMP.jl/issues/3214#issuecomment-1431813447. that functionality will only be available from 1.9 onwards. also:
- updates `ArrayInterfaceCore` -> `ArrayInterface` v7 (#458 )
- moves from `SnoopPrecompile` to `PrecompileTools`