### PR TITLE
Document Contains for Categoricals more clearly

### DIFF
--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -28,6 +28,12 @@ abstract type Selector{T} end
     IntSelector <: Selector
 
 Abstract supertype for [`Selector`](@ref)s that return a single `Int` index.
+
+IntSelectors provided by DimensionalData are:
+
+- [`At`](@ref)
+- [`Contains`](@ref)
+- [`Near`](@ref)
 """
 abstract type IntSelector{T} <: Selector{T} end
 
@@ -35,6 +41,12 @@ abstract type IntSelector{T} <: Selector{T} end
     ArraySelector <: Selector
 
 Abstract supertype for [`Selector`](@ref)s that return an `AbstractArray`.
+
+ArraySelectors provided by DimensionalData are:
+
+- [`Between`](@ref)
+- [`Touches`](@ref)
+- [`Where`](@ref)
 """
 abstract type ArraySelector{T} <: Selector{T} end
 

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -267,6 +267,8 @@ Selector that selects the interval the value is contained by. If the
 interval is not present in the index, an error will be thrown.
 
 Can only be used for [`Intervals`](@ref) or [`Categorical`](@ref).
+For [`Categorical`](@ref) it falls back to using [`At`](@ref).
+Use `Where(contains(x))` to check for containment in the categorical values.
 
 ## Example
 

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -268,7 +268,7 @@ interval is not present in the index, an error will be thrown.
 
 Can only be used for [`Intervals`](@ref) or [`Categorical`](@ref).
 For [`Categorical`](@ref) it falls back to using [`At`](@ref).
-Use `Where(contains(x))` to check for containment in the categorical values.
+`Contains` should not be confused with `Base.contains` - use `Where(contains(x))` to check for if values are contain in categorical values like strings.
 
 ## Example
 


### PR DESCRIPTION
This would close #532 
I am still wondering, whether we should give an error for Categorical{String} dimensions.
