### PR TITLE
add Begin End ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - version: 'nightly'
             os: ubuntu-latest
             arch: x64
+            allow_failure: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: true
       matrix:
@@ -23,6 +24,7 @@ jobs:
           - windows-latest
         arch:
           - x64
+        allow_failure: [false]
         include:
           - version: 'nightly'
             os: ubuntu-latest

--- a/docs/src/api/lookuparrays.md
+++ b/docs/src/api/lookuparrays.md
@@ -19,7 +19,7 @@ Lookups.Transformed
 Dimensions.MergedLookup
 Lookups.NoLookup
 Lookups.AutoLookup
-Lookups.AutoIndex
+Lookups.AutoValues
 ```
 
 The generic value getter `val`
@@ -33,7 +33,6 @@ Lookup methods:
 ```@docs
 bounds
 hasselection
-Lookups.index
 Lookups.sampling
 Lookups.span
 Lookups.order

--- a/docs/src/api/lookuparrays.md
+++ b/docs/src/api/lookuparrays.md
@@ -91,14 +91,15 @@ Lookups.Points
 Lookups.Intervals
 ```
 
-### Loci
+### Positions
 
 ```@docs
-Lookups.Locus
+Position
 Lookups.Center
 Lookups.Start
+Lookups.Begin
 Lookups.End
-Lookups.AutoLocus
+Lookups.AutoPosition
 ```
 
 ## Metadata

--- a/docs/src/dimarrays.md
+++ b/docs/src/dimarrays.md
@@ -116,6 +116,23 @@ Mixing them will throw an error:
 da1[X(3), 4]
 ```
 
+## Begin End indexing
+
+```@ansi dimarray
+da1[X=Begin+1, Y=End]
+```
+
+It also works in ranges, even with basic math:
+
+```@ansi dimarray
+da1[X=Begin:Begin+1, Y=Begin+1:End-1]
+```
+
+In base julia the keywords `begin` and `end` can be used to
+index the first or last element of an array. But this doesn't 
+work when named indexing is used. Instead you can use the types
+`Begin` and `End`.
+
 ::: info Indexing
 
 Indexing `AbstractDimArray`s works with `getindex`, `setindex!` and

--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -38,7 +38,7 @@ using .Dimensions.Lookups
 using .Dimensions: StandardIndices, DimOrDimType, DimTuple, DimTupleOrEmpty, DimType, AllDims
 import .Lookups: metadata, set, _set, rebuild, basetypeof, 
     order, span, sampling, locus, val, index, bounds, intervalbounds,
-    hasselection, units, SelectorOrInterval
+    hasselection, units, SelectorOrInterval, Begin, End
 import .Dimensions: dims, refdims, name, lookup, kw2dims, hasdim, label, _astuple
 
 import DataAPI.groupby
@@ -55,6 +55,8 @@ export X, Y, Z, Ti, Dim, Coord
 
 # Selector
 export At, Between, Touches, Contains, Near, Where, All, .., Not, Bins, CyclicBins
+
+export Begin, End
 
 export AbstractDimArray, DimArray
 

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -25,9 +25,10 @@ const LookupArrays = Lookups
 
 import .Lookups: rebuild, order, span, sampling, locus, val, index, set, _set,
     metadata, bounds, intervalbounds, units, basetypeof, unwrap, selectindices, hasselection,
-    shiftlocus, maybeshiftlocus, SelectorOrInterval, Interval
+    shiftlocus, maybeshiftlocus
 using .Lookups: StandardIndices, SelTuple, CategoricalEltypes,
-    LookupTrait, AllMetadata, LookupSetters
+    LookupTrait, AllMetadata, LookupSetters, AbstractBeginEndRange,
+    SelectorOrInterval, Interval
 
 using Base: tail, OneTo, @propagate_inbounds
 

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -11,7 +11,7 @@ Errors are thrown if dims don't match the array dims or size,
 and any fields holding `Auto-` objects are filled with guessed objects.
 
 If a [`Lookup`](@ref) hasn't been specified, a lookup is chosen
