### PR TITLE
Reverse along all dimensions by default

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -592,7 +592,6 @@ function _reverse(A::AbstractDimArray, dims)
     # Use setdims here because newdims is not all the dims
     setdims(rebuild(A, newdata), newdims)
 end
-
 _reverse(dims::Tuple{Vararg{Dimension}}) = map(d -> reverse(d), dims)
 _reverse(dim::Dimension) = reverse(dim)
 

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -586,7 +586,6 @@ function _reverse(A::AbstractDimArray, ::Colon)
     # Use setdims here because newdims is not all the dims
     setdims(rebuild(A, newdata), newdims)
 end
-
 function _reverse(A::AbstractDimArray, dims)
     newdims = _reverse(DD.dims(A, dims))
     newdata = reverse(parent(A); dims=dimnum(A, dims))

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -578,14 +578,23 @@ function Base._replace!(new::Base.Callable, res::AbstractDimArray, A::AbstractDi
     return res
 end
 
-function Base.reverse(A::AbstractDimArray; dims=1)
+Base.reverse(A::AbstractDimArray; dims=:) = _reverse(A, dims)
+
+function _reverse(A::AbstractDimArray, ::Colon)
+    newdims = _reverse(DD.dims(A))
+    newdata = reverse(parent(A))
+    # Use setdims here because newdims is not all the dims
+    setdims(rebuild(A, newdata), newdims)
+end
+
+function _reverse(A::AbstractDimArray, dims)
     newdims = _reverse(DD.dims(A, dims))
     newdata = reverse(parent(A); dims=dimnum(A, dims))
     # Use setdims here because newdims is not all the dims
     setdims(rebuild(A, newdata), newdims)
 end
 
-_reverse(dims::Tuple) = map(d -> reverse(d), dims)
+_reverse(dims::Tuple{Vararg{Dimension}}) = map(d -> reverse(d), dims)
 _reverse(dim::Dimension) = reverse(dim)
 
 # Dimension

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,13 +15,21 @@ using DimensionalData: uniquekeys
     da = DimArray(A, (X(10:10:20), Y(300:-100:100)); name=:test)
     s = DimStack(da)
 
-    rev = reverse(da; dims=Y)
-    @test rev == [3 2 1; 6 5 4]
-    @test index(rev, X) == 10:10:20
-    @test index(rev, Y) == 100:100:300
-    @test span(rev, Y) == Regular(100)
-    @test order(rev, Y) == ForwardOrdered()
-    @test order(rev, X) == ForwardOrdered()
+    rev_y = reverse(da; dims=Y)
+    @test rev_y == [3 2 1; 6 5 4]
+    @test index(rev_y, X) == 10:10:20
+    @test index(rev_y, Y) == 100:100:300
+    @test span(rev_y, Y) == Regular(100)
+    @test order(rev_y, Y) == ForwardOrdered()
+    @test order(rev_y, X) == ForwardOrdered()
+
+    rev = reverse(da; dims=:)
+    @test parent(rev) == reverse(parent(da))
+    @test all(index(rev, d) == reverse(index(da, d)) for d in (X,Y))
+    @test all(span(rev, d) == reverse(span(da, d)) for d in (X,Y))
+    @test all(order(rev, d) == reverse(order(da, d)) for d in (X,Y))
+    @test rev == reverse(da; dims=(X,Y))
+
 
     @testset "NoLookup dim index is not reversed" begin
         da = DimArray(A, (X(), Y()))


### PR DESCRIPTION
Fixes #622.

Changes `reverse(::AbstractDimArray)` to reverse along all dimensions instead of just the first one.  Equivalently, a `:` may be passed to the `dims` argument and is the new default. This behavior is consistent with what happens for a plain `AbstractArray`.