### PR TITLE
Breaking: document and tweak stack interface

### DIFF
--- a/docs/src/stacks.md
+++ b/docs/src/stacks.md
@@ -12,7 +12,10 @@ x, y = X(1.0:10.0), Y(5.0:10.0)
 st = DimStack((a=rand(x, y), b=rand(x, y), c=rand(y), d=rand(x)))
 ````
 
-The behaviour is somewhere ebetween a `NamedTuple` and an `AbstractArray`.
+The behaviour of a `DimStack` is at times like a `NamedTuple` of
+`DimArray` and, others an `AbstractArray` of `NamedTuple`.
+
+## NamedTuple-like indexing
 
 ::: tabs
 
@@ -24,6 +27,52 @@ Layers can be accessed with `.name` or `[:name]`
 st.a
 st[:c]
 ````
+
+== subsetting layers
+
+We can subset layers with a `Tupe` of `Symbol`:
+
+````@ansi stack
+st[(:a, :c)]
+````
+
+== inverted subsets
+
+`Not` works on `Symbol` keys just like it does on `Selector`:
+It inverts the keys to give you a `DImStack` with all the other layers:
+
+````@ansi stack
+st[Not(:b)]
+st[Not((:a, :c))]
+````
+
+== merging
+
+We can merge a `DimStack` with another `DimStack`:
+
+````@ansi stack
+st2 = DimStack((m=rand(x, y), n=rand(x, y), o=rand(y)))
+merge(st, st2)
+````
+
+Or merge a `DimStack` with a `NamedTuple` of `DimArray`:
+
+````@ansi stack
+merge(st, (; d = rand(y, x), e = rand(y)))
+````
+
+Merging only works when dimensions match: 
+
+````@ansi stack
+merge(st, (; d = rand(Y('a':'n'))))
+````
+
+:::
+
+
+## Array-like indexing
+
+::: tabs
 
 == scalars
 
@@ -50,8 +99,15 @@ The layers without another dimension are now zero-dimensional:
 st[X=At(2.0)]
 ````
 
-:::
+== linear indexing
 
+If we index with `:` we get a `Vector{<:NamedTuple}`
+
+````@ansi stack
+st[:]
+````
+
+:::
 
 ## Reducing functions
 
@@ -112,14 +168,14 @@ var(st; dims=Y)
 
 ````@ansi stack
 reduce(+, st)
-# reduce(+, st; dims=Y) # broken
+reduce(+, st; dims=Y)
 ````
 
 == extrema
 
 ````@ansi stack
 extrema(st)
-extrema(st; dims=Y) # Kind of broken? should :d be tuples too?
+extrema(st; dims=Y)
 ````
 
 == dropdims

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -699,6 +699,8 @@ struct AlwaysTuple <: QueryMode end
 @inline _dim_query1(f, op::Function, t, x, query) = _dim_query1(f, op, t, dims(x), query)
 @inline _dim_query1(f, op::Function, t, x::Nothing) = _dimsnotdefinederror()
 @inline _dim_query1(f, op::Function, t, x::Nothing, query) = _dimsnotdefinederror()
+@inline _dim_query1(f, op::Function, t, ds::Tuple, query::Colon) =
+    _dim_query1(f, op, t, ds, basedims(ds))
 @inline function _dim_query1(f, op::Function, t, ds::Tuple, query::Function) 
     selection = foldl(ds; init=()) do acc, d
         query(d) ? (acc..., d) : acc

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -39,6 +39,8 @@ function Broadcast.copy(bc::Broadcasted{DimensionalStyle{S}}) where S
     data = copy(_unwrap_broadcasted(bc))
     return if A isa Nothing || _dims isa Nothing || ndims(A) == 0
         data
+    elseif data isa AbstractDimArray
+        rebuild(A, parent(data), _dims, refdims(A), Symbol(""))
     else
         rebuild(A, data, _dims, refdims(A), Symbol(""))
     end

