### PR TITLE
Add `intervalbounds`

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -38,7 +38,8 @@ using .Dimensions
 using .Dimensions.LookupArrays
 using .Dimensions: StandardIndices, DimOrDimType, DimTuple, DimTupleOrEmpty, DimType, AllDims
 import .LookupArrays: metadata, set, _set, rebuild, basetypeof, 
-    order, span, sampling, locus, val, index, bounds, hasselection, units, SelectorOrInterval
+    order, span, sampling, locus, val, index, bounds, intervalbounds, 
+    hasselection, units, SelectorOrInterval
 import .Dimensions: dims, refdims, name, lookup, dimstride, kwdims, hasdim, label, _astuple
 
 export LookupArrays, Dimensions

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -21,7 +21,7 @@ include("../LookupArrays/LookupArrays.jl")
 using .LookupArrays
 
 import .LookupArrays: rebuild, order, span, sampling, locus, val, index, set, _set,
-    metadata, bounds, units, basetypeof, unwrap, selectindices, hasselection,
+    metadata, bounds, intervalbounds, units, basetypeof, unwrap, selectindices, hasselection,
     shiftlocus, maybeshiftlocus, SelectorOrInterval, Interval
 using .LookupArrays: StandardIndices, SelTuple, CategoricalEltypes,
     LookupArrayTrait, AllMetadata, LookupArraySetters

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -173,20 +173,21 @@ lookuptype(dim::Dimension) = typeof(lookup(dim))
 lookuptype(::Type{<:Dimension{L}}) where L = L
 lookuptype(x) = NoLookup
 
-# LookupArrays methods
-metadata(dim::Dimension) = metadata(lookup(dim))
-
-index(dim::Dimension{<:AbstractArray}) = index(val(dim))
-index(dim::Dimension{<:Val}) = unwrap(index(val(dim)))
-
 name(dim::Dimension) = name(typeof(dim))
 name(dim::Val{D}) where D = name(D)
 
 label(x) = string(string(name(x)), (units(x) === nothing ? "" : string(" ", units(x))))
 
-bounds(dim::Dimension) = bounds(val(dim))
-shiftlocus(locus::Locus, dim::Dimension) = rebuild(dim, shiftlocus(locus, lookup(dim)))
-maybeshiftlocus(locus::Locus, d::Dimension) = rebuild(d, maybeshiftlocus(locus, lookup(d)))
+# LookupArrays methods
+LookupArrays.metadata(dim::Dimension) = metadata(lookup(dim))
+
+LookupArrays.index(dim::Dimension{<:AbstractArray}) = index(val(dim))
+LookupArrays.index(dim::Dimension{<:Val}) = unwrap(index(val(dim)))
+
+LookupArrays.bounds(dim::Dimension) = bounds(val(dim))
+LookupArrays.intervalbounds(dim::Dimension, args...) = intervalbounds(val(dim), args...)
+LookupArrays.shiftlocus(locus::Locus, dim::Dimension) = rebuild(dim, shiftlocus(locus, lookup(dim)))
+LookupArrays.maybeshiftlocus(locus::Locus, d::Dimension) = rebuild(d, maybeshiftlocus(locus, lookup(d)))
 
 function hasselection(x, selectors::Union{DimTuple,SelTuple,Selector,Dimension})
     hasselection(dims(x), selectors)

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -210,7 +210,7 @@ for func in (:order, :span, :sampling, :locus)
 end
 
 # Dipatch on Tuple{<:Dimension}, and map to single dim methods
-for f in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :bounds, :locus,
+for f in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :locus, :bounds, :intervalbounds,
           :name, :label, :units)
     @eval begin
         $f(ds::DimTuple) = map($f, ds)

--- a/src/LookupArrays/LookupArrays.jl
+++ b/src/LookupArrays/LookupArrays.jl
@@ -25,7 +25,7 @@ using Base: tail, OneTo, @propagate_inbounds
 
 export order, sampling, span, bounds, locus, hasselection, transformdim,
     metadata, units, sort, selectindices, val, index, reducelookup, shiftlocus,
-    maybeshiftlocus
+    maybeshiftlocus, intervalbounds
 
 export Selector
 export At, Between, Touches, Contains, Near, Where, All

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -56,7 +56,7 @@ end
 @inline rebuildsliced(f::Function, A::AbstractDimArray, data::AbstractArray, I::Tuple, name=name(A)) =
     rebuild(A, data, slicedims(f, A, I)..., name)
 
-for func in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :bounds, :locus)
+for func in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :locus, :bounds, :intervalbounds)
     @eval ($func)(A::AbstractDimArray, args...) = ($func)(dims(A), args...)
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -76,10 +76,12 @@ end
     @test order(da) == (ForwardOrdered(), ForwardOrdered())
     @test sampling(da) == (Points(), Points())
     @test span(da) == (Regular(2.0), Regular(2.0))
-    @test bounds(da) == ((143.0, 145.0), (-38.0, -36.0))
     @test locus(da) == (Center(), Center())
+    @test bounds(da) == ((143.0, 145.0), (-38.0, -36.0))
     @test layerdims(da) == (X(), Y())
     @test index(da, Y) == LinRange(-38.0, -36.0, 2)
+    da_intervals = set(da, X => Intervals, Y => Intervals)
+    @test intervalbounds(da_intervals) == ([(142.0, 144.0), (144.0, 146.0)], [(-39.0, -37.0), (-37.0, -35.0)])
 end
 
 @testset "copy and friends" begin


### PR DESCRIPTION
Adds an `intervalbounds` method to return either the specific bounds of the nth interval or the bounds of all of the intervals as a vector of Tuple. (Possibly it should be a vector of `IntervalSets.Interval` so they can be explicitly closed/open intervals?)

@asinghvi17 this should help getting the correct pixel edges for Makie in https://github.com/rafaqz/Rasters.jl/issues/428

I've got a PR coming to fix that in Rasters.jl