### PR TITLE
Modify compilation

### DIFF
--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -101,5 +101,5 @@ _firstdimarray(x::Tuple{}) = nothing
 _broadcasted_dims(bc::Broadcasted) = _broadcasted_dims(bc.args...)
 _broadcasted_dims(a, bs...) =
     comparedims(_broadcasted_dims(a), _broadcasted_dims(bs...); ignore_length_one=true, order=true)
-_broadcasted_dims(a::AbstractDimArray) = dims(a)
+_broadcasted_dims(a::AbstractBasicDimArray) = dims(a)
 _broadcasted_dims(a) = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,6 +86,10 @@ This also works for all the data layers in a `DimStack`.
 """
 function modify end
 modify(f, s::AbstractDimStack) = map(a -> modify(f, a), s)
+# Stack optimisation to avoid compilation to build all the `AbstractDimArray` 
+# layers, and instead just modify the parent data directly.
+modify(f, s::AbstractDimStack{<:NamedTuple}) = 
+    rebuild(s; data=map(a -> modify(f, a), parent(s)))
 function modify(f, A::AbstractDimArray)
     newdata = f(parent(A))
     size(newdata) == size(A) || error("$f returns an array with a different size")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -115,13 +115,13 @@ end
         @test typeof(parent(mda)) == BitArray{2}
         @test_throws ErrorException modify(A -> A[1, :], da)
     end
-    @testset "dataset" begin
+    @testset "stack" begin
         da1 = DimArray(A, dimz; name=:da1)
         da2 = DimArray(2A, dimz; name=:da2)
         s = DimStack(da1, da2)
         ms = modify(A -> A .> 3, s)
         @test parent(ms) == (da1=[false false false; true true true],
-                              da2=[false true  true ; true true true])
+                             da2=[false true  true ; true true true])
         @test typeof(parent(ms[:da2])) == BitArray{2}
     end
     @testset "dimension" begin


### PR DESCRIPTION
`modify` doesn't need to construct the parent arrays for a stack with `NamedTuple` data. It just needs to apply `f` to each array in the `NamedTuple` and `rebuild`. This is a major compilation saving for laved DimStacks.