### PR TITLE
allow Contains on Points

### DIFF
--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -288,12 +288,8 @@ function contains(::NoSampling, l::LookupArray, sel::Contains; kw...)
     at(l, At(val(sel)); kw...)
 end
 # Points --------------------------------------
-function contains(::Points, l::LookupArray, sel::Contains; err=_True())
-    if err isa _True
-        throw(ArgumentError("Points LookupArray cannot use `Contains`, use `Near` or `At` for Points."))
-    else
-        nothing
-    end
+function contains(::Points, l::LookupArray, sel::Contains; kw...)
+    at(l, At(val(sel)); kw...)
 end
 # Intervals -----------------------------------
 function contains(sampling::Intervals, l::LookupArray, sel::Contains; err=_True())

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -917,6 +917,11 @@ A = DimArray([1 2 3; 4 5 6], dims_)
             @test at(rev, At(30)) == 1
         end
 
+        @testset "contains" begin
+            @test contains(fwd, Contains(30)) == 26
+            @test contains(rev, Contains(30)) == 1
+        end
+
         @testset "near" begin
             @test near(fwd, Near(50))   == 26
             @test near(fwd, Near(0))    == 1
@@ -925,10 +930,6 @@ A = DimArray([1 2 3; 4 5 6], dims_)
             @test near(rev, Near(29.4)) == 2
             @test near(rev, Near(30.1)) == 1
             @test_throws ArgumentError near(Sampled((5.0:30.0); order=Unordered(), sampling=Points()), Near(30.1))
-        end
-
-        @testset "contains" begin
-            @test_throws ArgumentError contains(fwd, Contains(50))
         end
 
     end

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1346,11 +1346,6 @@ end
     @test selectindices(dims_, ()) == ()
 end
 
-@testset "errors" begin
-    @test_throws ArgumentError DimensionalData.selectindices(X(Sampled(1:4, sampling=Points())), Contains(1))
-end
-
-
 @testset "hasselection" begin
     @test hasselection(A, X(At(20)))
     @test hasselection(dims(A, X), X(At(20)))


### PR DESCRIPTION
Fixes issues brought up in #534 

@felixcremer this is just letting `Contains` work on `Points` to be consistent but not breaking.