### PR TITLE
better reorder

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           cache-registries: "true"
       - name: Install documentation dependencies
-        run: julia --project=docs -e 'using Pkg; pkg"dev ."; Pkg.instantiate()'
+        run: julia --project=docs -e 'using Pkg; pkg"dev ."; pkg"dev BaseInterfaces"; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           cache-registries: "true"
       - name: Install documentation dependencies
-        run: julia --project=docs -e 'using Pkg; pkg"dev ."; pkg"dev BaseInterfaces"; Pkg.instantiate()'
+        run: julia --project=docs -e 'using Pkg; pkg"dev ."; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,8 @@ reorder(dim::Dimension, ot::Type{<:Order}) =
 _reorder(x, orderdims::DimTuple) = _reorder(reorder(x, orderdims[1]), tail(orderdims))
 _reorder(x, orderdims::Tuple{}) = x
 
-reorder(x, orderdim::Dimension) = _reorder(val(orderdim), x, dims(x, orderdim))
+reorder(x, orderdim::Dimension{<:Order}) = _reorder(val(orderdim), x, dims(x, orderdim))
+reorder(x, orderdim::Dimension{<:LookupArray}) = _reorder(order(orderdim), x, dims(x, orderdim))
 
 _reorder(neworder::Order, x, dim::Dimension) = _reorder(basetypeof(neworder), x, dim)
 # Reverse the dimension index

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,7 +27,7 @@ true
 """
 function reorder end
 
-reorder(x, A) = reorder(x, dims(A))
+reorder(x, A::Union{AbstractDimArray,AbstractDimStack,AbstractDimIndices}) = reorder(x, dims(A))
 reorder(x, ::Nothing) = throw(ArgumentError("object has no dimensions"))
 reorder(x, p::Pair, ps::Vararg{Pair}) = reorder(x, (p, ps...))
 reorder(x, ps::Tuple{Vararg{Pair}}) = reorder(x, Dimensions.pairdims(ps...))
@@ -43,7 +43,7 @@ reorder(dim::Dimension, ot::Type{<:Order}) =
 _reorder(x, orderdims::DimTuple) = _reorder(reorder(x, orderdims[1]), tail(orderdims))
 _reorder(x, orderdims::Tuple{}) = x
 
-reorder(x, orderdim::Dimension{<:Order}) = _reorder(val(orderdim), x, dims(x, orderdim))
+reorder(x, orderdim::Dimension) = _reorder(val(orderdim), x, dims(x, orderdim))
 reorder(x, orderdim::Dimension{<:LookupArray}) = _reorder(order(orderdim), x, dims(x, orderdim))
 
 _reorder(neworder::Order, x, dim::Dimension) = _reorder(basetypeof(neworder), x, dim)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,14 +1,29 @@
 
 """
-    reorder(A::AbstractDimArray, order::Pair) => AbstractDimArray
-    reorder(A::Dimension, order::Order) => AbstractDimArray
+    reorder(A::Union{AbstractDimArray,AbstractDimStack}, order::Pair...)
+    reorder(A::Union{AbstractDimArray,AbstractDimStack}, order)
+    reorder(A::Dimension, order::Order)
 
 Reorder every dims index/array to `order`, or reorder index for
-the the given dimension(s) to the `Order` they wrap.
+the the given dimension(s) in `order`.
 
-`order` can be an [`Order`](@ref), or `Dimeension => Order` pairs.
+`order` can be an [`Order`](@ref), `Dimension => Order` pairs.
+A Tuple of Dimensions or any object that defines `dims` can be used
+in which case dimensions are
 
 If no axis reversal is required the same objects will be returned, without allocation.
+
+## Example
+
+```jldoctest
+# Create a DimArray
+da = DimArray([1 2 3; 4 5 6], (X(10:10:20), Y(300:-100:100)))
+# Reverse it
+rev = reverse(da, dims=Y)
+# using `da` in reorder will return it to the original order
+reorder(rev, da) == da
+# output 
+true
 """
 function reorder end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,6 +12,8 @@ If no axis reversal is required the same objects will be returned, without alloc
 """
 function reorder end
 
+reorder(x, A) = reorder(x, dims(A))
+reorder(x, ::Nothing) = throw(ArgumentError("object has no dimensions"))
 reorder(x, p::Pair, ps::Vararg{Pair}) = reorder(x, (p, ps...))
 reorder(x, ps::Tuple{Vararg{Pair}}) = reorder(x, Dimensions.pairdims(ps...))
 # Reorder specific dims.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -82,7 +82,12 @@ end
     @test rev != da
     @test reo == da
     @test dims(reo) == dims(da)
-    @test_throws ArgumentError reorder(rev, :test)
+    @test_throws MethodError reorder(rev, :test)
+    rev_s = reverse(s, dims=Y)
+    reo_s = reorder(rev_s, da)
+    @test rev_s != s
+    @test reo_s == s
+    @test dims(reo_s) == dims(s)
 end
 
 @testset "modify" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -75,6 +75,13 @@ end
     d = reorder(dims(da, Y), ForwardOrdered()) 
     @test order(d) isa ForwardOrdered
     @test index(d) == 100:100:300
+
+    # reorder with dimension lookups
+    rev = reverse(da, dims=Y)
+    reo = reorder(rev, dims(da))
+    @test rev != da
+    @test reo == da
+    @test dims(reo) == dims(da)
 end
 
 @testset "modify" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -78,10 +78,11 @@ end
 
     # reorder with dimension lookups
     rev = reverse(da, dims=Y)
-    reo = reorder(rev, dims(da))
+    reo = reorder(rev, da)
     @test rev != da
     @test reo == da
     @test dims(reo) == dims(da)
+    @test_throws ArgumentError reorder(rev, :test)
 end
 
 @testset "modify" begin


### PR DESCRIPTION
Somehow missed the most obvious `reorder` arguments - dimensions holding lookups with an existing order

This means we can match the order of array lookups  to any other that defines `dims`. 