### PR TITLE
fix parent of DimTable for DimStack

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -28,7 +28,7 @@ Tables.schema(s::AbstractDimStack) = Tables.schema(DimTable(s))
     Tables.getcolumn(t, dimnum(t, dim))
 
 function _colnames(s::AbstractDimStack)
-    dimkeys = map(dim2key, (dims(s)))
+    dimkeys = map(dim2key, dims(s))
     # The data is always the last column/s
     (dimkeys..., keys(s)...)
 end
@@ -165,7 +165,7 @@ DimTable with 1024 rows, 4 columns, and schema:
 ```
 """
 struct DimTable <: AbstractDimTable
-    parent::AbstractDimArray
+    parent::Union{AbstractDimArray,AbstractDimStack}
     colnames::Vector{Symbol}
     dimcolumns::Vector{DimColumn}
     dimarraycolumns::Vector{DimArrayColumn}
@@ -177,7 +177,7 @@ function DimTable(s::AbstractDimStack; mergedims=nothing)
     dimcolumns = map(d -> DimColumn(d, dims_), dims_)
     dimarraycolumns = map(A -> DimArrayColumn(A, dims_), s)
     keys = _colnames(s)
-    return DimTable(first(s), collect(keys), collect(dimcolumns), collect(dimarraycolumns))
+    return DimTable(s, collect(keys), collect(dimcolumns), collect(dimarraycolumns))
 end
 
 function DimTable(xs::Vararg{AbstractDimArray}; layernames=nothing, mergedims=nothing)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -14,7 +14,8 @@ da2 = DimArray(fill(2, (3, 2, 3)), dimz; name=:data2)
     ds = DimStack(da)
     t = Tables.columns(ds)
     @test t isa DimTable
-    @test dims(t) == dims(da)
+    @test dims(t) === dims(da)
+    @test parent(t) === ds
 
     @test Tables.columns(t) === t
     @test t[:X] isa DimColumn


### PR DESCRIPTION
@JoshuaBillson turns out I was mistaken about this, the `parent` object is really needed, our tests just didn't pick up on the difference because the stack only contains one array so the results are the same. 

Now I just test the parent object is the exact stack passed in to be sure.