### PR TITLE
fix cat where dims holds a lookup array

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -240,8 +240,13 @@ function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
         else
             # Concatenate new dims
             if all(map(x -> hasdim(refdims(x), catdim), Xin))
-                # vcat the refdims 
-                reduce(vcat, map(x -> refdims(x, catdim), Xin))
+                if catdim isa Dimension && val(catdim) isa AbstractArray
+                    # Combine the refdims properties with the passed in catdim
+                    set(refdims(first(Xin), catdim), catdim)
+                else
+                    # vcat the refdims 
+                    reduce(vcat, map(x -> refdims(x, catdim), Xin))
+                end
             else
                 # Use the catdim as the new dimension
                 catdim

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -369,6 +369,14 @@ end
         @test all(map(==, index(dx), index(DimensionalData.format((X([4.0, 5.0, 6.0, 7.0]), Y(6:8), Ti(1:2)), dx))))
         @test_throws ErrorException vcat(da, reverse(db; dims=X))
         @test_throws ErrorException vcat(db, da)
+        @testset "lookup array in dims" begin
+            @test dims(cat(da, db; dims=Ti(1:2)), Ti) == Ti(Sampled(1:2, ForwardOrdered(), Regular(1), Points(), NoMetadata()))
+            @test dims(cat(da, db; dims=Ti(Categorical(1:2))), Ti) == Ti(Categorical(1:2, ForwardOrdered(), NoMetadata()))
+            # Categorical is taken from refdims
+            dra = rebuild(da; refdims=(Z(Categorical([1], ForwardOrdered(), NoMetadata())),))
+            drb = rebuild(db; refdims=(Z(Categorical([1], ForwardOrdered(), NoMetadata())),))
+            @test dims(cat(dra, drb; dims=Z(1:2)), Z) == Z(Categorical(1:2, ForwardOrdered(), NoMetadata()))
+        end
     end
 
     # https://github.com/rafaqz/DimensionalData.jl/issues/451


### PR DESCRIPTION
Currently `cat` doesn't use the contents of the dims dimension, like `dims=X(1:2)`.

This is pretty much a bug, fixed in this PR.

Now the lookup array or array will be used, and if possible merged with refdims properties.