### PR TITLE
no custom `lookup` for AnonDim

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -380,7 +380,6 @@ end
 AnonDim() = AnonDim(Colon())
 AnonDim(val, arg1, args...) = AnonDim(val)
 
-lookup(::AnonDim) = NoLookup()
 metadata(::AnonDim) = NoMetadata()
 name(::AnonDim) = :Anon
 


### PR DESCRIPTION
For some reason there was a useless `lookup` method for `AnonDim` that returned `NoLookup` when it actually holds a lookup and the values/length matters

Closes #511