### PR TITLE
dont break the show_after interface

### DIFF
--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -95,7 +95,6 @@ print_type(io, x::AbstractArray{T,N}) where {T,N} = print(io, string(nameof(type
 print_type(io, x) = print(io, string(nameof(typeof(x))))
 
 function print_top(io, mime, A)
-    lines = 4
     _, displaywidth = displaysize(io)
     blockwidth = min(displaywidth - 2, textwidth(sprint(summary, A)) + 2)
     printstyled(io, '╭', '─'^blockwidth, '╮'; color=:light_black)
@@ -105,7 +104,7 @@ function print_top(io, mime, A)
     printstyled(io, " │"; color=:light_black)
     println(io)
     n, blockwidth = print_dims_block(io, mime, dims(A); displaywidth, blockwidth)
-    lines += n + 1
+    lines = 2 + n
     return lines, blockwidth, displaywidth
 end
 
@@ -129,10 +128,10 @@ function print_dims_block(io, mime, dims; displaywidth, blockwidth, label="dims"
     else
         dim_lines = split(sprint(print_dims, mime, dims), '\n')
         new_blockwidth = min(displaywidth - 2, max(blockwidth, maximum(textwidth, dim_lines)))
-        print_block_top(io, label, blockwidth, new_blockwidth)
+        lines += print_block_top(io, label, blockwidth, new_blockwidth)
         lines += print_dims(io, mime, dims; kw...)
         println(io)
-        lines += 2
+        lines += 1
         printed = true
     end
     return lines, new_blockwidth, printed
@@ -170,6 +169,8 @@ function print_block_top(io, label, prev_width, new_width)
     end
     printstyled(io, top_line; color=:light_black)
     println(io)
+    lines = 1
+    return lines
 end
 
 function print_block_separator(io, label, prev_width, new_width)

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -124,7 +124,7 @@ function print_dims_block(io, mime, dims; displaywidth, blockwidth, label="dims"
     lines = 0
     if isempty(dims)
         printed = false
-        newblockwidth = blockwidth
+        new_blockwidth = blockwidth
     else
         dim_lines = split(sprint(print_dims, mime, dims), '\n')
         new_blockwidth = min(displaywidth - 2, max(blockwidth, maximum(textwidth, dim_lines)))

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -279,7 +279,6 @@ function _print_matrix(io::IO, A::AbstractArray{<:Any,2}, lookups::Tuple)
 
     # A bit convoluted so it plays nice with GPU arrays
     topleft = Matrix{eltype(A)}(undef, map(length, (itop, ileft)))
-    @show CartesianIndices(topleft) CartesianIndices((itop, ileft))
     copyto!(topleft, CartesianIndices(topleft), A, CartesianIndices((itop, ileft)))
     bottomleft = Matrix{eltype(A)}(undef, map(length, (ibottom, ileft))) 
     copyto!(bottomleft, CartesianIndices(bottomleft), A, CartesianIndices((ibottom, ileft)))

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -269,7 +269,6 @@ function _print_matrix(io::IO, A::AbstractArray{<:Any,2}, lookups::Tuple)
         ibottom = s1 < h  ? (f1:f1 - 1) : (f1 + s1 - h ÷ 2 - 1:f1 + s1 - 1)
         ileft   = s2 < wn ? (f2:l2)     : (f2:f2 + wn ÷ 2 - 1)
         iright  = s2 < wn ? (f2:f2 - 1) : (f2 + s2 - wn ÷ 2:f2 + s2 - 1)
-        @show f1 f2 l1 l2 itop ibottom ileft iright
     else
         itop    = f1:l1
         ibottom = f1:f1-1

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -317,20 +317,6 @@ end
     return view(ds._data, rebuild(d, d[i]))
 end
 
-# function Base.show(io::IO, mime, A::DimSlices)
-#     parentdims = otherdims(A.data, dims(A))
-#     _, width = displaysize(io)
-#     sorteddims = (dims(A)..., otherdims(parentdims, dims(A))...)
-#     colordims = dims(map(rebuild, sorteddims, ntuple(dimcolors, Val(length(sorteddims)))), dims(first(A)))
-#     colors = collect(map(val, colordims))
-#     print_dims_block(io, mime, basedims(first(A)); width, maxlen, label="group dims", colors)
-#     length(A) > 0 || return nothing
-#     A1 = map(x -> DimSummariser(x, colors), A)
-#     show_after(io, mime, A1; maxlen)
-#     map(x -> DimSummariser(x, colors), A)
-#     Base.printmatrix(io, A)
-# end
-
 # Extends the dimensions of any `AbstractBasicDimArray`
 # as if the array assigned into a larger array accross all dimensions,
 # but without the copying. Theres is a cost for linear indexing these objects

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -51,15 +51,18 @@ function Base.summary(io::IO, A::DimGroupByArray{T,N}) where {T,N}
     print(io, string(nameof(typeof(A)), "{$(nameof(T)),$N}"))
 end
 
-function show_after(io::IO, mime, A::DimGroupByArray; maxlen=0)
-    _, width = displaysize(io)
+function show_after(io::IO, mime, A::DimGroupByArray)
+    _, displaywidth = displaysize(io)
+    blockwidth = get(io, :blockwidth, 0)
     sorteddims = (dims(A)..., otherdims(first(A), dims(A))...)
     colordims = dims(map(rebuild, sorteddims, ntuple(dimcolors, Val(length(sorteddims)))), dims(first(A)))
     colors = collect(map(val, colordims))
-    print_dims_block(io, mime, basedims(first(A)); width, maxlen, label="group dims", colors)
+    print_dims_block(io, mime, basedims(first(A)); 
+        displaywidth, blockwidth, label="group dims", colors
+    )
     length(A) > 0 || return nothing
     A1 = map(x -> DimSummariser(x, colors), A)
-    show_after(io, mime, A1; maxlen)
+    show_after(io, mime, A1; blockwidth)
     return nothing
 end
 

--- a/src/stack/show.jl
+++ b/src/stack/show.jl
@@ -20,7 +20,8 @@ function show_main(io, mime, stack::AbstractDimStack)
     _, blockwidth = print_metadata_block(io, mime, metadata(stack); displaywidth, blockwidth=min(displaywidth-2, blockwidth))
 end
 
-function show_after(io, mime, stack::AbstractDimStack; blockwidth)
+function show_after(io, mime, stack::AbstractDimStack)
+    blockwidth = get(io, :blockwidth, 0)
     print_block_close(io, blockwidth)
 end
 


### PR DESCRIPTION
Closes #635

Now the block width is passed in `io` as `:blockwidth`, if packages need it. 