### PR TITLE
fix cat and test error messages

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -288,11 +288,11 @@ end
 
 # LookupArrays may need adjustment for `cat`
 function _vcat_lookups(lookups::LookupArray...)
-    newindex = _vcat_index(lookups[1], lookups...)
+    newindex = _vcat_index(lookups...)
     return rebuild(lookups[1]; data=newindex)
 end
 function _vcat_lookups(lookups::AbstractSampled...)
-    newindex = _vcat_index(lookups[1], lookups...)
+    newindex = _vcat_index(lookups...)
     newlookup = _vcat_lookups(sampling(first(lookups)), span(first(lookups)), lookups...)
     return rebuild(newlookup; data=newindex)
 end
@@ -328,27 +328,28 @@ end
 _vcat_lookups(::Points, ::Irregular, lookups...) = 
     rebuild(first(lookups); span=Irregular(nothing, nothing))
 
-_vcat_index(lookup::NoLookup, A...) = OneTo(mapreduce(length, +, A))
+_vcat_index(A::NoLookup...) = OneTo(mapreduce(length, +, A))
 # TODO: handle vcat OffsetArrays?
 # Otherwise just vcat. TODO: handle order breaking vcat?
 # function _vcat_index(lookup::LookupArray, lookups...) 
     # _vcat_index(span(lookup), lookup, lookups...) 
 # end
-function _vcat_index(lookup::LookupArray, lookups...)
-    xl = last(lookup)
-    foreach(Base.tail(lookups)) do l
+function _vcat_index(lookups::LookupArray...)
+    lookup1 = first(lookups)
+    xl = last(lookup1)
+    foreach(Base.tail(lookups)) do lookup
         if order(lookup) isa Ordered 
-            order(l) === order(lookup) || error("Lookups do not all have the same order")
+            order(lookup) === order(lookup1) || error("Lookups do not all have the same order")
             if order(lookup) isa ForwardOrdered
-                first(l) > xl || _lookup_index_cat_error(l, xl)
+                first(lookup) > xl || _lookup_index_cat_error(lookup, xl)
             else
-                first(l) < xl || _lookup_index_cat_error(l, xl)
+                first(lookup) < xl || _lookup_index_cat_error(lookup, xl)
             end
-            xl = last(l)
+            xl = last(lookup)
         end
     end
     shifted = map(lookups) do l
-        parent(maybeshiftlocus(locus(lookup), l))
+        parent(maybeshiftlocus(locus(lookup1), l))
     end
     return reduce(vcat, shifted)
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,8 @@
 
+using DimensionalData
 PrecompileTools.@compile_workload begin
     buffer = IOContext(IOBuffer(), :color=>true)
+    f = zeros
     for f in (zeros, ones, falses, trues, rand)
         x, y, z = X([:a, :b]), Y(10.0:10.0:30.0), Z()
         dimz = x, y

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -381,7 +381,7 @@ end
         @test typeof(dims(cat(da2, db2; dims=:y))) === typeof(dims(da2))
         @test lookup(cat(da2, db2; dims=:y)) == (lookup(da2)[1], 1:6)
         @test cat(da2, db2; dims=(X(), :y)) == cat(da2, db2; dims=(X, Dim{:y})) ==
-            cat(da2, db2; dims=(X(), Dim{:y}()))
+            @inferred(cat(da2, db2; dims=(X(), Dim{:y}())))
         @test typeof(dims(cat(da2, db2; dims=(X(), :y)))) ===
             typeof((Xcatdim, dims(da2, :y)))
         @test lookup(cat(da2, db2; dims=(X(), :y))) == (lookup(Xcatdim), 1:6)
@@ -430,6 +430,7 @@ end
         @test lookup(ni_dim) == NoLookup(Base.OneTo(20))
         # Order doesn't matter
         @test vcat(d2, d1) == ni_dim
+        @test vcat(d1, reverse(d2)) == ni_dim
     end
 
     @testset "rebuild dim index from refdims" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -377,11 +377,11 @@ end
         da2 = DimArray(a, (X(4.0:5.0), :y))
         db2 = DimArray(b, (X(6.0:7.0), :y))
         @test cat(da2, db2; dims=:y) == cat(da2, db2; dims=Dim{:y}) ==
-            @inferred(cat(da2, db2; dims=Dim{:y}()))
+            cat(da2, db2; dims=Dim{:y}())
         @test typeof(dims(cat(da2, db2; dims=:y))) === typeof(dims(da2))
         @test lookup(cat(da2, db2; dims=:y)) == (lookup(da2)[1], 1:6)
         @test cat(da2, db2; dims=(X(), :y)) == cat(da2, db2; dims=(X, Dim{:y})) ==
-            @inferred(cat(da2, db2; dims=(X(), Dim{:y}())))
+            cat(da2, db2; dims=(X(), Dim{:y}()))
         @test typeof(dims(cat(da2, db2; dims=(X(), :y)))) ===
             typeof((Xcatdim, dims(da2, :y)))
         @test lookup(cat(da2, db2; dims=(X(), :y))) == (lookup(Xcatdim), 1:6)


### PR DESCRIPTION
@tiemvanderdeure this should fix your `Explicit` `cat` problem. It also adds a bunch more checks to make sure `cat` is actually correct. I'm sure there are more ways it can be wrong, if you can see anything else that will either still break on `cat` or will work when it shouldn't, let me know, and feel free to do a code review.