--- a/src/array/indexing.jl
+++ b/src/array/indexing.jl
@@ -114,7 +114,7 @@ function _merge_and_index(f, A, inds)
                 lazylinear = rebuild(mdim, LazyDims2Linear(inds, DD.dims(A, dims_to_merge)))
                 f(M, lazylinear)
             else
-                # Index anyway with al Colon() just for type consistency
+                # Index anyway with all Colon() just for type consistency
                 f(M, basedims(M)...)
             end
         else
@@ -122,7 +122,7 @@ function _merge_and_index(f, A, inds)
             f(A, m_inds)
         end
     else
-        d = first(dims_to_merge)
+        d = only(dims_to_merge)
         val_array = reinterpret(typeof(val(d)), dims_to_merge)
         f(A, rebuild(d, val_array))
     end

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -357,33 +357,6 @@ function _groups_from(_, bins::CyclicBins)
     end
 end
 
-# Return the bin for a value
-# function _choose_bin(b::AbstractBins, groups::LookupArray, val)
-#     groups[ispoints(groups) ? At(val) : Contains(val)]
-# end
-# function _choose_bin(b::AbstractBins, groups, val)
-#     i = findfirst(Base.Fix1(_in, val), groups)
-#     isnothing(i) && return nothing
-#     return groups[i]
-# end
-# function _choose_bin(b::Bins, groups::AbstractArray{<:Number}, val)
-#     i = searchsortedlast(groups, val; by=_by)
-#     i >= firstindex(groups) && val in groups[i] || return nothing
-#     return groups[i]
-# end
-# function _choose_bin(b::Bins, groups::AbstractArray{<:Tuple{Vararg{Union{Number,AbstractRange,IntervalSets.Interval}}}}, val::Tuple)
-#     @assert length(val) == length(first(groups))
-#     i = searchsortedlast(groups, val; by=_by)
-#     i >= firstindex(groups) && last(val) in last(groups[i]) || return nothing
-#     return groups[i]
-# end
-# _choose_bin(b::Bins, groups::AbstractArray{<:IntervalSets.Interval}, val::Tuple) = _choose_bin(b::Bins, groups, last(val))
-# function _choose_bin(b::Bins, groups::AbstractArray{<:IntervalSets.Interval}, val)
-#     i = searchsortedlast(groups, val; by=_by)
-#     i >= firstindex(groups) && val in groups[i] || return nothing
-#     return groups[i]
-# end
-
 _maybe_label(vals) = vals
 _maybe_label(f::Function, vals) = f.(vals)
 _maybe_label(::Nothing, vals) = vals

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -153,7 +153,7 @@ for (mod, fnames) in
     (:Base => (:sum, :prod, :maximum, :minimum, :extrema, :dropdims),
      :Statistics => (:mean, :median, :std, :var))
     for fname in fnames
-        @eval function ($mod.$fname)(s::AbstractDimStack; dims=1, kw...)
+        @eval function ($mod.$fname)(s::AbstractDimStack; dims=:, kw...)
             map(s) do A
                 layer_dims = dims isa Colon ? dims : commondims(A, dims)
                 $mod.$fname(A; dims=layer_dims, kw...)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -48,6 +48,24 @@ Base.@assume_effects :foldable function hassamedims(s::AbstractDimStack)
     all(map(==(first(layerdims(s))), layerdims(s)))
 end
 
