### PR TITLE
fix Makie ambiguities on 0.20

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -5,9 +5,6 @@ using DimensionalData.Dimensions, DimensionalData.LookupArrays
 
 const DD = DimensionalData
 
-# Handle changes between Makie 0.19 and 0.20
-const SurfaceLikeCompat = isdefined(Makie, :SurfaceLike) ? Makie.SurfaceLike : Union{Makie.VertexGrid,Makie.CellGrid,Makie.ImageLike}
-
 _paired(args...) = map(x -> x isa Pair ? x : x => x, args)
 
 
@@ -354,11 +351,28 @@ end
 function Makie.convert_arguments(t::Makie.PointBased, A::AbstractDimArray{<:Number,2})
     return Makie.convert_arguments(t, parent(A))
 end
-function Makie.convert_arguments(t::SurfaceLikeCompat, A::AbstractDimArray{<:Any,2})
-    A1 = _prepare_for_makie(A)
-    xs, ys = map(parent, lookup(A1))
-    return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
+
+# Handle changes between Makie 0.19 and 0.20
+@static if isdefined(Makie, :SurfaceLike) 
+    function Makie.convert_arguments(t::Makie.SurfaceLike, A::AbstractDimArray{<:Any,2})
+        A1 = _prepare_for_makie(A)
+        xs, ys = map(parent, lookup(A1))
+        return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
+    end
+else
+    function Makie.convert_arguments(t::Makie.VertexGrid, A::AbstractDimArray{<:Any,2})
+        A1 = _prepare_for_makie(A)
+        xs, ys = map(parent, lookup(A1))
+        return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
+    end
+    function Makie.convert_arguments(t::Makie.ImageLike, A::AbstractDimArray{<:Any,2})
+        A1 = _prepare_for_makie(A)
+        xs, ys = map(parent, lookup(A1))
+        return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
+    end
 end
+
+# This is now CellGrid
 function Makie.convert_arguments(
     t::Makie.DiscreteSurface, A::AbstractDimArray{<:Any,2}
 )


### PR DESCRIPTION
We needed explicit dispatch for makie recipes, the current solution hits ambiguity issues from the `Union`

`CellGrid` is actually aliased as `DiscreteSurface` which we already have, so we can ignore it.
