### PR TITLE
Reset version to 0.25.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalData"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.25.10"
+version = "0.25.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
For some reason there was no registration made with 0.25.7 and therefore all following registration attempts failed.
This should reallow the automerge of the Registrator bot. 
See https://github.com/JuliaRegistries/General/pull/96347 for the latest failing registration.