-based on the type and element type of the index.
+based on the type and element type of the values.
 """
 format(dims, A::AbstractArray) = format((dims,), A)
 function format(dims::NamedTuple, A::AbstractArray)
@@ -49,99 +49,99 @@ format(v, D::Type, axis::AbstractRange) = _valformaterror(v, D)
 
 # Format Lookups
 # No more identification required for NoLookup
-format(m::NoLookup, D::Type, index, axis::AbstractRange) = m
-format(m::NoLookup, D::Type, index::AutoIndex, axis::AbstractRange) = NoLookup(axis)
+format(m::NoLookup, D::Type, values, axis::AbstractRange) = m
+format(m::NoLookup, D::Type, values::AutoValues, axis::AbstractRange) = NoLookup(axis)
 # # AutoLookup
-function format(m::AutoLookup, D::Type, index::AbstractArray{T}, axis::AbstractRange) where T
-    # A mixed type index is Categorical
+function format(m::AutoLookup, D::Type, values::AbstractArray{T}, axis::AbstractRange) where T
+    # A mixed type lookup is Categorical
     m = if isconcretetype(T) 
         Sampled(; order=order(m), span=span(m), sampling=sampling(m), metadata=metadata(m))
     else
         o = order(m) isa AutoOrder ? Unordered() : order(m)
         Categorical(; order=o, metadata=metadata(m))
     end
-    format(m, D, index, axis)
+    format(m, D, values, axis)
 end
-function format(m::AutoLookup, D::Type, index::AbstractArray{<:CategoricalEltypes}, axis::AbstractRange)
-    o = _format(order(m), D, index)
-    return Categorical(index; order=o, metadata=metadata(m))
+function format(m::AutoLookup, D::Type, values::AbstractArray{<:CategoricalEltypes}, axis::AbstractRange)
+    o = _format(order(m), D, values)
+    return Categorical(values; order=o, metadata=metadata(m))
 end
-function format(m::Categorical, D::Type, index, axis::AbstractRange)
-    i = _format(index, axis)
-    o = _format(order(m), D, index)
+function format(m::Categorical, D::Type, values, axis::AbstractRange)
+    i = _format(values, axis)
+    o = _format(order(m), D, values)
     return rebuild(m; data=i, order=o)
 end
-# # Sampled
-function format(m::AbstractSampled, D::Type, index, axis::AbstractRange)
-    i = _format(index, axis)
-    o = _format(order(m), D, index)
-    sp = _format(span(m), D, index)
-    sa = _format(sampling(m), sp, D, index)
+# Sampled
+function format(m::AbstractSampled, D::Type, values, axis::AbstractRange)
+    i = _format(values, axis)
+    o = _format(order(m), D, values)
+    sp = _format(span(m), D, values)
+    sa = _format(sampling(m), sp, D, values)
     x = rebuild(m; data=i, order=o, span=sp, sampling=sa)
     return x
 end
-# # Transformed
-format(m::Transformed, D::Type, index::AutoIndex, axis::AbstractRange) =
+# Transformed
+format(m::Transformed, D::Type, values::AutoValues, axis::AbstractRange) =
     rebuild(m; dim=D(), data=axis)
-format(m::Transformed, D::Type, index, axis::AbstractRange) = rebuild(m; dim=D())
+format(m::Transformed, D::Type, values, axis::AbstractRange) = rebuild(m; dim=D())
 
-# Index
-_format(index::AbstractArray, axis::AbstractRange) = index
-_format(index::AutoLookup, axis::AbstractRange) = axis
+# Values
+_format(values::AbstractArray, axis::AbstractRange) = values
+_format(values::AutoLookup, axis::AbstractRange) = axis
 # Order
-_format(order::Order, D::Type, index) = order
-_format(order::AutoOrder, D::Type, index) = Lookups.orderof(index)
+_format(order::Order, D::Type, values) = order
+_format(order::AutoOrder, D::Type, values) = Lookups.orderof(values)
 # Span
-_format(span::AutoSpan, D::Type, index::Union{AbstractArray,Val}) =
-    _format(Irregular(), D, index)
-_format(span::AutoSpan, D::Type, index::AbstractRange) = Regular(step(index))
-_format(span::Regular{AutoStep}, D::Type, index::Union{AbstractArray,Val}) = _arraynosteperror()
-_format(span::Regular{AutoStep}, D::Type, index::LinRange) = Regular(step(index))
-_format(span::Regular{AutoStep}, D::Type, index::AbstractRange) = Regular(step(index))
-_format(span::Regular, D::Type, index::Union{AbstractArray,Val}) = span
-function _format(span::Regular, D::Type, index::AbstractRange)
-    step(span) isa Number && !(step(span) ≈ step(index)) && _steperror(index, span)
+_format(span::AutoSpan, D::Type, values::Union{AbstractArray,Val}) =
+    _format(Irregular(), D, values)
+_format(span::AutoSpan, D::Type, values::AbstractRange) = Regular(step(values))
+_format(span::Regular{AutoStep}, D::Type, values::Union{AbstractArray,Val}) = _arraynosteperror()
+_format(span::Regular{AutoStep}, D::Type, values::LinRange) = Regular(step(values))
+_format(span::Regular{AutoStep}, D::Type, values::AbstractRange) = Regular(step(values))
+_format(span::Regular, D::Type, values::Union{AbstractArray,Val}) = span
+function _format(span::Regular, D::Type, values::AbstractRange)
+    step(span) isa Number && !(step(span) ≈ step(values)) && _steperror(values, span)
     return span
 end
-function _format(span::Regular, D::Type, index::LinRange{T}) where T
-    step(span) isa Number && step(index) > zero(T) && !(step(span) ≈ step(index)) && _steperror(index, span)
+function _format(span::Regular, D::Type, values::LinRange{T}) where T
+    step(span) isa Number && step(values) > zero(T) && !(step(span) ≈ step(values)) && _steperror(values, span)
     return span
 end
-_format(span::Irregular{AutoBounds}, D, index) = Irregular(nothing, nothing)
-_format(span::Irregular{<:Tuple}, D, index) = span
-_format(span::Explicit, D, index) = span
+_format(span::Irregular{AutoBounds}, D, values) = Irregular(nothing, nothing)
+_format(span::Irregular{<:Tuple}, D, values) = span
+_format(span::Explicit, D, values) = span
 # Sampling
-_format(sampling::AutoSampling, span::Span, D::Type, index) = Points()
+_format(sampling::AutoSampling, span::Span, D::Type, values) = Points()
 _format(::AutoSampling, ::Span, D::Type, ::AbstractArray{<:IntervalSets.Interval}) =
     Intervals(Start())
-_format(sampling::AutoSampling, span::Explicit, D::Type, index) =
-    Intervals(_format(locus(sampling), D, index))
+_format(sampling::AutoSampling, span::Explicit, D::Type, values) =
+    Intervals(_format(locus(sampling), D, values))
 # For ambiguity, not likely to happen in practice
 _format(::AutoSampling, ::Explicit, D::Type, ::AbstractArray{<:IntervalSets.Interval}) =
-    Intervals(_format(locus(sampling), D, index))
-_format(sampling::Points, span::Span, D::Type, index) = sampling
-_format(sampling::Points, span::Explicit, D::Type, index) = _explicitpoints_error() 
-_format(sampling::Intervals, span::Span, D::Type, index) =
-    rebuild(sampling, _format(locus(sampling), D, index))
+    Intervals(_format(locus(sampling), D, values))
+_format(sampling::Points, span::Span, D::Type, values) = sampling
+_format(sampling::Points, span::Explicit, D::Type, values) = _explicitpoints_error() 
+_format(sampling::Intervals, span::Span, D::Type, values) =
+    rebuild(sampling, _format(locus(sampling), D, values))
 # Locus
-_format(locus::AutoLocus, D::Type, index) = Center()
+_format(locus::AutoLocus, D::Type, values) = Center()
 # Time dimensions need to default to the Start() locus, as that is
 # nearly always the _format and Center intervals are difficult to
 # calculate with DateTime step values.
-_format(locus::AutoLocus, D::Type{<:TimeDim}, index) = Start()
-_format(locus::Locus, D::Type, index) = locus
+_format(locus::AutoLocus, D::Type{<:TimeDim}, values) = Start()
+_format(locus::Locus, D::Type, values) = locus
 
-_order(index) = first(index) <= last(index) ? ForwardOrdered() : ReverseOrdered()
+_order(values) = first(values) <= last(values) ? ForwardOrdered() : ReverseOrdered()
 
 checkaxis(lookup::Transformed, axis) = nothing
 checkaxis(lookup, axis) = first(axes(lookup)) == axis || _checkaxiserror(lookup, axis)
 
 @noinline _explicitpoints_error() =
     throw(ArgumentError("Cannot use Explicit span with Points sampling"))
-@noinline _steperror(index, span) =
-    throw(ArgumentError("lookup step $(step(span)) does not match index step $(step(index))"))
+@noinline _steperror(values, span) =
+    throw(ArgumentError("lookup step $(step(span)) does not match lookup step $(step(values))"))
 @noinline _arraynosteperror() =
-    throw(ArgumentError("`Regular` must specify `step` size with an index other than `AbstractRange`"))
+    throw(ArgumentError("`Regular` must specify `step` size with values other than `AbstractRange`"))
 @noinline _checkaxiserror(lookup, axis) =
     throw(DimensionMismatch(
         "axes of $(basetypeof(lookup)) of $(first(axes(lookup))) do not match array axis of $axis"

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -112,6 +112,7 @@ _unwrapdim(x) = x
 @inline _dims2indices(dim::Dimension, ::Nothing) = Colon()
 @inline _dims2indices(dim::Dimension, I::AbstractBeginEndRange) = I
 @inline _dims2indices(dim::Dimension, I::StandardIndices) = I
+@inline _dims2indices(dim::Dimension, i) = Base.to_indices(parent(dim), (i,))[1]
 @inline _dims2indices(dim::Dimension, I::SelectorOrInterval) = selectindices(val(dim), I)
 
 function _extent_as_intervals(extent::Extents.Extent{Keys}) where Keys

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -28,9 +28,7 @@ end
 
 Convert a `Dimension` or `Selector` `I` to indices of `Int`, `AbstractArray` or `Colon`.
 """
-@inline dims2indices(dim::Dimension, I::StandardIndices) = I
 @inline dims2indices(dim::Dimension, I) = _dims2indices(dim, I)
-
 @inline dims2indices(x, I) = dims2indices(dims(x), I)
 @inline dims2indices(::Nothing, I) = _dimsnotdefinederror()
 @inline dims2indices(::Tuple{}, I) = ()
@@ -106,13 +104,15 @@ _unwrapdim(dim::Dimension) = val(dim)
 _unwrapdim(x) = x
 
 # Single dim methods
+# Simply unwrap dimensions
+@inline _dims2indices(dim::Dimension, seldim::Dimension) = _dims2indices(dim, val(seldim))
 # A Dimension type always means Colon(), as if it was constructed with the default value.
 @inline _dims2indices(dim::Dimension, ::Type{<:Dimension}) = Colon()
 # Nothing means nothing was passed for this dimension
 @inline _dims2indices(dim::Dimension, ::Nothing) = Colon()
-# Simply unwrap dimensions
-@inline _dims2indices(dim::Dimension, seldim::Dimension) = 
-    Lookups.selectindices(val(dim), val(seldim))
+@inline _dims2indices(dim::Dimension, I::AbstractBeginEndRange) = I
+@inline _dims2indices(dim::Dimension, I::StandardIndices) = I
+@inline _dims2indices(dim::Dimension, I::SelectorOrInterval) = selectindices(val(dim), I)
 
 function _extent_as_intervals(extent::Extents.Extent{Keys}) where Keys
     map(map(key2dim, Keys), values(extent)) do k, v

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -14,9 +14,9 @@ for f in (:getindex, :view, :dotview)
         @propagate_inbounds function Base.$f(d::Dimension{<:AbstractArray}, i::SelectorOrInterval)
             Base.$f(d, selectindices(val(d), i))
         end
-        # Everything else (like custom indexing from other packages) passes through to the parent
         @propagate_inbounds function Base.$f(d::Dimension{<:AbstractArray}, i)
-            Base.$f(parent(d), i)
+            x = Base.$f(parent(d), i)
+            x isa AbstractArray ? rebuild(d, x) : x
         end
     end
 end

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -109,11 +109,11 @@ _unwrapdim(x) = x
 # A Dimension type always means Colon(), as if it was constructed with the default value.
 @inline _dims2indices(dim::Dimension, ::Type{<:Dimension}) = Colon()
 # Nothing means nothing was passed for this dimension
+@inline _dims2indices(dim::Dimension, i::AbstractBeginEndRange) = i
+@inline _dims2indices(dim::Dimension, i::Union{LU.Begin,LU.End,Type{LU.Begin},Type{LU.End}}) = 
+    to_indices(parent(dim), (i,))[1]
 @inline _dims2indices(dim::Dimension, ::Nothing) = Colon()
-@inline _dims2indices(dim::Dimension, I::AbstractBeginEndRange) = I
-@inline _dims2indices(dim::Dimension, I::StandardIndices) = I
-@inline _dims2indices(dim::Dimension, i) = Base.to_indices(parent(dim), (i,))[1]
-@inline _dims2indices(dim::Dimension, I::SelectorOrInterval) = selectindices(val(dim), I)
+@inline _dims2indices(dim::Dimension, x) = Lookups.selectindices(val(dim), x)
 
 function _extent_as_intervals(extent::Extents.Extent{Keys}) where Keys
     map(map(key2dim, Keys), values(extent)) do k, v

