### PR TITLE
add a cyclic lookup

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -168,6 +168,8 @@ LookupArrays.LookupArray
 LookupArrays.Aligned
 LookupArrays.AbstractSampled
 LookupArrays.Sampled
+LookupArrays.AbstractCyclic
+LookupArrays.Cyclic
 LookupArrays.AbstractCategorical
 LookupArrays.Categorical
 LookupArrays.Unaligned

--- a/src/LookupArrays/LookupArrays.jl
+++ b/src/LookupArrays/LookupArrays.jl
@@ -44,7 +44,7 @@ export AutoStep, AutoBounds, AutoIndex
 
 export LookupArray
 export AutoLookup, NoLookup
-export Aligned, AbstractSampled, Sampled, AbstractCategorical, Categorical
+export Aligned, AbstractSampled, Sampled, AbstractCyclic, Cyclic, AbstractCategorical, Categorical
 export Unaligned, Transformed
 
 const StandardIndices = Union{AbstractArray{<:Integer},Colon,Integer,CartesianIndex,CartesianIndices}

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -314,32 +314,22 @@ function cycle_val(l::AbstractCyclic, val)
     ncycles = (val - cycle_start) ÷ (cycle_start + cycle(l) - cycle_start)
     res = val - ncycles * cycle(l)
     # Catch precision errors
-    @show val res ncycles cycle(l)
     if (cycle_start + (ncycles + 1) * cycle(l)) <= val
-        @show "higher"
         i = 1
         while i < 10000
             if (cycle_start + (ncycles + i) * cycle(l)) > val
-                res = val - (ncycles + i - 1) * cycle(l) 
-                @show res i
-                return res
+                return val - (ncycles + i - 1) * cycle(l) 
             end
             i += 1
         end
     elseif res < cycle_start
-        @show "lower"
         i = 1
         while i < 10000
             res = val - (ncycles - i + 1) * cycle(l)
-            if res >= cycle_start
-                res = val - (ncycles - i + 1) * cycle(l)
-                @show res i val 
-                return res 
-            end
+            res >= cycle_start && return res
             i += 1
         end
     else
-        @show "no change"
         return res
     end
     error("`Cyclic` lookup too innacurate, value not found")

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -414,6 +414,7 @@ function Cyclic(data=AutoIndex();
     sampling=AutoSampling(), metadata=NoMetadata(),
     cycle, # Mandatory keyword, there are too many possible bugs with auto detection
 )
