### PR TITLE
Makie plot tweaks and fixes

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -346,6 +346,11 @@ Makie.plottype(A::AbstractDimArray{<:Any,2}) = Makie.Heatmap
 Makie.plottype(A::AbstractDimArray{<:Any,3}) = Makie.Volume
 
 # Conversions
+function Makie.convert_arguments(t::Type{<:Makie.Image}, A::AbstractDimArray{<:Any,2})
+    A1 = _prepare_for_makie(A)
+    xs, ys = map(parent, lookup(A1))
+    return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
+end
 function Makie.convert_arguments(t::Makie.PointBased, A::AbstractDimArray{<:Any,1})
     A = _prepare_for_makie(A)
     xs = parent(lookup(A, 1))

--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -346,7 +346,7 @@ Makie.plottype(A::AbstractDimArray{<:Any,2}) = Makie.Heatmap
 Makie.plottype(A::AbstractDimArray{<:Any,3}) = Makie.Volume
 
 # Conversions
-function Makie.convert_arguments(t::Type{<:Makie.Image}, A::AbstractDimArray{<:Any,2})
+function Makie.convert_arguments(t::Type{<:Makie.AbstractPlot}, A::AbstractDimArray{<:Any,2})
     A1 = _prepare_for_makie(A)
     xs, ys = map(parent, lookup(A1))
     return xs, ys, last(Makie.convert_arguments(t, parent(A1)))
@@ -437,8 +437,8 @@ function _split_attributes(dim::Dimension)
     return attributes, dims[1]
 end
 
-function _prepare_for_makie(A, replacements=()) 
-    A1 = _permute_xyz(A, replacements) |> _reorder
+function _prepare_for_makie(A, replacements=())
+    _permute_xyz(maybeshiftlocus(Center(), A; dims=(XDim, YDim)), replacements) |> _reorder
 end
 
 # Permute the data after replacing the dimensions with X/Y/Z

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -47,5 +47,6 @@ include("indexing.jl")
 include("set.jl")
 include("show.jl")
 include("merged.jl")
+include("utils.jl")
 
 end

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -47,6 +47,5 @@ include("indexing.jl")
 include("set.jl")
 include("show.jl")
 include("merged.jl")
-include("utils.jl")
 
 end

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -192,8 +192,16 @@ LookupArrays.index(dim::Dimension{<:Val}) = unwrap(index(val(dim)))
 
 LookupArrays.bounds(dim::Dimension) = bounds(val(dim))
 LookupArrays.intervalbounds(dim::Dimension, args...) = intervalbounds(val(dim), args...)
-LookupArrays.shiftlocus(locus::Locus, dim::Dimension) = rebuild(dim, shiftlocus(locus, lookup(dim)))
-LookupArrays.maybeshiftlocus(locus::Locus, d::Dimension) = rebuild(d, maybeshiftlocus(locus, lookup(d)))
+for f in (:shiftlocus, :maybeshiftlocus)
+    @eval function LookupArrays.$f(locus::Locus, x; dims=Dimensions.dims(x))
+        newdims = map(Dimensions.dims(x, dims)) do d
+            LookupArrays.$f(locus, d)
+        end
+        return setdims(x, newdims)
+    end
+    @eval LookupArrays.$f(locus::Locus, d::Dimension) =
+        rebuild(d, LookupArrays.$f(locus, lookup(d)))
+end
 
 function hasselection(x, selectors::Union{DimTuple,SelTuple,Selector,Dimension})
     hasselection(dims(x), selectors)

--- a/src/Dimensions/utils.jl
+++ b/src/Dimensions/utils.jl
@@ -1,0 +1,13 @@
+for f in (:shiftlocus, :maybeshiftlocus)
+    @eval begin
+        function LookupArrays.$f(locus::Locus, x; dims=Dimensions.dims(x))
+            newdims = map(Dimensions.dims(x, dims)) do d
+                LookupArrays.$f(locus, d)
+            end
+            return setdims(x, newdims)
+        end
+        function LookupArrays.$f(locus::Locus, d::Dimension)
+            rebuild(d, LookupArrays.$f(locus, lookup(d)))
+        end
+    end
+end


### PR DESCRIPTION
A few fixes for makie plots:

- fix the pixel position - it can  currently be half a pixel out for intervals.
- allow `AbstractPlot` based `covert_arguments` recipe methods to work