### PR TITLE
Allow empty `DimStack`

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -529,8 +529,12 @@ Combine the dimensions of each object in `xs`, in the order they are found.
 """
 function combinedims end
 function combinedims(xs::Vector; kw...)
-    reduce(xs; init=dims(first(xs))) do ds, A
-        _combinedims(ds, dims(A); kw...)
+    if length(xs) > 0
+        reduce(xs; init=dims(first(xs))) do ds, A
+            _combinedims(ds, dims(A); kw...)
+        end
+    else
+        ()
     end
 end
 combinedims(xs...; kw...) = combinedims(map(dims, xs)...; kw...)

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -537,7 +537,8 @@ function combinedims(xs::Vector; kw...)
         ()
     end
 end
-combinedims(xs...; kw...) = combinedims(map(dims, xs)...; kw...)
+combinedims(; kw...) = ()
+combinedims(x1, xs...; kw...) = combinedims(map(dims, (x1, xs...))...; kw...)
 combinedims(dt1::DimTupleOrEmpty; kw...) = dt1
 combinedims(dt1::DimTupleOrEmpty, dt2::DimTupleOrEmpty, dimtuples::DimTupleOrEmpty...; kw...) =
     reduce((dt2, dimtuples...); init=dt1) do dims1, dims2

--- a/src/stack/show.jl
+++ b/src/stack/show.jl
@@ -5,7 +5,11 @@ function Base.show(io::IO, mime::MIME"text/plain", stack::AbstractDimStack)
     layers_str = nlayers == 1 ? "layer" : "layers"
     printstyled(io, "\nand "; color=:light_black) 
     print(io, "$nlayers $layers_str:\n")
-    maxlen = reduce(max, map(length ∘ string, collect(keys(stack))))
+    maxlen = if length(keys(stack)) == 0
+        0
+    else
+        reduce(max, map(length ∘ string, collect(keys(stack))))
+    end
     for key in keys(stack)
         layer = stack[key]
         pkey = rpad(key, maxlen)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,7 +156,7 @@ function uniquekeys(das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}})
     uniquekeys(map(Symbol ∘ name, das))
 end
 function uniquekeys(das::Vector{<:AbstractDimArray})
-    uniquekeys(Symbol.(name.(das)))
+    map(uniquekeys ∘ Symbol ∘ name, das)
 end
 function uniquekeys(keys::Vector{Symbol})
     map(enumerate(keys)) do (id, k)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,7 +156,7 @@ function uniquekeys(das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}})
     uniquekeys(map(Symbol ∘ name, das))
 end
 function uniquekeys(das::Vector{<:AbstractDimArray})
-    map(uniquekeys ∘ Symbol ∘ name, das)
+    length(das) == 0 ? Symbol[] : uniquekeys(map(Symbol ∘ name, das))
 end
 function uniquekeys(keys::Vector{Symbol})
     map(enumerate(keys)) do (id, k)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -287,6 +287,7 @@ end
 
 @testset "combinedims" begin
     @test combinedims((X(1:10), Y(1:5)), (X(1:10), Z(3:10))) == (X(1:10), Y(1:5), Z(3:10))
+    @test combinedims([]) == combinedims() == ()
     @test_throws DimensionMismatch combinedims((X(1:2), Y(1:5)), (X(1:10), Z(3:10)))
 end
 

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -24,7 +24,6 @@ mixed = DimStack(da1, da2, da4)
         DimStack((one=da1, two=da2, three=da3)) == s
     @test length(DimStack(NamedTuple())) == length(DimStack()) == 0
     @test dims(DimStack()) == dims(DimStack(NamedTuple())) == ()
-    DimStack(, ())
 end
 
 @testset "ConstructionBase" begin

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -18,9 +18,13 @@ s = DimStack((da1, da2, da3))
 mixed = DimStack(da1, da2, da4)
 
 @testset "constructors" begin
-    @test DimStack((one=A, two=2A, three=3A), dimz) == s
-    @test DimStack(da1, da2, da3) == s
-    @test DimStack((one=da1, two=da2, three=da3), dimz) == s
+    @test DimStack((one=A, two=2A, three=3A), dimz) ==
+        DimStack(da1, da2, da3) ==
+        DimStack((one=da1, two=da2, three=da3), dimz) ==
+        DimStack((one=da1, two=da2, three=da3)) == s
+    @test length(DimStack(NamedTuple())) == length(DimStack()) == 0
+    @test dims(DimStack()) == dims(DimStack(NamedTuple())) == ()
+    DimStack(, ())
 end
 
 @testset "ConstructionBase" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,7 @@
 using DimensionalData, Test, Dates
 using DimensionalData.LookupArrays, DimensionalData.Dimensions
 using .LookupArrays: shiftlocus, maybeshiftlocus
+using DimensionalData: uniquekeys
 
 @testset "reverse" begin
     @testset "dimension" begin
@@ -214,4 +215,16 @@ end
         @test Dimensions.dim2boundsmatrix(dim) == [0.0 1.0 2.0
                                                    1.0 2.0 3.0]
     end
+end
+
+@testset "uniquekeys" begin
+    da1 = rand(X(2), Y(2); name=:name1)
+    da2 = rand(X(2), Y(2); name=:name1)
+    da3 = rand(X(2), Y(2); name=:name2)
+    @test uniquekeys([da1, da2, da3]) == [:layer1, :layer2, :name2] # Should we keep thoe original name?
+    @test uniquekeys((da1, da2, da3)) == (:layer1, :layer2, :name2) # Should we keep thoe original name?
+    @test uniquekeys([:name1, :name1, :name2]) == [:layer1, :layer2, :name2] # Should we keep thoe original name?
+    @test uniquekeys((:name1, :name1, :name2)) == (:layer1, :layer2, :name2) 
+    @test uniquekeys(Symbol[]) == Symbol[]
+    @test uniquekeys(()) == ()
 end


### PR DESCRIPTION
This required a few fixes  to `combinedims`, `uniquekeys` and `show` to handle zero length things.

`uniquekeys` failure seems like a base julia bug, dispatch should not be able to recur in that method, but it does. Using `map` instead of broadcasts fixed it.