### PR TITLE
add `AutoVal` struct so keywords can be incorporated later

### DIFF
--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -35,7 +35,7 @@ export name, label, dimnum, hasdim, hasselection, otherdims, commondims, combine
     basetypeof, basedims, dimstride, dims2indices, slicedims, dimsmatch, comparedims, reducedims
 
 export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim,
-    X, Y, Z, Ti, Dim, AnonDim, Coord, MergedLookup
+    X, Y, Z, Ti, Dim, AnonDim, Coord, MergedLookup, AutoVal
 
 export @dim
 

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -341,12 +341,15 @@ struct Dim{S,T} <: Dimension{T}
         end
         new{S,typeof(val)}(val)
     end
-end
-function Dim{S}(val::AbstractArray; kw...) where S
-    if length(kw) > 0
-        val = AutoLookup(val, values(kw))
+    function Dim{S}(val::AbstractArray; kw...) where S
+        if length(kw) > 0
+            val = AutoLookup(val, values(kw))
+        end
+        Dim{S,typeof(val)}(val)
     end
-    Dim{S,typeof(val)}(val)
+    function Dim{S,T}(val::T) where {S,T}
+        new{S,T}(val)
+    end
 end
 Dim{S}() where S = Dim{S}(:)
 

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -37,6 +37,8 @@ end
 
 format(val::AbstractArray, D::Type, axis::AbstractRange) = format(AutoLookup(), D, val, axis)
 format(m::LookupArray, D::Type, axis::AbstractRange) = format(m, D, parent(m), axis)
+format(v::AutoVal, D::Type, axis::AbstractRange) = _valformaterror(val(v), D)
+format(v, D::Type, axis::AbstractRange) = _valformaterror(v, D) 
 
 # Format LookupArrays
 # No more identification required for NoLookup
@@ -130,4 +132,8 @@ checkaxis(lookup, axis) = first(axes(lookup)) == axis || _checkaxiserror(lookup,
 @noinline _checkaxiserror(lookup, axis) =
     throw(DimensionMismatch(
         "axes of $(basetypeof(lookup)) of $(first(axes(lookup))) do not match array axis of $axis"
+    ))
+@noinline _valformaterror(v, D::Type) =
+    throw(ArgumentError(
+        "Lookup value of `$v` for dimension $D cannot be converted to a `LookupArray`. Did you mean to pass a range or array?"
     ))

--- a/src/LookupArrays/lookup_arrays.jl
+++ b/src/LookupArrays/lookup_arrays.jl
@@ -423,7 +423,7 @@ _check_ordered_cyclic(order::Unordered) = throw(ArgumentError("Cyclic lookups mu
 
 function rebuild(l::Cyclic;
     data=parent(l), order=order(l), span=span(l), sampling=sampling(l), metadata=metadata(l),
-    cycle=cycle(l), _cycle_status=cycle_status(l), kw...
+    cycle=cycle(l), cycle_status=cycle_status(l), kw...
 )
     Cyclic(data, order, span, sampling, metadata, cycle, cycle_status)
 end

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -117,6 +117,13 @@ end
     @test sortdims(dimz, (X, X)) === dimz
 end
 
+@testset "constructing with keywords" begin
+    @test X(1; foo=:bar) == X(DimensionalData.AutoVal(1, (; foo=:bar)))
+    @test X(1:10; foo=:bar) == X(DimensionalData.AutoLookup(1:10, (; foo=:bar)))
+    @test Dim{:x}(1; foo=:bar) == Dim{:x}(DimensionalData.AutoVal(1, (; foo=:bar)))
+    @test Dim{:x}(1:10; foo=:bar) == Dim{:x}(DimensionalData.AutoLookup(1:10, (; foo=:bar)))
+end
+
 @testset "applying function on a dimension" begin
     d = X(0:0.01:2π)
     a = DimArray(cos, d)

--- a/test/format.jl
+++ b/test/format.jl
@@ -94,4 +94,9 @@ end
         @test format(l, X, Base.OneTo(2)) === Sampled(l, ForwardOrdered(), Regular(0.0), Points(), NoMetadata())
     end
 
+    @testset "LookupArray conversion errors" begin
+        @test_throws ArgumentError DimArray(rand(5, 4), (X(1), Y(1:4)))
+        @test_throws ArgumentError DimArray(rand(5), X(1; foo=:bar))
+    end
+
 end


### PR DESCRIPTION
This PR adds an `AutoVal` object pretty much like `AutoLookup` but isn't an `AbstractArray`.

The point of this is for easy syntax - to let a function manipulate the contents of a `Dimension` at some stage after its construction, with the option to provide keywords at the time of construction. Otherwise separate input of keywords for each dimension is needed, which is clunky.

For example: Rasters.jl will use this in dimension value detection from file names. You can do 
```julia 
Ti(Int; sampling=Intervals(Start()))
``` 

and it knows to pass those keywords to the lookup after parsing strings from the filenames for each slice to `Int`.

I'm sure it will be useful for other similar use cases.
