### PR TITLE
allow extra dims in reorder

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,7 +40,10 @@ reorder(dim::Dimension, ot::Type{<:Order}) =
     ot <: basetypeof(order(dim)) ? dim : reverse(dim)
 
 # Recursive reordering. x may be reversed here
-_reorder(x, orderdims::DimTuple) = _reorder(reorder(x, orderdims[1]), tail(orderdims))
+function _reorder(x, orderdims::DimTuple)
+    ods = commondims(orderdims, dims(x))
+    _reorder(reorder(x, ods[1]), tail(ods))
+end
 _reorder(x, orderdims::Tuple{}) = x
 
 reorder(x, orderdim::Dimension) = _reorder(val(orderdim), x, dims(x, orderdim))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -88,6 +88,12 @@ end
     @test rev_s != s
     @test reo_s == s
     @test dims(reo_s) == dims(s)
+
+
+    @testset "reorder handles extra dimensions" begin
+        @test reorder(da[X=1], X=>ReverseOrdered(), Y=>ForwardOrdered()) == rev[X=1]
+        @test reorder(rev_s[X=1], da) == s[X=1]
+    end
 end
 
 @testset "modify" begin


### PR DESCRIPTION
Slightly annoying you cant pass a `DimArray` with more dims than you need as the second argument of `reorder`.

So we just drop any extra dimensions and reorder by the ones that match.