+    cycle_status = Cycling()
     Cyclic(data, order, span, sampling, metadata, cycle, cycle_status)
 end
 

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -402,12 +402,12 @@ struct Cyclic{X,T,A<:AbstractVector{T},O,Sp,Sa,M,C} <: AbstractCyclic{X,T,O,Sp,S
     metadata::M
     cycle::C
     cycle_status::X
-end
-function Cyclic(
-    data::A, order::O, span::Sp, sampling::Sa, metadata::M, cycle::C, cycle_status::X
-) where {A<:AbstractVector{T},O,Sp,Sa,M,C,X} where T
-    _check_ordered_cyclic(order)
-    Cyclic{X,T,A,O,Sp,Sa,M,C}(data, order, span, sampling, metadata, cycle, cycle_status)
+    function Cyclic(
+        data::A, order::O, span::Sp, sampling::Sa, metadata::M, cycle::C, cycle_status::X
+    ) where {A<:AbstractVector{T},O,Sp,Sa,M,C,X} where T
+        _check_ordered_cyclic(order)
+        new{X,T,A,O,Sp,Sa,M,C}(data, order, span, sampling, metadata, cycle, cycle_status)
+    end
 end
 function Cyclic(data=AutoIndex();
     order=AutoOrder(), span=AutoSpan(),

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -369,9 +369,9 @@ end
 
     Cyclic(data; order=AutoOrder(), span=AutoSpan(), sampling=Points(), metadata=NoMetadata(), cycle)
 
-A `Cyclic` lookup is similar to `Sampled` but out of range `Selectors` `At`, 
-`Near`, `Contains` will cycle the values to typemin/typemax over the
- length of `cycle`. `Where` and `..` work as for `Sampled`.
+A `Cyclic` lookup is similar to `Sampled` but out of range `Selectors` [`At`](@ref), 
+[`Near`](@ref), [`Contains`](@ref) will cycle the values to `typemin` or `typemax` 
+over the length of `cycle`. [`Where`](@ref) and `..` work as for [`Sampled`](@ref).
 
 This is useful when we are using mean annual datasets over a real time-span,
 or for wrapping longitudes so that `-360` and `360` are the same.
@@ -380,18 +380,19 @@ or for wrapping longitudes so that `-360` and `360` are the same.
 
 $SAMPLED_ARGUMENTS_DOC
 - `cycle`: the length of the cycle. This does not have to exactly match the data, 
-   the `step` size is `Week(1)` the cycle can be Years(1)`.
+   the `step` size is `Week(1)` the cycle can be `Years(1)`.
 
 ## Notes
 
 1. If you use dates and e.g. cycle over a `Year`, every year will have the 
-number and spacing of `Week`s and `Day`s as the cycle year. Using `At` may not be reliable
-in terms of exact dates, as it will be applied to the specified date plus or minus `n` years.
-2. Indexing into a `Cycled` with any `AbstractArray` or `AbstractRange` will return a `Sampled`
-as the full cycle is likely no longer available.
-3. `..` or `Between` selectors do not yet work in a cycled way: they work as for `Sampled`. 
-This may change in future to return cycled values, but there are problems with this, such as
-leap years breaking correct date cycling.
+    number and spacing of `Week`s and `Day`s as the cycle year. Using `At` may not be reliable
+    in terms of exact dates, as it will be applied to the specified date plus or minus `n` years.
+2. Indexing into a `Cycled` with any `AbstractArray` or `AbstractRange` will return 
+    a [`Sampled`](@ref) as the full cycle is likely no longer available.
+3. `..` or `Between` selectors do not work in a cycled way: they work as for [`Sampled`](@ref). 
+    This may change in future to return cycled values, but there are problems with this, such as
+    leap years breaking correct date cycling of a single year. If you actually need this behaviour, 
+    please make a GitHub issue.
 """
 struct Cyclic{X,T,A<:AbstractVector{T},O,Sp,Sa,M,C} <: AbstractCyclic{X,T,O,Sp,Sa}
     data::A

--- a/src/LookupArrays/lookup_traits.jl
+++ b/src/LookupArrays/lookup_traits.jl
@@ -269,4 +269,3 @@ change the `LookupArray` type without changing the index values.
 struct AutoIndex <: AbstractVector{Int} end
 
 Base.size(::AutoIndex) = (0,)
-

--- a/src/LookupArrays/selector.jl
+++ b/src/LookupArrays/selector.jl
@@ -122,6 +122,10 @@ selectindices(l::LookupArray, sel::At{<:AbstractVector}) = _selectvec(l, sel)
 
 _selectvec(l, sel) = [selectindices(l, rebuild(sel; val=v)) for v in val(sel)]
 
+function at(lookup::AbstractCyclic{Cycling}, sel::At; kw...) 
+    cycled_sel = rebuild(sel; val=cycle_val(lookup, val(sel)))
+    return at(no_cycling(lookup), cycled_sel; kw...) 
+end
 function at(lookup::NoLookup, sel::At; kw...) 
     v = val(sel)
     r = round(Int, v)
@@ -226,6 +230,10 @@ end
 selectindices(l::LookupArray, sel::Near) = near(l, sel)
 selectindices(l::LookupArray, sel::Near{<:AbstractVector}) = _selectvec(l, sel)
 
+function near(lookup::AbstractCyclic{Cycling}, sel::Near) 
+    cycled_sel = rebuild(sel; val=cycle_val(lookup, val(sel)))
+    near(no_cycling(lookup), cycled_sel) 
+end
 near(lookup::NoLookup, sel::Near{<:Real}) = max(1, min(round(Int, val(sel)), lastindex(lookup)))
 function near(lookup::LookupArray, sel::Near)
     span(lookup) isa Union{Irregular,Explicit} && locus(lookup) isa Union{Start,End} &&
@@ -306,6 +314,10 @@ end
 selectindices(l::LookupArray, sel::Contains; kw...) = contains(l, sel)
 selectindices(l::LookupArray, sel::Contains{<:AbstractVector}) = _selectvec(l, sel)
 
+function contains(lookup::AbstractCyclic{Cycling}, sel::Contains; kw...) 
+    cycled_sel = rebuild(sel; val=cycle_val(lookup, val(sel)))
+    return contains(no_cycling(lookup), cycled_sel; kw...) 
+end
 function contains(l::NoLookup, sel::Contains; kw...) 
     i = Int(val(sel))
     i in l || throw(SelectorError(l, i))
@@ -484,6 +496,11 @@ function between(l::NoLookup, sel::Interval)
     x = intersect(sel, first(axes(l, 1))..last(axes(l, 1)))
     return ceil(Int, x.left):floor(Int, x.right) 
 end
+# function between(l::AbstractCyclic{Cycling}, sel::Interval) 
+#     cycle_val(l, sel.x)..cycle_val(l, sel.x)
+#     cycled_sel = rebuild(sel; val=)
+#     near(no_cycling(lookup), cycled_sel; kw...) 
+# end
 between(l::LookupArray, interval::Interval) = between(sampling(l), l, interval)
 # This is the main method called above
 function between(sampling::Sampling, l::LookupArray, interval::Interval)

--- a/src/LookupArrays/show.jl
+++ b/src/LookupArrays/show.jl
@@ -73,7 +73,7 @@ end
 
 print_order(io, lookup) = print(io, nameof(typeof(order(lookup))))
 print_span(io, lookup) = print(io, nameof(typeof(span(lookup))))
-print_sampling(io, lookup) = print(io, nameof(typeof(sampling(lookup))))
+print_sampling(io, lookup) = print(io, typeof(sampling(lookup)))
 function print_metadata(io, lookup)
     metadata(lookup) isa NoMetadata && return nothing
     print(io, nameof(typeof(metadata(lookup))))

--- a/test/lookup.jl
+++ b/test/lookup.jl
@@ -246,8 +246,8 @@ end
     end
 
     @testset "Cyclic" begin
-        ind = -180.0:1:179.0
-        l = Cyclic(index; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
+        inds = -180.0:1:179.0
+        l = Cyclic(inds; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
         dim = X(l)
         @test order(dim) == ForwardOrdered()
         @test step(dim) == 1.0
@@ -261,7 +261,7 @@ end
         end
         # TODO clarify intervalbounds - we cant return the whole set to typemax, so we return onecycle?
         # @test intervalbounds(dim) 
-        dim = X(Cyclic(index; cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
+        dim = X(Cyclic(reverse(inds); cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
         @test bounds(dim) == (typemin(Float64), typemax(Float64))
         @test order(dim) == ReverseOrdered()
         @test bounds(dim) == (-Inf, Inf)

--- a/test/lookup.jl
+++ b/test/lookup.jl
@@ -255,6 +255,10 @@ end
         @test sampling(dim) == Intervals(Start())
         @test locus(dim) == Start()
         @test bounds(dim) == (-Inf, Inf)
+        # Indexing with AbstractArray returns Sampled
+        for f in (getindex, view, Base.dotview)
+            @test f(l, 1:10) isa Sampled
+        end
         # TODO clarify intervalbounds - we cant return the whole set to typemax, so we return onecycle?
         # @test intervalbounds(dim) 
         dim = X(Cyclic(index; cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))

--- a/test/lookup.jl
+++ b/test/lookup.jl
@@ -245,6 +245,25 @@ end
         @test_throws ErrorException intervalbounds(dim)
     end
 
+    @testset "Cyclic" begin
+        ind = -180.0:1:179.0
+        l = Cyclic(index; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
+        dim = X(l)
+        @test order(dim) == ForwardOrdered()
+        @test step(dim) == 1.0
+        @test span(dim) == Regular(1.0)
+        @test sampling(dim) == Intervals(Start())
+        @test locus(dim) == Start()
+        @test bounds(dim) == (-Inf, Inf)
+        # TODO clarify intervalbounds - we cant return the whole set to typemax, so we return onecycle?
+        # @test intervalbounds(dim) 
+        dim = X(Cyclic(index; cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
+        @test bounds(dim) == (typemin(Float64), typemax(Float64))
+        @test order(dim) == ReverseOrdered()
+        @test bounds(dim) == (-Inf, Inf)
+        @test_throws ArgumentError Cyclic(ind; cycle=360, order=Unordered())
+    end
+
 end
 
 @testset "dims2indices with Transformed" begin

--- a/test/lookup.jl
+++ b/test/lookup.jl
@@ -246,8 +246,8 @@ end
     end
 
     @testset "Cyclic" begin
-        inds = -180.0:1:179.0
-        l = Cyclic(inds; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
+        vals = -180.0:1:179.0
+        l = Cyclic(vals; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
         dim = X(l)
         @test order(dim) == ForwardOrdered()
         @test step(dim) == 1.0
@@ -261,11 +261,11 @@ end
         end
         # TODO clarify intervalbounds - we cant return the whole set to typemax, so we return onecycle?
         # @test intervalbounds(dim) 
-        dim = X(Cyclic(reverse(inds); cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
+        dim = X(Cyclic(reverse(vals); cycle=360.0, order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
         @test bounds(dim) == (typemin(Float64), typemax(Float64))
         @test order(dim) == ReverseOrdered()
         @test bounds(dim) == (-Inf, Inf)
-        @test_throws ArgumentError Cyclic(ind; cycle=360, order=Unordered())
+        @test_throws ArgumentError Cyclic(vals; cycle=360, order=Unordered())
     end
 
 end

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1378,6 +1378,13 @@ end
         @test at(lookup, At(DateTime(2007, 12, 31))) == findfirst(==(DateTime(2007 - 4, 12, 31)), lookup)
         @test at(lookup, At(DateTime(3000, 12, 31))) == 366 == findfirst(==(DateTime(3000 - 250 * 4, 12, 31)), lookup)
     end
+
+    @testset "Leap years are correct with four year cycles" begin
+        lookup = Cyclic(-180.0:1:179.0; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
+        @test contains(lookup, Contains(360)) == 181
+        @test contains(lookup, Contains(-360)) == 181
+        @test contains(lookup, Contains(180)) == 1
+    end
 end
 
 @testset "NoLookup" begin

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1333,57 +1333,56 @@ end
         month=Cyclic(DateTime(2001):Month(1):DateTime(2002, 12, 31); cycle=Year(1), order=ForwardOrdered(), span=Regular(Month(1)), sampling=Intervals(Start())),
         month_month=Cyclic(DateTime(2001):Month(1):DateTime(2002, 1, 31); cycle=Month(1), order=ForwardOrdered(), span=Regular(Month(1)), sampling=Intervals(Start())),
     )
-    lookup = lookups[1]
 
-    for lookup in lookups 
+    for l in lookups 
         # Test exact cycles
-        @test at(lookup, At(DateTime(1))) == 1
-        @test at(lookup, At(DateTime(1999))) == 1
-        @test at(lookup, At(DateTime(2000))) == 1
-        @test at(lookup, At(DateTime(2001))) == 1
-        @test at(lookup, At(DateTime(4000))) == 1
-        @test near(lookup, Near(DateTime(1))) == 1
-        @test near(lookup, Near(DateTime(1999))) == 1
-        @test near(lookup, Near(DateTime(2000))) == 1
-        @test near(lookup, Near(DateTime(2001))) == 1
-        @test near(lookup, Near(DateTime(4000))) == 1
-        @test contains(lookup, Contains(DateTime(1))) == 1
-        @test contains(lookup, Contains(DateTime(1999))) == 1
-        @test contains(lookup, Contains(DateTime(2000))) == 1
-        @test contains(lookup, Contains(DateTime(2001))) == 1
-        @test contains(lookup, Contains(DateTime(4000))) == 1
+        @test at(l, At(DateTime(1))) == 1
+        @test at(l, At(DateTime(1999))) == 1
+        @test at(l, At(DateTime(2000))) == 1
+        @test at(l, At(DateTime(2001))) == 1
+        @test at(l, At(DateTime(4000))) == 1
+        @test near(l, Near(DateTime(1))) == 1
+        @test near(l, Near(DateTime(1999))) == 1
+        @test near(l, Near(DateTime(2000))) == 1
+        @test near(l, Near(DateTime(2001))) == 1
+        @test near(l, Near(DateTime(4000))) == 1
+        @test contains(l, Contains(DateTime(1))) == 1
+        @test contains(l, Contains(DateTime(1999))) == 1
+        @test contains(l, Contains(DateTime(2000))) == 1
+        @test contains(l, Contains(DateTime(2001))) == 1
+        @test contains(l, Contains(DateTime(4000))) == 1
     end
 
-    lookup = lookups.month
-    @test at(lookup, At(DateTime(1, 12))) == 12
-    @test at(lookup, At(DateTime(1999, 12))) == 12
-    @test at(lookup, At(DateTime(2000, 12))) == 12
-    @test at(lookup, At(DateTime(2001, 12))) == 12
-    @test at(lookup, At(DateTime(3000, 12))) == 12
-    lookup = lookups.day
-    @test at(lookup, At(DateTime(1, 12, 31))) == 365 
-    @test at(lookup, At(DateTime(1999, 12, 31))) == 365
+    l = lookups.month
+    @test at(l, At(DateTime(1, 12))) == 12
+    @test at(l, At(DateTime(1999, 12))) == 12
+    @test at(l, At(DateTime(2000, 12))) == 12
+    @test at(l, At(DateTime(2001, 12))) == 12
+    @test at(l, At(DateTime(3000, 12))) == 12
+    l = lookups.day
+    @test at(l, At(DateTime(1, 12, 31))) == 365 
+    @test at(l, At(DateTime(1999, 12, 31))) == 365
     # This is kinda wrong, as there are 366 days in 2000
-    # But our lookup has 365. Leap years would be handled
+    # But our l has 365. Leap years would be handled
     # properly with a four year cycle
-    @test at(lookup, At(DateTime(2000, 12, 31))) == 365
-    @test at(lookup, At(DateTime(2001, 12, 31))) == 365
-    @test at(lookup, At(DateTime(3000, 12, 31))) == 365
+    @test at(l, At(DateTime(2000, 12, 31))) == 365
+    @test at(l, At(DateTime(2001, 12, 31))) == 365
+    @test at(l, At(DateTime(3000, 12, 31))) == 365
 
     @testset "Leap years are correct with four year cycles" begin
-        lookup = Cyclic(DateTime(2000):Day(1):DateTime(2003, 12, 31); cycle=Year(4), order=ForwardOrdered(), span=Regular(Day(1)), sampling=Intervals(Start()))
-        @test at(lookup, At(DateTime(1, 12, 31))) == findfirst(==(DateTime(2001, 12, 31)), lookup)
-        @test at(lookup, At(DateTime(1999, 12, 31))) == findfirst(==(DateTime(1999 + 4, 12, 31)), lookup)
-        @test at(lookup, At(DateTime(2000, 12, 31))) == 366 == findfirst(==(DateTime(2000, 12, 31)), lookup)
-        @test at(lookup, At(DateTime(2007, 12, 31))) == findfirst(==(DateTime(2007 - 4, 12, 31)), lookup)
-        @test at(lookup, At(DateTime(3000, 12, 31))) == 366 == findfirst(==(DateTime(3000 - 250 * 4, 12, 31)), lookup)
+        l = Cyclic(DateTime(2000):Day(1):DateTime(2003, 12, 31); cycle=Year(4), order=ForwardOrdered(), span=Regular(Day(1)), sampling=Intervals(Start()))
+        @test at(l, At(DateTime(1, 12, 31))) == findfirst(==(DateTime(2001, 12, 31)), l)
+        @test at(l, At(DateTime(1999, 12, 31))) == findfirst(==(DateTime(1999 + 4, 12, 31)), l)
+        @test at(l, At(DateTime(2000, 12, 31))) == 366 == findfirst(==(DateTime(2000, 12, 31)), l)
+        @test at(l, At(DateTime(2007, 12, 31))) == findfirst(==(DateTime(2007 - 4, 12, 31)), l)
+        @test at(l, At(DateTime(3000, 12, 31))) == 366 == findfirst(==(DateTime(3000 - 250 * 4, 12, 31)), l)
     end
 
-    @testset "Leap years are correct with four year cycles" begin
-        lookup = Cyclic(-180.0:1:179.0; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
-        @test contains(lookup, Contains(360)) == 181
-        @test contains(lookup, Contains(-360)) == 181
-        @test contains(lookup, Contains(180)) == 1
+    @testset "Cycling works with floats too" begin
+        l = Cyclic(-180.0:1:179.0; cycle=360.0, order=ForwardOrdered(), span=Regular(1.0), sampling=Intervals(Start()))
+        @test contains(l, Contains(360)) == 181
+        @test contains(l, Contains(-360)) == 181
+        @test contains(l, Contains(180)) == 1
     end
 end
 


### PR DESCRIPTION
This PR adds a `Cyclic` lookup type that modifies selectors to cycle the lookup below and above its range.

This works for `At`, `Near` and `Contains` 

I'm not yet sure how to support `..`. It probably needs to return a `Vector{Int}` but that would need special handling to have the correct `Ordered` unrolled cyclic lookup afterwards rather than just repeats of the cycle.