### PR TITLE
fix cat for vectors with AnonDim

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -483,18 +483,19 @@ returning the `Dimension` value if it exists.
 These are all `Bool` flags:
 
 - `type`: compare complete type, `true` by default.
-- `lookuptype`: compare wrapped `LookupArray` type, `false` by default. 
+- `valtype`: compare wrapped value type, `false` by default. 
+- `val`: compare wrapped values, `false` by default.
 - `length`: compare lengths, `true` by default.
 - `ignore_length_one`: ignore length `1` in comparisons, and return whichever
     dimension is not length 1, if any. This is useful in e.g. broadcasting comparisons.
     `false` by default.
-- `value`: compare all values in each `LookupArray` are identical, `false` by default.
 """
 function comparedims end
+@inline comparedims(ds::Dimension...; kw...) = map(d -> comparedims(first(ds), d; kw...), ds)
 @inline comparedims(x...; kw...) = comparedims(x; kw...)
 @inline comparedims(A::Tuple; kw...) = comparedims(map(dims, A)...; kw...)
 @inline comparedims(dims::Vararg{Tuple{Vararg{Dimension}}}; kw...) =
-    map(d -> comparedims(first(dims), d), dims; kw...) |> first
+    map(d -> comparedims(first(dims), d; kw...), dims) |> first
 
 @inline comparedims(a::DimTupleOrEmpty, ::Nothing; kw...) = a
 @inline comparedims(::Nothing, b::DimTupleOrEmpty; kw...) = b
@@ -509,7 +510,7 @@ function comparedims end
 @inline comparedims(a::Dimension, b::AnonDim; kw...) = a
 @inline comparedims(a::AnonDim, b::Dimension; kw...) = b
 @inline function comparedims(a::Dimension, b::Dimension;
-    type=true, valtype=false, length=true, ignore_length_one=false, val=false,
+    type=true, valtype=false, val=false, length=true, ignore_length_one=false,
 )
     type && basetypeof(a) != basetypeof(b) && _dimsmismatcherror(a, b)
     valtype && typeof(parent(a)) != typeof(parent(b)) && _valtypeerror(a, b)

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -482,7 +482,7 @@ returning the `Dimension` value if it exists.
 
 These are all `Bool` flags:
 
-- `type`: compare complete type, `true` by default.
+- `type`: compare dimension type, `true` by default.
 - `valtype`: compare wrapped value type, `false` by default. 
 - `val`: compare wrapped values, `false` by default.
 - `length`: compare lengths, `true` by default.

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -232,7 +232,7 @@ function Base._cat(catdim::Union{Int,DimOrDimType}, Xin::AbstractDimArray...)
 end
 function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
     Xin = (A1, As...)
-    comparedims(map(x -> otherdims(x, catdims), Xin)...)
+    comparedims(map(x -> otherdims(x, catdims), Xin)...; val=true)
     newcatdims = map(catdims) do catdim
         if all(x -> hasdim(x, catdim), Xin)
             # We concatenate an existing dimension

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -305,16 +305,13 @@ function Base.vcat(As::Union{AbstractDimVector,AbstractDimMatrix}...)
 end
 
 function Base.vcat(d1::Dimension, ds::Dimension...)
-    map(ds) do d
-        d isa basetypeof(d1) || throw(DimensionMismatch("Mixed dimensions in `vcat`: $(basetypeof(d)) and $(basetypeof(d1))"))
-    end
+    comparedims(d1, ds...; length=false)
     newlookup = _vcat_lookups(lookup((d1, ds...))...)
     rebuild(d1, newlookup)
 end
 
 # LookupArrays may need adjustment for `cat`
 function _vcat_lookups(lookups::LookupArray...)
-    comparedims(d1, ds...; length=false)
     newindex = _vcat_index(lookups...)
     return rebuild(lookups[1]; data=newindex)
 end

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -73,7 +73,7 @@ function print_name(io::IO, name)
     end
 end
 
-# Base.print_matrix(io::IO, A::AbstractDimArray) = _print_matrix(io, parent(A), lookup(A))
+Base.print_matrix(io::IO, A::AbstractDimArray) = _print_matrix(io, parent(A), lookup(A))
 # Labelled matrix printing is modified from AxisKeys.jl, thanks @mcabbot
 function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
     h, w = displaysize(io)

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -73,7 +73,7 @@ function print_name(io::IO, name)
     end
 end
 
-Base.print_matrix(io::IO, A::AbstractDimArray) = _print_matrix(io, parent(A), lookup(A))
+# Base.print_matrix(io::IO, A::AbstractDimArray) = _print_matrix(io, parent(A), lookup(A))
 # Labelled matrix printing is modified from AxisKeys.jl, thanks @mcabbot
 function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
     h, w = displaysize(io)
@@ -88,6 +88,7 @@ function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
     Base.print_matrix(io, A_dims)
     return nothing
 end
+_print_matrix(io::IO, A::AbstractDimArray, lookups::Tuple) = _print_matrix(io, parent(A), lookups) 
 function _print_matrix(io::IO, A::AbstractArray, lookups::Tuple)
     lu1, lu2 = lookups
     h, w = displaysize(io)
@@ -107,7 +108,7 @@ function _print_matrix(io::IO, A::AbstractArray, lookups::Tuple)
         bottomleft = hcat(map(showblack, parent(lu1)[ibottom]), bottomleft)
     end
 
-    leftblock = vcat(topleft, bottomleft)
+    leftblock = vcat(parent(topleft), parent(bottomleft))
     rightblock = vcat(A[itop, iright], A[ibottom, iright])
     bottomblock = hcat(leftblock, rightblock)
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -351,9 +351,11 @@ end
     da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
     b = [7 8 9; 10 11 12]
     db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
+    dc = DimArray(b, (X(6.0:7.0), Y(10.0:12.0)))
 
     @testset "Regular Sampled" begin
         @test cat(da, db; dims=X()) == [1 2 3; 4 5 6; 7 8 9; 10 11 12]
+        @test_throws DimensionMismatch cat(da, dc; dims=X())
         testdims = (X(Sampled([4.0, 5.0, 6.0, 7.0], ForwardOrdered(), Regular(1.0), Points(), NoMetadata())),
                     Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())))
         @test cat(da, db; dims=(X(),)) == cat(da, db; dims=X()) == cat(da, db; dims=X) ==

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -352,10 +352,16 @@ end
     b = [7 8 9; 10 11 12]
     db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
     dc = DimArray(b, (X(6.0:7.0), Y(10.0:12.0)))
+    dd = DimArray(b, (X(8.0:9.0), Y(6.0:8.0)))
+    de = DimArray(b, (Z(6.0:7.0), Y(6.0:8.0)))
 
     @testset "Regular Sampled" begin
         @test cat(da, db; dims=X()) == [1 2 3; 4 5 6; 7 8 9; 10 11 12]
         @test_throws DimensionMismatch cat(da, dc; dims=X())
+        @test_throws ErrorException cat(da, dd; dims=X())
+        @test_throws DimensionMismatch cat(da, de; dims=X())
+        @test_throws DimensionMismatch vcat(dims(da, 1), dims(de, 1))
+        # TODO define our own exception for this
         testdims = (X(Sampled([4.0, 5.0, 6.0, 7.0], ForwardOrdered(), Regular(1.0), Points(), NoMetadata())),
                     Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())))
         @test cat(da, db; dims=(X(),)) == cat(da, db; dims=X()) == cat(da, db; dims=X) ==

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -493,6 +493,7 @@ end
         db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
         c = [13 14 15; 16 17 18]
         dc = DimArray(c, (X(8.0:9.0), Y(6.0:8.0)))
+        dd = DimArray(c, (X(8.0:9.0), Z(6.0:8.0)))
 
         @test @inferred(vcat(da)) == da
         @test dims(vcat(da)) == 
@@ -504,11 +505,13 @@ end
             dims(cat(da, db; dims=1)) ==
             (X(Sampled(4.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
              Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test_throws DimensionMismatch hcat(da, dd)
         @test @inferred(vcat(da, db, dc)) == cat(da, db, dc; dims=1)
         @test dims(vcat(da, db, dc)) == 
             dims(cat(da, db, dc; dims=1)) ==
             (X(Sampled(4.0:9.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
              Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test_throws DimensionMismatch hcat(da, db, dd)
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -452,29 +452,110 @@ end
 end
 
 @testset "vcat" begin
-    a = [1 2 3; 4 5 6]
-    da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
-    b = [7 8 9; 10 11 12]
-    db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
-    c = [13 14 15; 16 17 18]
-    dc = DimArray(c, (X(8.0:9.0), Y(6.0:8.0)))
+    @testset "1d" begin
+        a = [1, 2]
+        da = DimArray(a, X(4.0:5.0))
+        b = [3, 4]
+        db = DimArray(b, X(6.0:7.0))
+        c = [5, 6]
+        dc = DimArray(c, X(8.0:9.0))
+        dd = DimArray(c, Y(8.0:9.0))
 
-    @test @inferred(vcat(da)) == da
-    @test @inferred(vcat(da, db)) == cat(da, db; dims=1)
-    @test @inferred(vcat(da, db, dc)) == cat(da, db, dc; dims=1)
+        @test @inferred(vcat(da)) == da
+        @test dims(vcat(da)) == 
+            dims(cat(da; dims=1)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())),)
+        @test @inferred(vcat(da, db)) == cat(da, db; dims=1)
+        @test dims(vcat(da, db)) == 
+            dims(cat(da, db; dims=1)) ==
+            (X(Sampled(4.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())),)
+        @test_throws DimensionMismatch hcat(da, dd)
+        @test @inferred(vcat(da, db, dc)) == cat(da, db, dc; dims=1)
+        @test dims(vcat(da, db, dc)) == 
+            dims(cat(da, db, dc; dims=1)) ==
+            (X(Sampled(4.0:9.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())),)
+        @test_throws DimensionMismatch hcat(da, db, dd)
+    end
+
+    @testset "2d" begin
+        a = [1 2 3; 4 5 6]
+        da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
+        dims(da)
+        b = [7 8 9; 10 11 12]
+        db = DimArray(b, (X(6.0:7.0), Y(6.0:8.0)))
+        c = [13 14 15; 16 17 18]
+        dc = DimArray(c, (X(8.0:9.0), Y(6.0:8.0)))
+
+        @test @inferred(vcat(da)) == da
+        @test dims(vcat(da)) == 
+            dims(cat(da; dims=1)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test @inferred(vcat(da, db)) == cat(da, db; dims=1)
+        @test dims(vcat(da, db)) == 
+            dims(cat(da, db; dims=1)) ==
+            (X(Sampled(4.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test @inferred(vcat(da, db, dc)) == cat(da, db, dc; dims=1)
+        @test dims(vcat(da, db, dc)) == 
+            dims(cat(da, db, dc; dims=1)) ==
+            (X(Sampled(4.0:9.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+    end
 end
 
 @testset "hcat" begin
-    a = [1 2 3; 4 5 6]
-    da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
-    b = [7 8 9; 10 11 12]
-    db = DimArray(b, (X(4.0:5.0), Y(9.0:11.0)))
-    c = [13 14 15; 16 17 18]
-    dc = DimArray(c, (X(4.0:5.0), Y(12.0:14.0)))
+    @testset "1d" begin
+        a = [1, 2]
+        da = DimArray(a, X(4.0:5.0))
+        b = [3, 4]
+        db = DimArray(b, X(4.0:5.0))
+        c = [5, 6]
+        dc = DimArray(c, X(4.0:5.0))
+        dd = DimArray(c, X(8.0:9.0))
 
-    @test @inferred(hcat(da)) == da
-    @test @inferred(hcat(da, db)) == cat(da, db; dims=2)
-    @test @inferred(hcat(da, db, dc)) == cat(da, db, dc; dims=2)
+        @test @inferred(hcat(da)) == [1; 2;;]
+        @test dims(hcat(da)) == 
+            dims(cat(da; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), AnonDim(NoLookup(Base.OneTo(1))))
+        @test @inferred(hcat(da, db)) == cat(da, db; dims=2)
+        @test dims(hcat(da, db)) == 
+            dims(cat(da, db; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), AnonDim(NoLookup(Base.OneTo(2))))
+        @test_throws DimensionMismatch hcat(da, dd)
+        @test @inferred(hcat(da, db, dc)) == 
+        @test dims(hcat(da, db, dc)) == 
+            dims(cat(da, db, dc; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), AnonDim(NoLookup(Base.OneTo(3))))
+        @test_throws DimensionMismatch hcat(da, db, dd)
+    end
+    @testset "2d" begin
+        a = [1 2 3; 4 5 6]
+        da = DimArray(a, (X(4.0:5.0), Y(6.0:8.0)))
+        b = [7 8 9; 10 11 12]
+        db = DimArray(b, (X(4.0:5.0), Y(9.0:11.0)))
+        c = [13 14 15; 16 17 18]
+        dc = DimArray(c, (X(4.0:5.0), Y(12.0:14.0)))
+        dd = DimArray(c, (X(12.0:13.0), Y(12.0:14.0)))
+
+        @test @inferred(hcat(da)) == da
+        @test dims(hcat(da)) == 
+            dims(cat(da; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:8.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test @inferred(hcat(da, db)) == cat(da, db; dims=2)
+        @test dims(hcat(da, db)) == 
+            dims(cat(da, db; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:11.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test_throws DimensionMismatch hcat(da, dd)
+        @test @inferred(hcat(da, db, dc)) == cat(da, db, dc; dims=2)
+        @test dims(hcat(da, db, dc)) == 
+            dims(cat(da, db, dc; dims=2)) ==
+            (X(Sampled(4.0:5.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata())), 
+             Y(Sampled(6.0:14.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))) 
+        @test_throws DimensionMismatch hcat(da, db, dd)
+    end
 end
 
 @testset "unique" begin


### PR DESCRIPTION
`hcat` and `vcat` were not tested with DimVector and were not actually working. This PR fixes that. It also standardises the output of `cat` on missing dimensions to use `AnonDim` so we always return a `DimArray`.

We also now rigorously check that the shared dimensions actually match all values as well as dimension type, and that span types are not mixed or broken (closes #433)

@sethaxen you may want a look at this, I think this was partly your code

Note: also fixed problems in docs in primatives as I used the keywords here