--- a/src/Lookups/Lookups.jl
+++ b/src/Lookups/Lookups.jl
@@ -63,11 +63,11 @@ include("lookup_traits.jl")
 include("lookup_arrays.jl")
 include("predicates.jl")
 include("selector.jl")
+include("beginend.jl")
 include("indexing.jl")
 include("methods.jl")
 include("utils.jl")
 include("set.jl")
-include("beginend.jl")
 include("show.jl")
 
 end

--- a/src/Lookups/Lookups.jl
+++ b/src/Lookups/Lookups.jl
@@ -25,9 +25,12 @@ import InvertedIndices
 using InvertedIndices: Not
 using Base: tail, OneTo, @propagate_inbounds
 
-export order, sampling, span, bounds, locus, hasselection, dim,
-    metadata, units, sort, selectindices, val, index, reducelookup, 
-    shiftlocus, maybeshiftlocus, intervalbounds
+export order, sampling, span, bounds, hasselection, dim,
+    metadata, units, sort, selectindices, val, reducelookup, 
+    locus, shiftlocus, maybeshiftlocus, intervalbounds
+
+# Deprecated
+export index
 
 export issampled, iscategorical, iscyclic, isnolookup, isintervals, ispoints, isregular,
     isexplicit, isstart, iscenter, isend, isordered, isforward, isreverse
@@ -41,9 +44,9 @@ export LookupTrait
 export Order, Ordered, ForwardOrdered, ReverseOrdered, Unordered, AutoOrder
 export Sampling, Points, Intervals, AutoSampling, NoSampling
 export Span, Regular, Irregular, Explicit, AutoSpan, NoSpan
-export Locus, Center, Start, End, AutoLocus
+export Position, Locus, Center, Start, End, AutoLocus, AutoPosition
 export Metadata, NoMetadata
-export AutoStep, AutoBounds, AutoIndex
+export AutoStep, AutoBounds, AutoValues
 
 export Lookup
 export AutoLookup, NoLookup

--- a/src/Lookups/Lookups.jl
+++ b/src/Lookups/Lookups.jl
@@ -67,6 +67,7 @@ include("indexing.jl")
 include("methods.jl")
 include("utils.jl")
 include("set.jl")
+include("beginend.jl")
 include("show.jl")
 
 end

--- a/src/Lookups/beginend.jl
+++ b/src/Lookups/beginend.jl
@@ -1,0 +1,89 @@
+struct LazyMath{T,F}
+    f::F
+end
+LazyMath{T}(f::F) where {T,F} = LazyMath{T,F}(f)
+Base.show(io::IO, l::LazyMath{T}) where T = print(io, _print_f(T, l.f))
+
+const BeginEndRangeVals = Union{Begin,End,LazyMath,Int}
+
+# Ranges
+abstract type AbstractBeginEndRange <: Function end
+struct BeginEndRange{A<:BeginEndRangeVals,B<:BeginEndRangeVals} <: AbstractBeginEndRange
+    start::A
+    stop::B
+end
+struct BeginEndStepRange{A<:BeginEndRangeVals,B<:BeginEndRangeVals} <: AbstractBeginEndRange
+    start::A
+    step::Int
+    stop::B
+end
+
+Base.first(r::AbstractBeginEndRange) = r.start
+Base.last(r::AbstractBeginEndRange) = r.stop
+Base.step(r::BeginEndStepRange) = r.step
+
+(::Colon)(a::LazyMath, b::LazyMath) = BeginEndRange(a, b)
+(::Colon)(a::Union{Int,LazyMath}, b::Union{Type{Begin},Type{End}}) = BeginEndRange(a, b())
+(::Colon)(a::Union{Type{Begin},Type{End}}, b::Union{Int,LazyMath}) = BeginEndRange(a(), b)
+(::Colon)(a::Union{Type{Begin},Type{End}}, b::Union{Type{Begin},Type{End}}) = BeginEndRange(a(), b())
+
+(::Colon)(a::LazyMath, step::Int, b::LazyMath) = BeginEndStepRange(a, step, b)
+(::Colon)(a::Union{Int,LazyMath}, step::Int, b::Union{Type{Begin},Type{End}}) = BeginEndStepRange(a, step, b())
+(::Colon)(a::Union{Type{Begin},Type{End}}, step::Int, b::Union{Int,LazyMath}) = BeginEndStepRange(a(), step, b)
+(::Colon)(a::Union{Type{Begin},Type{End}}, step::Int, b::Union{Type{Begin},Type{End}}) = 
+    BeginEndStepRange(a(), step, b())
+
+
+Base.to_indices(A, inds, (r, args...)::Tuple{BeginEndRange,Vararg}) =
+    (_to_index(inds[1], r.start):_to_index(inds[1], r.stop), to_indices(A, Base.tail(inds), args)...)
+Base.to_indices(A, inds, (r, args...)::Tuple{BeginEndStepRange,Vararg}) =
+    (_to_index(inds[1], r.start):r.step:_to_index(inds[1], r.stop), to_indices(A, Base.tail(inds), args)...)
+
+_to_index(inds, a::Int) = a
+_to_index(inds, ::Begin) = first(inds)
+_to_index(inds, ::End) = last(inds)
+_to_index(inds, l::LazyMath{End}) = l.f(last(inds))
+_to_index(inds, l::LazyMath{Begin}) = l.f(first(inds))
+
+Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, ber::AbstractBeginEndRange) =
+    Base.checkindex(Bool, inds, _to_index(inds, first(ber)):_to_index(inds, last(ber)))
+
+for f in (:+, :-, :*, :÷, :|, :&)
+    @eval Base.$f(::Type{T}, i::Int) where T <: Union{Begin,End} = LazyMath{T}(Base.Fix2($f, i))
+    @eval Base.$f(i::Int, ::Type{T}) where T <: Union{Begin,End} = LazyMath{T}(Base.Fix1($f, i))
+    @eval Base.$f(x::LazyMath{T}, i::Int) where T = LazyMath{T}(Base.Fix2(x.f ∘ $f, i))
+    @eval Base.$f(i::Int, x::LazyMath{T}) where T = LazyMath{T}(Base.Fix1(x.f ∘ $f, i))
+end
+
+
+Base.show(io::IO, ::MIME"text/plain", r::AbstractBeginEndRange) = show(io, r)
+function Base.show(io::IO, r::BeginEndRange)  
+    _show(io, first(r))
+    print(io, ':')
+    _show(io, last(r))
+end
+function Base.show(io::IO, r::BeginEndStepRange)  
+    _show(io, first(r))
+    print(io, ':')
+    show(io, step(r))
+    print(io, ':')
+    _show(io, last(r))
+end
+
+_show(io, x::Union{Begin,End}) = show(io, typeof(x))
+_show(io, x) = show(io, x)
+# Here we recursively print `Fix1` and `Fix2` either left or right 
+# to recreate the function
+_print_f(T, f) = string(T, _pf(f))
+_print_f(T, f::Base.ComposedFunction) = string('(', _print_f(T, f.outer), ')', _print_f("", f.inner))
+_print_f(T, f::Base.Fix1) = string(f.x, _print_f(T, f.f))
+_print_f(T, f::Base.Fix2) = string(_print_f(T, f.f), f.x)
+
+_pf(::typeof(div)) = "÷"
+_pf(f) = string(f)
+
+for T in (UnitRange, AbstractUnitRange, StepRange, StepRangeLen, LinRange)
+    for f in (:getindex, :view, :dotview)
+        @eval Base.$f(A::$T, i::AbstractBeginEndRange) = Base.$f(A, to_indices(A, (i,))...)
+    end
+end

--- a/src/Lookups/indexing.jl
+++ b/src/Lookups/indexing.jl
@@ -9,7 +9,12 @@ for f in (:getindex, :view, :dotview)
             rebuild(l; data=Base.$f(parent(l), i))
         # Selector gets processed with `selectindices`
         @propagate_inbounds Base.$f(l::Lookup, i::SelectorOrInterval) = Base.$f(l, selectindices(l, i))
-        # Everything else (like custom indexing from other packages) passes through to the parent
-        @propagate_inbounds Base.$f(l::Lookup, i) = Base.$f(parent(l), i)
+        @propagate_inbounds function Base.$f(l::Lookup, i)
+            x = Base.$f(parent(l), i)
+            x isa AbstractArray ? rebuild(l; data=x) : x
+        end
+        @propagate_inbounds function Base.$f(l::Lookup, i::AbstractBeginEndRange)
+            l[Base.to_indices(l, (i,))...]
+        end
     end
 end

--- a/src/Lookups/lookup_arrays.jl
+++ b/src/Lookups/lookup_arrays.jl
@@ -263,7 +263,7 @@ $SAMPLED_ARGUMENTS_DOC
 
 Create an array with [`Interval`] sampling, and `Regular` span for a vector with known spacing.
 