+function rebuild(
+    s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s),
+    layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
+)
+    basetypeof(s)(data, dims, refdims, layerdims, metadata, layermetadata)
+end
+function rebuild(s::AbstractDimStack; data=data(s), dims=dims(s), refdims=refdims(s),
+    layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
+)
+    basetypeof(s)(data, dims, refdims, layerdims, metadata, layermetadata)
+end
+
+function rebuildsliced(f::Function, s::AbstractDimStack, layers, I)
+    layerdims = map(basedims, layers)
+    dims, refdims = slicedims(f, s, I)
+    rebuild(s; data=map(parent, layers), dims=dims, refdims=refdims, layerdims=layerdims)
+end
+
 """
     rebuild_from_arrays(s::AbstractDimStack, das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}}; kw...)
 
@@ -89,19 +107,18 @@ function rebuild_from_arrays(
     end
 end
 
+# Dipatch on Tuple of Dimension, and map
+for func in (:index, :lookup, :metadata, :sampling, :span, :bounds, :locus, :order)
+    @eval ($func)(s::AbstractDimStack, args...) = ($func)(dims(s), args...)
+end
+
 Base.parent(s::AbstractDimStack) = data(s)
-@inline Base.keys(s::AbstractDimStack) = keys(data(s))
-@inline Base.propertynames(s::AbstractDimStack) = keys(data(s))
-Base.haskey(s::AbstractDimStack, k) = k in keys(s)
-Base.values(s::AbstractDimStack) = values(layers(s))
-Base.values(s::AbstractDimStack{<:NamedTuple{Keys}}) where Keys = map(K -> s[K], Keys)
-Base.first(s::AbstractDimStack) = s[first(keys(s))]
-Base.last(s::AbstractDimStack) = s[last(keys(s))]
 # Only compare data and dim - metadata and refdims can be different
 Base.:(==)(s1::AbstractDimStack, s2::AbstractDimStack) =
     data(s1) == data(s2) && dims(s1) == dims(s2) && layerdims(s1) == layerdims(s2)
-Base.@assume_effects :foldable Base.getproperty(s::AbstractDimStack, x::Symbol) = s[x]
-Base.length(s::AbstractDimStack) = length(keys(s))
+Base.read(s::AbstractDimStack) = map(read, s)
+
+# Array-like
 Base.ndims(s::AbstractDimStack) = length(dims(s))
 Base.size(s::AbstractDimStack) = map(length, dims(s))
 Base.size(s::AbstractDimStack, dims::DimOrDimType) = size(s, dimnum(s, dims))
@@ -111,9 +128,25 @@ Base.axes(s::AbstractDimStack, dims::DimOrDimType) = axes(s, dimnum(s, dims))
 Base.axes(s::AbstractDimStack, dims::Integer) = axes(s)[dims]
 Base.similar(s::AbstractDimStack, args...) = map(A -> similar(A, args...), s)
 Base.eltype(s::AbstractDimStack, args...) = NamedTuple{keys(s),Tuple{map(eltype, s)...}}
-Base.iterate(s::AbstractDimStack, args...) = iterate(layers(s), args...)
-Base.read(s::AbstractDimStack) = map(read, s)
 Base.CartesianIndices(s::AbstractDimStack) = CartesianIndices(dims(s))
+Base.LinearIndices(s::AbstractDimStack) = LinearIndices(CartesianIndices(map(l -> axes(l, 1), lookup(s))))
+function Base.eachindex(s::AbstractDimStack) 
+    li = LinearIndices(s)
+    first(li):last(li)
+end
+# all of methods.jl is also Array-like...
+
+# NamedTuple-like
+Base.@assume_effects :foldable Base.getproperty(s::AbstractDimStack, x::Symbol) = s[x]
+Base.haskey(s::AbstractDimStack, k) = k in keys(s)
+Base.values(s::AbstractDimStack) = values(layers(s))
+@inline Base.keys(s::AbstractDimStack) = keys(data(s))
+@inline Base.propertynames(s::AbstractDimStack) = keys(data(s))
+# Remove these, but explain
+Base.iterate(::AbstractDimStack, args...) = error("Use iterate(layers(s)) rather than `iterate(s)`") #iterate(layers(s), args...)
+Base.length(::AbstractDimStack) = error("Use length(layers(s)) rather than `length(s)`") # length(keys(s)) 
+Base.first(::AbstractDimStack) = error("Use first(layers(s)) rather than `first(s)`")
+Base.last(::AbstractDimStack) = error("Use last(layers(s)) rather than `last(s)`")
 # `merge` for AbstractDimStack and NamedTuple.
 # One of the first three arguments must be an AbstractDimStack for dispatch to work.
 Base.merge(s::AbstractDimStack) = s
@@ -132,7 +165,16 @@ end
 function Base.setindex(s::AbstractDimStack, val::AbstractBasicDimArray, key) 
     rebuild_from_arrays(s, Base.setindex(layers(s), val, key))
 end
-Base.NamedTuple(s::AbstractDimStack) = layers(s)
+Base.NamedTuple(s::AbstractDimStack) = NamedTuple(layers(s))
+Base.map(f, s::AbstractDimStack) = _maybestack(s,map(f, values(s)))
+function Base.map(f, x1::Union{AbstractDimStack,NamedTuple}, xs::Union{AbstractDimStack,NamedTuple}...)
+    stacks = (x1, xs...)
+    _check_same_names(stacks...)
+    vals = map(f, map(values, stacks)...)
+    return _maybestack(_firststack(stacks...), vals)
+end
+
+# Other interfaces
 
 Extents.extent(A::AbstractDimStack, args...) = Extents.extent(dims(A), args...) 
 
@@ -140,30 +182,7 @@ ConstructionBase.getproperties(s::AbstractDimStack) = layers(s)
 ConstructionBase.setproperties(s::AbstractDimStack, patch::NamedTuple) = 
     ConstructionBase.constructorof(typeof(s))(ConstructionBase.setproperties(layers(s), patch))
 
-function rebuild(
-    s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s),
-    layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
-)
-    basetypeof(s)(data, dims, refdims, layerdims, metadata, layermetadata)
-end
-function rebuild(s::AbstractDimStack; data=data(s), dims=dims(s), refdims=refdims(s),
-    layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
-)
-    basetypeof(s)(data, dims, refdims, layerdims, metadata, layermetadata)
-end
-
-function rebuildsliced(f::Function, s::AbstractDimStack, layers, I)
-    layerdims = map(basedims, layers)
-    dims, refdims = slicedims(f, s, I)
-    rebuild(s; data=map(parent, layers), dims=dims, refdims=refdims, layerdims=layerdims)
-end
-
 Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> Adapt.adapt(to, A), s)
-
-# Dipatch on Tuple of Dimension, and map
-for func in (:index, :lookup, :metadata, :sampling, :span, :bounds, :locus, :order)
-    @eval ($func)(s::AbstractDimStack, args...) = ($func)(dims(s), args...)
-end
 
 function mergedims(st::AbstractDimStack, dim_pairs::Pair...)
     dim_pairs = map(dim_pairs) do (as, b)
@@ -185,6 +204,43 @@ end
 
 function unmergedims(s::AbstractDimStack, original_dims)
     return map(A -> unmergedims(A, original_dims), s)
+end
+
+@noinline _stack_size_mismatch() = throw(ArgumentError("Arrays must have identical axes. For mixed dimensions, use DimArrays`"))
+
+function _layerkeysfromdim(A, dim)
+    map(index(A, dim)) do x
+        if x isa Number
+            Symbol(string(DD.dim2key(dim), "_", x))
+        else
+            Symbol(x)
+        end
+    end
+end
+
+_check_same_names(::Union{AbstractDimStack{<:NamedTuple{names}},NamedTuple{names}}, 
+    ::Union{AbstractDimStack{<:NamedTuple{names}},NamedTuple{names}}...) where {names} = nothing
+_check_same_names(::Union{AbstractDimStack,NamedTuple}, ::Union{AbstractDimStack,NamedTuple}...) = 
+    throw(ArgumentError("Named tuple names do not match."))
+
+_firststack(s::AbstractDimStack, args...) = s
+_firststack(arg1, args...) = _firststack(args...) 
+_firststack() = nothing
+
+_maybestack(s::AbstractDimStack{<:NamedTuple{K}}, xs::Tuple) where K = NamedTuple{K}(xs)
+_maybestack(s::AbstractDimStack, xs::Tuple) = NamedTuple{keys(s)}(xs)
+# Without the `@nospecialise` here this method is also compile with the above method
+# on every call to _maybestack. And `rebuild_from_arrays` is expensive to compile.
+function _maybestack(
+    s::AbstractDimStack, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+)
+    # Avoid compiling this in the simple cases in the above method
+    Base.invokelatest(() -> rebuild_from_arrays(s, das))
+end
+function _maybestack(
+    s::AbstractDimStack{<:NamedTuple{K}}, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+) where K
+    Base.invokelatest(() -> rebuild_from_arrays(s, das))
 end
 
 
@@ -311,6 +367,7 @@ function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}};
     DimStack(data, dims, refdims, layerdims, metadata, layermetadata)
 end
 # Same sized arrays
+DimStack(data::NamedTuple, dim::Dimension; kw...) = DimStack(data::NamedTuple, (dim,); kw...)
 function DimStack(data::NamedTuple, dims::Tuple;
     refdims=(), metadata=NoMetadata(), 
     layermetadata=map(_ -> NoMetadata(), data),
@@ -320,16 +377,4 @@ function DimStack(data::NamedTuple, dims::Tuple;
     DimStack(data, format(dims, first(data)), refdims, layerdims, metadata, layermetadata)
 end
 
-@noinline _stack_size_mismatch() = throw(ArgumentError("Arrays must have identical axes. For mixed dimensions, use DimArrays`"))
-
 layerdims(s::DimStack{<:Any,<:Any,<:Any,Nothing}, key::Symbol) = dims(s)
-
-function _layerkeysfromdim(A, dim)
-    map(index(A, dim)) do x
-        if x isa Number
-            Symbol(string(DD.dim2key(dim), "_", x))
-        else
-            Symbol(x)
-        end
-    end
-end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -89,13 +89,6 @@ function DimTable(s::AbstractDimStack; mergedims=nothing)
     keys = collect(_colnames(s))
     return DimTable(s, keys, dimcolumns, dimarraycolumns)
 end
-
-_dimcolumns(x) = map(d -> _dimcolumn(x, d), dims(x))
-function _dimcolumn(x, d::Dimension)
-    dim_as_dimarray = DimArray(index(d), d)
-    vec(DimExtensionArray(dim_as_dimarray, dims(x)))
-end
-
 function DimTable(xs::Vararg{AbstractDimArray}; layernames=nothing, mergedims=nothing)
     # Check that dims are compatible
     comparedims(xs...)
@@ -114,7 +107,6 @@ function DimTable(xs::Vararg{AbstractDimArray}; layernames=nothing, mergedims=no
     # Return DimTable
     return DimTable(first(xs), colnames, dimcolumns, dimarraycolumns)
 end
-
 function DimTable(x::AbstractDimArray; layersfrom=nothing, mergedims=nothing)
     if !isnothing(layersfrom) && any(hasdim(x, layersfrom))
         d = dims(x, layersfrom)
@@ -131,6 +123,14 @@ function DimTable(x::AbstractDimArray; layersfrom=nothing, mergedims=nothing)
         return  DimTable(s, mergedims=mergedims)
     end
 end
+
+_dimcolumns(x) = map(d -> _dimcolumn(x, d), dims(x))
+function _dimcolumn(x, d::Dimension)
+    dim_as_dimarray = DimArray(index(d), d)
+    vec(DimExtensionArray(dim_as_dimarray, dims(x)))
+end
+
+
 
 dimcolumns(t::DimTable) = getfield(t, :dimcolumns)
 dimarraycolumns(t::DimTable) = getfield(t, :dimarraycolumns)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -511,7 +511,8 @@ end
             linear1d = view(s[X(2)], 1)
             @test linear1d isa DimStack
             @test parent(linear1d) == (one=fill(4.0), two=fill(8.0f0), three=fill(12))
-            @test_broken linear2d = @inferred s[1:2]
+            @test_broken linear2d = @inferred 
+            s[1:2]
             linear2d = s[1:2]
             @test linear2d isa DimStack
             @test NamedTuple(linear2d) == (one=[1.0, 4.0], two=[2.0f0, 8.0f0], three=[3, 12])

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -503,24 +503,23 @@ end
         slicedds_mixed = s_mixed[At(:a), :]
         @test slicedds_mixed[:one] == [1.0, 2.0, 3.0]
         @test parent(slicedds_mixed) == (one=[1.0, 2.0, 3.0], two=[2.0f0, 4.0f0, 6.0f0], three=[3, 6, 9], four=fill(4))
-        @testset "linear indices" begin
-            linear2d = @inferred s[1]
-            @test linear2d isa NamedTuple
-            @test linear2d == (one=1.0, two=2.0f0, three=3)
-            @test_broken linear1d = @inferred view(s[X(2)], 1)
-            linear1d = view(s[X(2)], 1)
-            @test linear1d isa DimStack
-            @test parent(linear1d) == (one=fill(4.0), two=fill(8.0f0), three=fill(12))
-            @test_broken linear2d = @inferred 
-            s[1:2]
-            linear2d = s[1:2]
-            @test linear2d isa DimStack
-            @test NamedTuple(linear2d) == (one=[1.0, 4.0], two=[2.0f0, 8.0f0], three=[3, 12])
-            linear1d = @inferred s[X(1)][1:2]
-            linear1d = @inferred s[X(1)][1:2]
-            @test linear1d isa DimStack
-            @test parent(linear1d) == (one=[1.0, 2.0], two=[2.0f0, 4.0f0], three=[3, 6])
-        end
+    end
+
+    @testset "linear indices" begin
+        linear2d = @inferred s[1]
+        @test linear2d isa NamedTuple
+        @test linear2d == (one=1.0, two=2.0f0, three=3)
+        @test_broken linear1d = @inferred view(s[X(2)], 1)
+        linear1d = view(s[X(2)], 1)
+        @test linear1d isa DimStack
+        @test parent(linear1d) == (one=fill(4.0), two=fill(8.0f0), three=fill(12))
+        @test @inferred s[1:2] isa Array
+        linear2d = s[1:2]
+        @test linear2d == [(one=1.0, two=2.0f0, three=3), (one=4.0, two=8.0f0, three=12)]
+        linear1d = @inferred s[X(1)][1:2]
+        linear1d = @inferred s[X(1)][1:2]
+        @test linear1d isa DimStack
+        @test parent(linear1d) == (one=[1.0, 2.0], two=[2.0f0, 4.0f0], three=[3, 6])
     end
 
     @testset "getindex Tuple" begin

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -22,7 +22,6 @@ mixed = DimStack(da1, da2, da4)
         DimStack(da1, da2, da3) ==
         DimStack((one=da1, two=da2, three=da3), dimz) ==
         DimStack((one=da1, two=da2, three=da3)) == s
-    @test length(DimStack(NamedTuple())) == length(DimStack()) == 0
     @test dims(DimStack()) == dims(DimStack(NamedTuple())) == ()
 end
 
@@ -66,7 +65,7 @@ end
     @test eltype(mixed) === @NamedTuple{one::Float64, two::Float32, extradim::Float64}
     @test haskey(s, :one) == true
     @test haskey(s, :zero) == false
-    @test length(s) == 3 # length is as for NamedTuple
+    @test_throws ErrorException length(s) == 3
     @test size(mixed) === (2, 3, 4) # size is as for Array
     @test size(mixed, Y) === 3
     @test size(mixed, 3) === 4
@@ -77,8 +76,8 @@ end
     @test dims(axes(mixed, X)) == dims(mixed, X)
     @test axes(mixed, 2) == Base.OneTo(3)
     @test dims(axes(mixed, 2)) == dims(mixed, 2)
-    @test first(s) == da1 # first/last are for the NamedTuple
-    @test last(s) == da3
+    @test_throws ErrorException first(s) == da1 # first/last are for the NamedTuple
+    @test_throws ErrorException last(s) == da3
     @test NamedTuple(s) == (one=da1, two=da2, three=da3)
 end
 


### PR DESCRIPTION
Notably this breaks the `AbstrackDimStack` methods:

- `first`
- `last`
- `iterate`
- `length`

These should never have worked how they do (NamedTuple-like). Now they just throw an error - we can do something better and more Array-like with them later.

@sethaxen a few more breaks, hopefully wont break anything that matters.