-We set the [`Locus`](@ref) of the `Intervals` to `Start` specifying
+We set the [`locus`](@ref) of the `Intervals` to `Start` specifying
 that the lookup values are for the locuss at the start of each interval.
 
 ```jldoctest Sampled

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -111,6 +111,9 @@ struct Start <: Position end
 
 Used to specify the `begin` index of a `Dimension` axis. 
 as regular `begin` will not work with named dimensions.
+
+Can be used with `:` to create a `BeginEndRange` or 
+`BeginEndStepRange`.
 """
 struct Begin <: Position end
 
@@ -121,8 +124,8 @@ struct Begin <: Position end
 
 Used to specify the `end` index of a `Dimension` axis, 
 as regular `end` will not work with named dimensions.
-Can be used with `:` to create a [`BeginEndRange`](@ref)
-or [`BeginEndStepRange`](@ref).
+Can be used with `:` to create a `BeginEndRange` or 
+`BeginEndStepRange`.
 
 Also used to specify lookup values correspond to the end 
 locus of an interval.

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -74,7 +74,7 @@ isrev(::Type{<:ReverseOrdered}) = true
 """
    Position <: LookupTrait
 
-Abstract supertype of types that indicate the position of index values
+Abstract supertype of types that indicate the locus of index values
 where they represent [`Intervals`](@ref).
 
 These allow for values array cells to align with the [`Start`](@ref),
@@ -90,7 +90,7 @@ abstract type Position <: LookupTrait end
 
     Center()
 
-Used to specify lookup values correspond to the center position in an interval.
+Used to specify lookup values correspond to the center locus in an interval.
 """
 struct Center <: Position end
 
@@ -100,7 +100,7 @@ struct Center <: Position end
     Start()
 
 Used to specify lookup values correspond to the center 
-position of an interval.
+locus of an interval.
 """
 struct Start <: Position end
 
@@ -119,11 +119,13 @@ struct Begin <: Position end
 
     End()
 
-Used to specify the `end` index of aa `Dimension` axis, 
+Used to specify the `end` index of a `Dimension` axis, 
 as regular `end` will not work with named dimensions.
+Can be used with `:` to create a [`BeginEndRange`](@ref)
+or [`BeginEndStepRange`](@ref).
 
-Also ysed to specify lookup values correspond to the center 
-position of an interval.
+Also used to specify lookup values correspond to the end 
+locus of an interval.
 """
 struct End <: Position end
 
@@ -132,12 +134,12 @@ struct End <: Position end
 
     AutoPosition()
 
-Indicates a interval where the index position is not yet known.
+Indicates a interval where the index locus is not yet known.
 This will be filled with a default value on object construction.
 """
 struct AutoPosition <: Position end
 
-# Deprecated
+# Locus does not include `Begin` 
 const Locus = Union{AutoPosition,Start,Center,End}
 const AutoLocus = AutoPosition
 
@@ -171,7 +173,7 @@ locus(sampling::Points) = Center()
 """
     Intervals <: Sampling
 
-    Intervals(locus::Locus)
+    Intervals(locus::Position)
 
 [`Sampling`](@ref) specifying that sampled values are the mean (or similar)
 value over an _interval_, rather than at one specific point.
@@ -179,8 +181,8 @@ value over an _interval_, rather than at one specific point.
 Intervals require a [`Locus`](@ref) of [`Start`](@ref), [`Center`](@ref) or
 [`End`](@ref) to define the location in the interval that the index values refer to.
 """
-struct Intervals{L} <: Sampling
-    locus::L
+struct Intervals{P} <: Sampling
+    locus::P
 end
 Intervals() = Intervals(AutoPosition())
 
@@ -270,12 +272,12 @@ Base.:(==)(l1::Explicit, l2::Explicit) = val(l1) == val(l2)
 Adapt.adapt_structure(to, s::Explicit) = Explicit(Adapt.adapt_structure(to, val(s)))
 
 """
-    AutoIndex
+    AutoValues
 
-Detect a `Lookup` index from the context. This is used in `NoLookup` to simply
+Detect `Lookup` values from the context. This is used in `NoLookup` to simply
 use the array axis as the index when the array is constructed, and in `set` to
 change the `Lookup` type without changing the index values.
 """
-struct AutoIndex <: AbstractVector{Int} end
+struct AutoValues <: AbstractVector{Int} end
 
-Base.size(::AutoIndex) = (0,)
+Base.size(::AutoValues) = (0,)

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -181,7 +181,7 @@ locus(sampling::Points) = Center()
 [`Sampling`](@ref) specifying that sampled values are the mean (or similar)
 value over an _interval_, rather than at one specific point.
 
-Intervals require a [`Locus`](@ref) of [`Start`](@ref), [`Center`](@ref) or
+Intervals require a [`locus`](@ref) of [`Start`](@ref), [`Center`](@ref) or
 [`End`](@ref) to define the location in the interval that the index values refer to.
 """
 struct Intervals{P} <: Sampling

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -72,7 +72,7 @@ isrev(::Type{<:ForwardOrdered}) = false
 isrev(::Type{<:ReverseOrdered}) = true
 
 """
-   Locus <: LookupTrait
+   Position <: LookupTrait
 
 Abstract supertype of types that indicate the position of index values
 where they represent [`Intervals`](@ref).
@@ -83,49 +83,63 @@ These allow for values array cells to align with the [`Start`](@ref),
 This means they can be plotted with correct axis markers, and allows automatic
 converrsions to between formats with different standards (such as NetCDF and GeoTiff).
 """
-abstract type Locus <: LookupTrait end
+abstract type Position <: LookupTrait end
 
 """
-    Center <: Locus
+    Center <: Position
 
     Center()
 
-Indicates a lookup value is for the center of its corresponding array cell.
+Used to specify lookup values correspond to the center position in an interval.
 """
-struct Center <: Locus end
+struct Center <: Position end
 
 """
-    Begin <: Locus
+    Start <: Position
+
+    Start()
+
+Used to specify lookup values correspond to the center 
+position of an interval.
+"""
+struct Start <: Position end
+
+"""
+    Begin <: Position
 
     Begin()
 
-Indicates a lookup value is for the start of its corresponding array cell,
-in the direction of the lookup index order.
+Used to specify the `begin` index of a `Dimension` axis. 
+as regular `begin` will not work with named dimensions.
 """
-struct Begin <: Locus end
-
-const Start = Begin
+struct Begin <: Position end
 
 """
-    End <: Locus
+    End <: Position
 
     End()
 
-Indicates a lookup value is for the end of its corresponding array cell,
-in the direction of the lookup index order.
+Used to specify the `end` index of aa `Dimension` axis, 
+as regular `end` will not work with named dimensions.
+
+Also ysed to specify lookup values correspond to the center 
+position of an interval.
 """
-struct End <: Locus end
+struct End <: Position end
 
 """
-    AutoLocus <: Locus
+    AutoPosition <: Position
 
-    AutoLocus()
+    AutoPosition()
 
 Indicates a interval where the index position is not yet known.
 This will be filled with a default value on object construction.
 """
-struct AutoLocus <: Locus end
+struct AutoPosition <: Position end
 
+# Deprecated
+const Locus = Union{AutoPosition,Start,Center,End}
+const AutoLocus = AutoPosition
 
 """
     Sampling <: LookupTrait
@@ -139,7 +153,7 @@ struct NoSampling <: Sampling end
 locus(sampling::NoSampling) = Center()
 
 struct AutoSampling <: Sampling end
-locus(sampling::AutoSampling) = AutoLocus()
+locus(sampling::AutoSampling) = AutoPosition()
 
 """
     Points <: Sampling
@@ -168,7 +182,7 @@ Intervals require a [`Locus`](@ref) of [`Start`](@ref), [`Center`](@ref) or
 struct Intervals{L} <: Sampling
     locus::L
 end
-Intervals() = Intervals(AutoLocus())
+Intervals() = Intervals(AutoPosition())
 
 locus(sampling::Intervals) = sampling.locus
 rebuild(::Intervals, locus) = Intervals(locus)

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -297,4 +297,13 @@ _to_indices(a::Int, inds) = a
 _to_indices(::Begin, inds) = first(inds)
 _to_indices(::End, inds) = last(inds)
 
+struct Lazy{T,F}
+    f::F
+end
 
+for f in (:+, :-, :*, :÷, :|, :&, :mod, :rem)
+    @eval Base.$f(::Type{T}, i::Int) where T <: Union{Begin,End} = Lazy{T}(Fix1($f, i))
+    @eval Base.$f(i::Int, ::Type{T}) where T <: Union{Begin,End} = Lazy{T}(Fix2($f, i))
+    @eval Base.$f(x::Lazy{T}, i::Int) where T = Lazy{T}(Fix1(x.f ∘ $f, i))
+    @eval Base.$f(i::Int, ::Type{T}) where T <: Union{Begin,End} = Lazy{T}(Fix2($f, i))
+end

--- a/src/Lookups/methods.jl
+++ b/src/Lookups/methods.jl
@@ -3,7 +3,7 @@
 Base.reverse(lookup::NoLookup) = lookup
 Base.reverse(lookup::AutoLookup) = lookup
 function Base.reverse(lookup::AbstractCategorical)
-    i = reverse(index(lookup))
+    i = reverse(parent(lookup))
     o = reverse(order(lookup))
     rebuild(lookup; data=i, order=o)
 end

--- a/src/Lookups/selector.jl
+++ b/src/Lookups/selector.jl
@@ -77,7 +77,10 @@ function selectindices(l::Lookup, sel::Not; kw...)
     indices = selectindices(l, sel.skip; kw...)
     return first(to_indices(l, (Not(indices),)))
 end
-selectindices(l::Lookup, i; kw...) = first(Base.to_indices(l, (i,)))
+@inline function selectindices(l::Lookup, sel; kw...)
+    selstr = sprint(show, sel)
+    throw(ArgumentError("Invalid index `$selstr`. Did you mean `At($selstr)`? Use stardard indices, `Selector`s, or `Val` for compile-time `At`."))
+end
 
 """
     At <: IntSelector
@@ -1043,10 +1046,6 @@ function selectindices end
 # @inline selectindices(dim::Lookup, sel::Val) = selectindices(val(dim), At(sel))
 # Standard indices are just returned.
 @inline selectindices(::Lookup, sel::StandardIndices) = sel
-@inline function selectindices(l::Lookup, sel)
-    selstr = sprint(show, sel)
-    throw(ArgumentError("Invalid index `$selstr`. Did you mean `At($selstr)`? Use stardard indices, `Selector`s, or `Val` for compile-time `At`."))
-end
 # Vectors are mapped
 @inline selectindices(lookup::Lookup, sel::Selector{<:AbstractVector}) =
     [selectindices(lookup, rebuild(sel; val=v)) for v in val(sel)]

--- a/src/Lookups/selector.jl
+++ b/src/Lookups/selector.jl
@@ -77,6 +77,7 @@ function selectindices(l::Lookup, sel::Not; kw...)
     indices = selectindices(l, sel.skip; kw...)
     return first(to_indices(l, (Not(indices),)))
 end
+selectindices(l::Lookup, i; kw...) = first(Base.to_indices(l, (i,)))
 
 """
     At <: IntSelector

--- a/src/Lookups/set.jl
+++ b/src/Lookups/set.jl
@@ -15,7 +15,7 @@ _set(lookup::Lookup, newlookup::AbstractCategorical) = begin
     rebuild(newlookup; data=parent(lookup), order=o, metadata=md)
 end
 _set(lookup::AbstractSampled, newlookup::AutoLookup) = begin
-    # Update index
+    # Update lookup values
     lookup = _set(lookup, parent(newlookup))
     o = _set(order(lookup), order(newlookup))
     sa = _set(sampling(lookup), sampling(newlookup))
@@ -34,24 +34,24 @@ _set(lookup::Lookup, newlookup::AbstractSampled) = begin
     # Rebuild the new lookup with the merged fields
     rebuild(newlookup; data=parent(lookup), order=o, span=sp, sampling=sa, metadata=md)
 end
-_set(lookup::AbstractArray, newlookup::NoLookup{<:AutoIndex}) = NoLookup(axes(lookup, 1))
-_set(lookup::Lookup, newlookup::NoLookup{<:AutoIndex}) = NoLookup(axes(lookup, 1))
+_set(lookup::AbstractArray, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
+_set(lookup::Lookup, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
 _set(lookup::Lookup, newlookup::NoLookup) = newlookup
 
-# Set the index
-_set(lookup::Lookup, index::Val) = rebuild(lookup; data=index)
-_set(lookup::Lookup, index::Colon) = lookup
-_set(lookup::Lookup, index::AutoLookup) = lookup
-_set(lookup::Lookup, index::AbstractArray) = rebuild(lookup; data=index)
+# Set the lookup values
+_set(lookup::Lookup, values::Val) = rebuild(lookup; data=values)
+_set(lookup::Lookup, values::Colon) = lookup
+_set(lookup::Lookup, values::AutoLookup) = lookup
+_set(lookup::Lookup, values::AbstractArray) = rebuild(lookup; data=values)
 
-_set(lookup::Lookup, index::AutoIndex) = lookup
-_set(lookup::Lookup, index::AbstractRange) =
-    rebuild(lookup; data=_set(parent(lookup), index), order=orderof(index))
+_set(lookup::Lookup, values::AutoValues) = lookup
+_set(lookup::Lookup, values::AbstractRange) =
+    rebuild(lookup; data=_set(parent(lookup), values), order=orderof(values))
 # Update the Sampling lookup of Sampled dims - it must match the range.
-_set(lookup::AbstractSampled, index::AbstractRange) = begin
-    i = _set(parent(lookup), index)
-    o = orderof(index)
-    sp = Regular(step(index))
+_set(lookup::AbstractSampled, values::AbstractRange) = begin
+    i = _set(parent(lookup), values)
+    o = orderof(values)
+    sp = Regular(step(values))
     rebuild(lookup; data=i, span=sp, order=o)
 end
 
@@ -79,26 +79,26 @@ _set(sampling::Sampling, newsampling::Intervals) =
 # Locus
 _set(lookup::AbstractSampled, locus::Locus) =
     rebuild(lookup; sampling=_set(sampling(lookup), locus))
-_set(sampling::Points, locus::Union{AutoLocus,Center}) = Points()
+_set(sampling::Points, locus::Union{AutoPosition,Center}) = Points()
 _set(sampling::Points, locus::Locus) = _locuserror()
 _set(sampling::Intervals, locus::Locus) = Intervals(locus)
-_set(sampling::Intervals, locus::AutoLocus) = sampling
+_set(sampling::Intervals, locus::AutoPosition) = sampling
 
 _set(locus::Locus, newlocus::Locus) = newlocus
-_set(locus::Locus, newlocus::AutoLocus) = locus
+_set(locus::Locus, newlocus::AutoPosition) = locus
 
 # Metadata
 _set(lookup::Lookup, newmetadata::AllMetadata) = rebuild(lookup; metadata=newmetadata)
 _set(metadata::AllMetadata, newmetadata::AllMetadata) = newmetadata
 
-# Index
-_set(index::AbstractArray, newindex::AbstractArray) = newindex
-_set(index::AbstractArray, newindex::AutoLookup) = index
-_set(index::AbstractArray, newindex::Colon) = index
-_set(index::Colon, newindex::AbstractArray) = newindex
-_set(index::Colon, newindex::Colon) = index
+# Looup values
+_set(values::AbstractArray, newvalues::AbstractArray) = newvalues
+_set(values::AbstractArray, newvalues::AutoLookup) = values
+_set(values::AbstractArray, newvalues::Colon) = values
+_set(values::Colon, newvalues::AbstractArray) = newvalues
+_set(values::Colon, newvalues::Colon) = values
 
 _set(A, x) = _cantseterror(A, x)
 
-@noinline _locuserror() = throw(ArgumentError("Can't set a locus for `Points` sampling other than `Center` - the index values are the exact points"))
+@noinline _locuserror() = throw(ArgumentError("Can't set a locus for `Points` sampling other than `Center` - the lookup values are the exact points"))
 @noinline _cantseterror(a, b) = throw(ArgumentError("Can not set any fields of $(typeof(a)) to $(typeof(b))"))

--- a/src/Lookups/utils.jl
+++ b/src/Lookups/utils.jl
@@ -1,47 +1,47 @@
 """
     shiftlocus(locus::Locus, x)
 
-Shift the index of `x` from the current locus to the new locus.
+Shift the values of `x` from the current locus to the new locus.
 
 We only shift `Sampled`, `Regular` or `Explicit`, `Intervals`. 
 """
 function shiftlocus(locus::Locus, lookup::Lookup)
     samp = sampling(lookup)
     samp isa Intervals || error("Cannot shift locus of $(nameof(typeof(samp)))")
-    newindex = _shiftindexlocus(locus, lookup)
-    newlookup = rebuild(lookup; data=newindex)
+    newvalues = _shiftlocus(locus, lookup)
+    newlookup = rebuild(lookup; data=newvalues)
     return set(newlookup, locus)
 end
 
 # Fallback - no shifting
-_shiftindexlocus(locus::Locus, lookup::Lookup) = index(lookup)
+_shiftlocus(locus::Locus, lookup::Lookup) = parent(lookup)
 # Sampled
-function _shiftindexlocus(locus::Locus, lookup::AbstractSampled)
-    _shiftindexlocus(locus, span(lookup), sampling(lookup), lookup)
+function _shiftlocus(locus::Locus, lookup::AbstractSampled)
+    _shiftlocus(locus, span(lookup), sampling(lookup), lookup)
 end
 # TODO:
-_shiftindexlocus(locus::Locus, span::Irregular, sampling::Sampling, lookup::Lookup) = index(lookup)
+_shiftlocus(locus::Locus, span::Irregular, sampling::Sampling, lookup::Lookup) = parent(lookup)
 # Sampled Regular
-function _shiftindexlocus(destlocus::Center, span::Regular, sampling::Intervals, dim::Lookup)
+function _shiftlocus(destlocus::Center, span::Regular, sampling::Intervals, l::Lookup)
     if destlocus === locus(sampling)
-        return index(dim)
+        return parent(l)
     else
         offset = _offset(locus(sampling), destlocus)
-        shift = ((index(dim) .+ abs(step(span))) .- index(dim)) .* offset
-        return index(dim) .+ shift
+        shift = ((parent(l) .+ abs(step(span))) .- parent(l)) .* offset
+        return parent(l) .+ shift
     end
 end
-function _shiftindexlocus(destlocus::Locus, span::Regular, sampling::Intervals, lookup::Lookup)
-    index(lookup) .+ (abs(step(span)) * _offset(locus(sampling), destlocus))
+function _shiftlocus(destlocus::Locus, span::Regular, sampling::Intervals, lookup::Lookup)
+    parent(lookup) .+ (abs(step(span)) * _offset(locus(sampling), destlocus))
 end
 # Sampled Explicit
-_shiftindexlocus(::Start, span::Explicit, sampling::Intervals, lookup::Lookup) = val(span)[1, :]
-_shiftindexlocus(::End, span::Explicit, sampling::Intervals, lookup::Lookup) = val(span)[2, :]
-function _shiftindexlocus(destlocus::Center, span::Explicit, sampling::Intervals, lookup::Lookup)
-    _shiftindexlocus(destlocus, locus(lookup), span, sampling, lookup)
+_shiftlocus(::Start, span::Explicit, sampling::Intervals, lookup::Lookup) = val(span)[1, :]
+_shiftlocus(::End, span::Explicit, sampling::Intervals, lookup::Lookup) = val(span)[2, :]
+function _shiftlocus(destlocus::Center, span::Explicit, sampling::Intervals, lookup::Lookup)
+    _shiftlocus(destlocus, locus(lookup), span, sampling, lookup)
 end
-_shiftindexlocus(::Center, ::Center, span::Explicit, sampling::Intervals, lookup::Lookup) = index(lookup)
-function _shiftindexlocus(::Center, ::Locus, span::Explicit, sampling::Intervals, lookup::Lookup)
+_shiftlocus(::Center, ::Center, span::Explicit, sampling::Intervals, lookup::Lookup) = parent(lookup)
+function _shiftlocus(::Center, ::Locus, span::Explicit, sampling::Intervals, lookup::Lookup)
     # A little complicated so that DateTime works
     (view(val(span), 2, :)  .- view(val(span), 1, :)) ./ 2 .+ view(val(span), 1, :)
 end
@@ -110,3 +110,6 @@ end
 
 _order(A) = first(A) <= last(A) ? ForwardOrdered() : ReverseOrdered()
 _order(A::AbstractArray{<:IntervalSets.Interval}) = first(A).left <= last(A).left ? ForwardOrdered() : ReverseOrdered()
+
+@deprecate maybeshiftlocus maybeshiftlocus
+@deprecate shiftlocus shiftlocus

--- a/src/array/indexing.jl
+++ b/src/array/indexing.jl
@@ -62,17 +62,19 @@ for f in (:getindex, :view, :dotview)
         # Except 1D DimArrays
         @propagate_inbounds Base.$f(A::AbstractDimVector, i::Union{Colon,AbstractArray{<:Integer}}) =
             rebuildsliced(Base.$f, A, Base.$f(parent(A), i), (i,))
+        @propagate_inbounds Base.$f(A::AbstractDimVector, i::SelectorOrInterval) = 
+            Base.$f(A, dims2indices(A, (i,))...)
         # Selector/Interval indexing
         @propagate_inbounds Base.$f(A::AbstractDimArray, i1::SelectorOrStandard, i2::SelectorOrStandard, I::SelectorOrStandard...) =
             Base.$f(A, dims2indices(A, (i1, i2, I...))...)
 
-        @propagate_inbounds Base.$f(A::AbstractDimVector, extent::Extents.Extent) =
+        @propagate_inbounds Base.$f(A::AbstractDimVector, extent::Union{Extents.Extent,Touches{<:Extents.Extent}}) =
             Base.$f(A, dims2indices(A, extent)...)
-        @propagate_inbounds Base.$f(A::AbstractDimArray, extent::Extents.Extent) =
+        @propagate_inbounds Base.$f(A::AbstractDimArray, extent::Union{Extents.Extent,Touches{<:Extents.Extent}}) =
             Base.$f(A, dims2indices(A, extent)...)
-        @propagate_inbounds Base.$f(A::AbstractBasicDimVector, extent::Extents.Extent) =
+        @propagate_inbounds Base.$f(A::AbstractBasicDimVector, extent::Union{Extents.Extent,Touches{<:Extents.Extent}}) =
             Base.$f(A, dims2indices(A, extent)...)
-        @propagate_inbounds Base.$f(A::AbstractBasicDimArray, extent::Extents.Extent) =
+        @propagate_inbounds Base.$f(A::AbstractBasicDimArray, extent::Union{Extents.Extent,Touches{<:Extents.Extent}}) =
             Base.$f(A, dims2indices(A, extent)...)
         # All Dimension indexing modes combined
         @propagate_inbounds Base.$f(A::AbstractBasicDimArray; kw...) =

--- a/src/array/indexing.jl
+++ b/src/array/indexing.jl
@@ -37,6 +37,22 @@ for f in (:getindex, :view, :dotview)
             @propagate_inbounds Base.$f(A::AbstractDimArray, I::CartesianIndices) =
                 Base.$f(A, to_indices(A, (I,))...)
         end
+        @propagate_inbounds function Base.$f(A::AbstractDimVector, i)
+            x = Base.$f(parent(A), i)
+            if $f != view || x isa AbstractArray
+                rebuildsliced(Base.$f, A, x, i)
+            else
+                x
+            end
+        end
+        @propagate_inbounds function Base.$f(A::AbstractDimArray, i1, i2, I...)
+            x = Base.$f(parent(A), i1, i2, I...)
+            if $f != view || x isa AbstractArray
+                rebuildsliced(Base.$f, A, x, to_indices(A, (i1, i2, I...)))
+            else
+                x
+            end
+        end
         # Linear indexing forwards to the parent array as it will break the dimensions
         @propagate_inbounds Base.$f(A::AbstractDimArray, i::Union{Colon,AbstractArray{<:Integer}}) =
             Base.$f(parent(A), i)

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -301,7 +301,7 @@ function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
         else
             # Concatenate new dims
             if all(map(x -> hasdim(refdims(x), catdim), Xin))
-                if catdim isa Dimension && val(catdim) isa AbstractArray && !(lookup(catdim) isa NoLookup{AutoIndex})
+                if catdim isa Dimension && val(catdim) isa AbstractArray && !(lookup(catdim) isa NoLookup{AutoValues})
                     # Combine the refdims properties with the passed in catdim
                     set(refdims(first(Xin), catdim), catdim)
                 else

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -142,7 +142,7 @@ function print_metadata_block(io, mime, metadata; blockwidth=0, displaywidth)
     else
         metadata_lines = split(sprint(show, mime, metadata), "\n")
         new_blockwidth = min(displaywidth-2, max(blockwidth, maximum(length, metadata_lines) + 4))
-        print_block_separator(io, "metadata", blockwidth, new_blockwidth)
+        new_blockwidth = print_block_separator(io, "metadata", blockwidth, new_blockwidth)
         println(io)
         print(io, "  ")
         show(io, mime, metadata)
@@ -179,7 +179,9 @@ function print_block_separator(io, label, prev_width, new_width=prev_width)
         line = string('├', '─'^max(0, new_width - textwidth(label) - 2))
         corner = '┤'
     end
-    printstyled(io, string(line, ' ', label, ' ', corner); color=:light_black)
+    full = string(line, ' ', label, ' ', corner)
+    printstyled(io, full; color=:light_black)
+    return length(full) - 2
 end
 
 function print_block_close(io, blockwidth)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -95,10 +95,15 @@ function val end
     lookup(x, dim) => Lookup
 
 Returns the [`Lookup`](@ref) of a dimension. This dictates
-properties of the dimension such as array axis and index order,
+properties of the dimension such as array axis and lookup order,
 and sampling properties.
 
 `dims` can be a `Dimension`, a dimension type, or a tuple of either.
+
+This is separate from `val` in that it will only work when dimensions
+actually contain an `AbstractArray` lookup, and can be used on a 
+`DimArray` or `DimStack` to retriev all lookups, as there is no ambiguity 
+of meaning as there is with `val`.
 """
 function lookup end
 
@@ -108,23 +113,6 @@ function lookup end
 # Lookup, and tuples of Dimension/Lookup. A `dims` argument
 # can be supplied to select a subset of dimensions or a single
 # Dimension.
-
-"""
-    index(x) => Tuple{Vararg{AbstractArray}}
-    index(x, dims::Tuple) => Tuple{Vararg{AbstractArray}}
-    index(dims::Tuple) => Tuple{Vararg{AbstractArray}}}
-    index(x, dim) => AbstractArray
-    index(dim::Dimension) => AbstractArray
-
-Return the contained index of a `Dimension`.
-
-Only valid when a `Dimension` contains an `AbstractArray`
-or a Val tuple like `Val{(:a, :b)}()`. The `Val` is unwrapped
-to return just the `Tuple`
-
-`dims` can be a `Dimension`, or a tuple of `Dimension`.
-"""
-function index end
 
 """
     metadata(x) => (object metadata)
@@ -202,7 +190,7 @@ function bounds end
     order(xs::Tuple) => Tuple
     order(x::Union{Dimension,Lookup}) => Order
 
-Return the `Ordering` of the dimension index for each dimension:
+Return the `Ordering` of the dimension lookup for each dimension:
 `ForwardOrdered`, `ReverseOrdered`, or [`Unordered`](@ref) 
 
 Second argument `dims` can be `Dimension`s, `Dimension` types,
@@ -242,7 +230,7 @@ function span end
     locus(xs::Tuple) => Tuple{Vararg{Locus,N}}
     locus(x::Union{Dimension,Lookup}) => Locus
 
-Return the [`Locus`](@ref) for each dimension.
+Return the [`Position`](@ref) of lookup values for each dimension.
 
 Second argument `dims` can be `Dimension`s, `Dimension` types,
 or `Symbols` for `Dim{Symbol}`.

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -75,7 +75,7 @@ end
     ind, dep = dims(A)
     :xguide --> label(A)
     :legendtitle --> label(dep)
-    :label --> string.(permutedims(index(dep)))
+    :label --> string.(permutedims(parent(lookup(dep))))
     _withaxes(ind, A)
 end
 
@@ -91,7 +91,7 @@ end
     :xguide --> label(ind)
     :yguide --> label(A)
     :legendtitle --> label(ind)
-    :label --> string.(permutedims(index(ind)))
+    :label --> string.(permutedims(parent(lookup(ind))))
     _xticks!(plotattributes, s, ind)
     parent(A)
 end
@@ -102,7 +102,7 @@ end
     :xguide --> label(ind)
     :yguide --> label(A)
     :legendtitle --> label(ind)
-    :label --> string.(permutedims(index(ind)))
+    :label --> string.(permutedims(parent(lookup(ind))))
     _xticks!(plotattributes, s, ind)
     parent(A)
 end
@@ -132,27 +132,27 @@ end
 
 
 _withaxes(dim::Dimension, A::AbstractDimArray) =
-    _withaxes(lookup(dim), index(dim), parent(A))
-_withaxes(::NoLookup, index, A::AbstractArray) = A
-_withaxes(::Lookup, index, A::AbstractArray) = index, A
-_withaxes(::Categorical, index, A::AbstractArray) = eachindex(index), A
+    _withaxes(lookup(dim), parent(lookup(dim)), parent(A))
+_withaxes(::NoLookup, values, A::AbstractArray) = A
+_withaxes(::Lookup, values, A::AbstractArray) = values, A
+_withaxes(::Categorical, values, A::AbstractArray) = eachindex(values), A
 
 _withaxes(dx::Dimension, dy::Dimension, A::AbstractDimArray) =
-    _withaxes(lookup(dx), lookup(dy), index(dx), index(dy), parent(A))
+    _withaxes(lookup(dx), lookup(dy), parent(lookup(dx)), parent(lookup(dy)), parent(A))
 _withaxes(::Lookup, ::Lookup, ix, iy, A) = ix, iy, A
 _withaxes(::NoLookup, ::Lookup, ix, iy, A) = axes(A, 2), iy, A
 _withaxes(::Lookup, ::NoLookup, ix, iy, A) = ix, axes(A, 1), A
 _withaxes(::NoLookup, ::NoLookup, ix, iy, A) = axes(A, 2), axes(A, 1), A
 
-_xticks!(attr, s, d::Dimension) = _xticks!(attr, s, lookup(d), index(d))
-_xticks!(attr, s, ::Categorical, index) =
-    RecipesBase.is_explicit(attr, :xticks) || (attr[:xticks] = (eachindex(index), index))
-_xticks!(attr, s, ::Lookup, index) = nothing
+_xticks!(attr, s, d::Dimension) = _xticks!(attr, s, lookup(d), parent(lookup(d)))
+_xticks!(attr, s, ::Categorical, values) =
+    RecipesBase.is_explicit(attr, :xticks) || (attr[:xticks] = (eachindex(values), values))
+_xticks!(attr, s, ::Lookup, values) = nothing
 
-_yticks!(attr, s, d::Dimension) = _yticks!(attr, s, lookup(d), index(d))
-_yticks!(attr, s, ::Categorical, index) =
-    RecipesBase.is_explicit(attr, :yticks) || (attr[:yticks] = (eachindex(index), index))
-_yticks!(attr, s, ::Lookup, index) = nothing
+_yticks!(attr, s, d::Dimension) = _yticks!(attr, s, lookup(d), parent(lookup(d)))
+_yticks!(attr, s, ::Categorical, values) =
+    RecipesBase.is_explicit(attr, :yticks) || (attr[:yticks] = (eachindex(values), values))
+_yticks!(attr, s, ::Lookup, values) = nothing
 
 ### Shared utils
 

--- a/src/stack/indexing.jl
+++ b/src/stack/indexing.jl
@@ -17,7 +17,7 @@ for f in (:getindex, :view, :dotview)
 end
 
 for f in (:getindex, :view, :dotview)
-    _f = Symbol(:_, f)
+    _dim_f = Symbol(:_dim_, f)
     @eval begin
         @propagate_inbounds function Base.$f(s::AbstractDimStack, i::Union{SelectorOrInterval,Extents.Extent})
             Base.$f(s, dims2indices(s, i)...)
@@ -69,7 +69,7 @@ for f in (:getindex, :view, :dotview)
         @propagate_inbounds function Base.$f(
             s::AbstractDimStack, D::DimensionalIndices...; kw...
         )
-            $_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
+            $_dim_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
         end
         # Ambiguities
         @propagate_inbounds function Base.$f(
@@ -78,33 +78,33 @@ for f in (:getindex, :view, :dotview)
             ::Union{Tuple{Dimension,Vararg{Dimension}},AbstractArray{<:Dimension},AbstractArray{<:Tuple{Dimension,Vararg{Dimension}}},DimIndices,DimSelectors,Dimension},
             ::_DimIndicesAmb...
         )
-            $_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
+            $_dim_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
         end
         @propagate_inbounds function Base.$f(
             s::AbstractDimStack, 
             d1::Union{AbstractArray{Union{}}, DimIndices{<:Integer}, DimSelectors{<:Integer}}, 
             D::Vararg{Union{AbstractArray{Union{}}, DimIndices{<:Integer}, DimSelectors{<:Integer}}}
         )
-            $_f(s, _simplify_dim_indices(d1, D...))
+            $_dim_f(s, _simplify_dim_indices(d1, D...))
         end
         @propagate_inbounds function Base.$f(
             s::AbstractDimStack, 
             D::Union{AbstractArray{Union{}},DimIndices{<:Integer},DimSelectors{<:Integer}}
         )
-            $_f(s, _simplify_dim_indices(D...))
+            $_dim_f(s, _simplify_dim_indices(D...))
         end
 
 
-        @propagate_inbounds function $_f(
+        @propagate_inbounds function $_dim_f(
             A::AbstractDimStack, a1::Union{Dimension,DimensionIndsArrays}, args::Union{Dimension,DimensionIndsArrays}...
         )
             return merge_and_index(Base.$f, A, (a1, args...))
         end
         # Handle zero-argument getindex, this will error unless all layers are zero dimensional
-        @propagate_inbounds function $_f(s::AbstractDimStack)
+        @propagate_inbounds function $_dim_f(s::AbstractDimStack)
             map(Base.$f, s)
         end
-        @propagate_inbounds function $_f(s::AbstractDimStack, d1::Dimension, ds::Dimension...)
+        @propagate_inbounds function $_dim_f(s::AbstractDimStack, d1::Dimension, ds::Dimension...)
             D = (d1, ds...)
             extradims = otherdims(D, dims(s))
             length(extradims) > 0 && Dimensions._extradimswarn(extradims)

--- a/src/stack/show.jl
+++ b/src/stack/show.jl
@@ -37,7 +37,7 @@ function print_layers_block(io, mime, stack; blockwidth, displaywidth)
     for key in keys(layers)
         newblockwidth = min(displaywidth - 2, max(newblockwidth, length(sprint(print_layer, stack, key, keylen))))
     end
-    print_block_separator(io, "layers", blockwidth, newblockwidth)
+    newblockwidth = print_block_separator(io, "layers", blockwidth, newblockwidth)
     println(io)
     for key in keys(layers)
         print_layer(io, stack, key, keylen)

--- a/test/adapt.jl
+++ b/test/adapt.jl
@@ -43,7 +43,7 @@ end
     @test parent(parent(l1)) isa Base.OneTo
     l = AutoLookup()
     l1 = Adapt.adapt(CustomArray, l)
-    @test parent(l1) isa AutoIndex
+    @test parent(l1) isa AutoValues
 end
 
 @testset "Dimension" begin

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -42,8 +42,9 @@ end
 @testset "lookup" begin
     @testset "Points" begin
         l = Sampled(2.0:2.0:10, ForwardOrdered(), Regular(2.0), Points(), nothing)
-        @test l[:] == l
-        @test l[1:5] == l
+        @test l[:] == l[Begin:End] == l
+        @test l[Begin:5] == l[1:5] == l
+        @test l[Begin:End] isa typeof(l)
         @test l[1:5] isa typeof(l)
         @test l[[1, 3, 4]] == view(l, [1, 3, 4]) == 
             Base.dotview(l, [1, 3, 4]) ==
@@ -110,9 +111,10 @@ end
 
     @testset "Intervals" begin
         l = Sampled(2.0:2.0:10, ForwardOrdered(), Regular(2.0), Intervals(Start()), nothing)
-        @test l[:] == l
+        @test l[:] == l[Begin:End] == l
         @test l[1:5] == l
         @test l[1:5] isa typeof(l)
+        @test l[Begin:End] isa typeof(l)
         @test l[[1, 3, 4]] == Sampled([2.0, 6.0, 8.0], ForwardOrdered(), Irregular(2.0, 10.0), Intervals(Start()), nothing)
         @test l[Int[]] == Sampled(Float64[], ForwardOrdered(), Irregular(nothing, nothing), Intervals(Start()), nothing)
         @test l[Near(2.1)] == 2.0
@@ -168,7 +170,9 @@ end
     d = X(Sampled(2.0:2.0:10, ForwardOrdered(), Regular(2.0), Points(), nothing))
     @test @inferred d[:] == d
     @test @inferred d[1:5] == d
-    @test @inferred d[1:5] isa typeof(d)
+    @test d[1:5] isa typeof(d)
+    @test @inferred d[Begin:End] == d
+    @test d[Begin:End] isa typeof(d)
     # TODO properly handle index mashing arrays: here Regular should become Irregular
     # @test d[[1, 3, 4]] == X(Sampled([2.0, 6.0, 8.0], ForwardOrdered(), Regular(2.0), Points(), nothing))
     # @test d[[true, false, false, false, true]] == X(Sampled([2.0, 10.0], ForwardOrdered(), Regular(2.0), Points(), nothing))

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -560,7 +560,7 @@ end
     end
 
     @testset "view" begin
-        sv = @inferred view(s, 1, 1)
+        sv = @inferred view(s, Begin, Begin)
         @test parent(sv) == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
         @test dims(sv) == ()
         sv = @inferred view(s, X(1:2), Y(3:3)) 
@@ -574,7 +574,7 @@ end
             @test linear2d isa DimStack
             @test parent(linear2d) == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
             @test_broken linear1d = @inferred view(s[X(1)], 1)
-            linear1d = view(s[X(1)], 1)
+            linear1d = view(s, 1)
             @test linear1d isa DimStack
             @test parent(linear1d) == (one=fill(1.0), two=fill(2.0f0), three=fill(3))
             linear2d = view(s, 1:2)
@@ -640,4 +640,29 @@ end
     @test @inferred view(A1, Ti(5)) == permutedims([5])
     @test @inferred view(A2, Ti(5)) == permutedims([5])
     @test @inferred view(A3, Ti(5)) == permutedims([5])
+end
+
+@testset "Begin End indexng" begin
+    @testset "generic indexing" begin
+        @test (1:10)[Begin] == 1
+        @test (1:10)[Begin()] == 1
+        @test (1:10)[End] == 10
+        @test (1:10)[End()] == 10
+        @test (1:10)[Begin:End] == 1:10
+        @test (1:10)[Begin:10] == 1:10
+        @test (1:10)[1:End] == 1:10
+        @test (1:10)[Begin():End()] == 1:10
+        @test (1:10)[Begin+1:End-1] == 2:9
+        @test (1:10)[Begin()+1:End()-1] == 2:9
+        @test (1:10)[Begin:End÷2] == 1:5
+        @test (1:10)[Begin|3:End] == 3:10
+        @test (1:10)[Begin:End&3] == 1:2
+        @test (1:10)[Begin()+1:End()-1] == 2:9
+    end
+    @testset "dimension indexing" begin
+        A = DimArray((1:5)*(6:3:20)', (X, Y))
+        @test A[X=Begin, Y=End] == 18
+        @test A[X=End(), Y=Begin()] == 30
+        @test A[X=Begin:Begin+1, Y=End] == [18, 36]
+    end
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -334,9 +334,9 @@ end
             da2 = DimArray(randn(2, 3), (X(1:2), Y(1:3)))
 
             for inds in ((), (1,), (1, 1), (1, 1, 1), (CartesianIndex(),), (CartesianIndices(da0),))
-                @test typeof(parent(view(da0, inds...))) === typeof(view(parent(da0), inds...))
-                @test parent(view(da0, inds...)) == view(parent(da0), inds...)
                 a = view(da0, inds...)
+                @test typeof(parent(a)) === typeof(view(parent(da0), inds...))
+                @test parent(a) == view(parent(da0), inds...)
                 @test a isa DimArray{eltype(da0),0}
                 @test length(dims(a)) == 0
                 @test length(refdims(a)) == 0
@@ -569,7 +569,7 @@ end
         @test @inferred slicedds[:one] == [1.0, 2.0, 3.0]
         @test parent(slicedds) == (one=[1.0, 2.0, 3.0], two=[2.0f0, 4.0f0, 6.0f0], three=[3, 6, 9])
         @testset "linear indices" begin
-            @test_broken linear2d = @inferred view(s, 1)
+            linear2d = @inferred view(s, 1)
             linear2d = view(s, 1)
             @test linear2d isa DimStack
             @test parent(linear2d) == (one=fill(1.0), two=fill(2.0f0), three=fill(3))

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1027,11 +1027,7 @@ end
         for idx in indices
             from2d = view(da, idx)
             @test from2d == view(parent(da), idx)
-            if idx isa Integer
-                @test from2d isa DimArray
-            else
-                @test from2d isa SubArray
-            end
+            @test from2d isa SubArray
             from1d = view(da[Y(At(10))], idx)
             @test from1d == view(parent(da)[1, :], idx)
             @test from1d isa DimArray
@@ -1144,7 +1140,7 @@ end
     @testset "Extent indexing" begin
         # THese should be the same because da is the maximum size
         # we can index with `Touches`
-        da[Touches(Extents.extent(da))] == da[Extents.extent(da)] == da
+        @test da[Touches(Extents.extent(da))] == da[Extents.extent(da)] == da
     end
 
     @testset "with dim wrappers" begin

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -976,7 +976,7 @@ end
             (Near([13]), Near([1.3u"s", 3.3u"s"])),
             (Between(11, 20), At((2:3)u"s"))
         ]
-        positions =  [
+        locuss =  [
             (1:3, [3, 4]),
             (2, [3, 4]),
             (2, [2, 3]),
@@ -984,7 +984,7 @@ end
             ([1], [1, 3]),
             (2:2, [2, 3])
         ]
-        for (selector, pos) in zip(selectors, positions)
+        for (selector, pos) in zip(selectors, locuss)
             pairs = collect(zip(selector, pos))
             cases = [(i, j) for i in pairs[1], j in pairs[2]]
             for (case1, case2) in combinations(cases, 2)

--- a/test/set.jl
+++ b/test/set.jl
@@ -69,7 +69,7 @@ end
     cat_da = set(da, X=NoLookup(), Y=Categorical())
     @test index(cat_da) == 
         (NoLookup(Base.OneTo(2)), Categorical(-38.0:2.0:-36.0, Unordered(), NoMetadata())) 
-    cat_da_m = set(dims(cat_da, Y), X(DimensionalData.AutoIndex(); metadata=Dict()))
+    cat_da_m = set(dims(cat_da, Y), X(DimensionalData.AutoValues(); metadata=Dict()))
     @test metadata(cat_da_m) == Dict()
  
     @testset "span" begin


### PR DESCRIPTION
its been really annoying me lately that we can't use `begin` and `end` in dimensional `getindex`.

So I'm considering repurposing our exising `Start`/`End` types to use as placeholders in ranges to work like `begin` and `end` (probably making an alias `Begin = Start`.

Closes #195