### PR TITLE
(Slightly) Breaking: make `name` more systematic

### DIFF
--- a/docs/src/api/dimensions.md
+++ b/docs/src/api/dimensions.md
@@ -57,8 +57,7 @@ They are not guaranteed to keep their interface, but usually will.
 
 ```@docs
 Dimensions.commondims
-Dimensions.dim2key
-Dimensions.key2dim
+Dimensions.name2dim
 Dimensions.reducedims
 Dimensions.swapdims
 Dimensions.slicedims

--- a/docs/src/tables.md
+++ b/docs/src/tables.md
@@ -12,7 +12,7 @@ are unrolled so they are all the same size, and dimensions
 loop to match the length of the largest layer.
 
 Columns are given the [`name`](@ref) or the array or the stack layer key.
-`Dimension` columns use the `Symbol` version (the result of `DD.dim2key(dimension)`).
+`Dimension` columns use the `Symbol` version (the result of `DD.name(dimension)`).
 
 Looping of dimensions and stack layers is done _lazily_,
 and does not allocate unless collected.

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -33,7 +33,7 @@ using .Lookups: StandardIndices, SelTuple, CategoricalEltypes,
 using Base: tail, OneTo, @propagate_inbounds
 
 export name, label, dimnum, hasdim, hasselection, otherdims, commondims, combinedims,
-    setdims, swapdims, sortdims, lookup, set, format, rebuild, key2dim, dim2key,
+    setdims, swapdims, sortdims, lookup, set, format, rebuild, name2dim,
     basetypeof, basedims, dims2indices, slicedims, dimsmatch, comparedims, reducedims
 
 export Dimension, IndependentDim, DependentDim, XDim, YDim, ZDim, TimeDim,

--- a/src/Dimensions/coord.jl
+++ b/src/Dimensions/coord.jl
@@ -59,7 +59,7 @@ struct Coord{T} <: Dimension{T}
 end
 function Coord(val::T, dims::Tuple) where {T<:AbstractVector}
     length(dims) == length(first(val)) || throw(ArgumentError("Number of dims must match number of points"))
-    lookup = CoordLookup(val, key2dim(dims))
+    lookup = CoordLookup(val, name2dim(dims))
     Coord(lookup)
 end
 const SelOrStandard = Union{Selector,StandardIndices}

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -184,7 +184,7 @@ lookuptype(x) = NoLookup
 
 name(dim::Dimension) = name(typeof(dim))
 name(dim::Val{D}) where D = name(D)
-name(dim::Type{D}) where D = nameof(D)
+name(dim::Type{D}) where D<:Dimension = nameof(D)
 
 label(x) = string(name(x))
 

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -184,6 +184,7 @@ lookuptype(x) = NoLookup
 
 name(dim::Dimension) = name(typeof(dim))
 name(dim::Val{D}) where D = name(D)
+name(dim::Type{D}) where D = nameof(D)
 
 label(x) = string(name(x))
 

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -185,7 +185,7 @@ lookuptype(x) = NoLookup
 name(dim::Dimension) = name(typeof(dim))
 name(dim::Val{D}) where D = name(D)
 
-label(x) = string(string(name(x)), (units(x) === nothing ? "" : string(" ", units(x))))
+label(x) = string(name(x))
 
 # Lookups methods
 Lookups.metadata(dim::Dimension) = metadata(lookup(dim))
@@ -227,10 +227,10 @@ end
 for f in (:val, :index, :lookup, :metadata, :order, :sampling, :span, :locus, :bounds, :intervalbounds,
           :name, :label, :units)
     @eval begin
-        $f(ds::DimTuple) = map($f, ds)
+        $f(ds::Tuple) = map($f, ds)
         $f(::Tuple{}) = ()
-        $f(ds::DimTuple, i1, I...) = $f(ds, (i1, I...))
-        $f(ds::DimTuple, I) = $f(dims(ds, key2dim(I)))
+        $f(ds::Tuple, i1, I...) = $f(ds, (i1, I...))
+        $f(ds::Tuple, I) = $f(dims(ds, name2dim(I)))
     end
 end
 
@@ -287,10 +287,10 @@ Base.CartesianIndices(dims::DimTuple) = CartesianIndices(map(d -> axes(d, 1), di
 function Extents.extent(ds::DimTuple, args...)
     extent_dims = _astuple(dims(ds, args...))
     extent_bounds = bounds(extent_dims)
-    return Extents.Extent{dim2key(extent_dims)}(extent_bounds)
+    return Extents.Extent{name(extent_dims)}(extent_bounds)
 end
 
-dims(extent::Extents.Extent{K}) where K = map(rebuild, key2dim(K), values(extent))
+dims(extent::Extents.Extent{K}) where K = map(rebuild, name2dim(K), values(extent))
 dims(extent::Extents.Extent, ds) = dims(dims(extent), ds)
 
 # Produce a 2 * length(dim) matrix of interval bounds from a dim
@@ -367,8 +367,7 @@ Dim{S}() where S = Dim{S}(:)
 
 name(::Type{<:Dim{S}}) where S = S
 basetypeof(::Type{<:Dim{S}}) where S = Dim{S}
-key2dim(s::Val{S}) where S = Dim{S}()
-dim2key(::Type{D}) where D<:Dim{S} where S = S
+name2dim(s::Val{S}) where S = Dim{S}()
 
 """
     AnonDim <: Dimension
@@ -385,16 +384,21 @@ AnonDim() = AnonDim(Colon())
 AnonDim(val, arg1, args...) = AnonDim(val)
 
 metadata(::AnonDim) = NoMetadata()
-name(::AnonDim) = :Anon
 
 """
-    @dim typ [supertype=Dimension] [name::String=string(typ)]
+    @dim typ [supertype=Dimension] [label::String=string(typ)]
 
-Macro to easily define new dimensions. The supertype will be inserted
-into the type of the dim. The default is simply `YourDim <: Dimension`. Making
-a Dimesion inherit from `XDim`, `YDim`, `ZDim` or `TimeDim` will affect
+Macro to easily define new dimensions. 
+
+The supertype will be inserted into the type of the dim. 
+The default is simply `YourDim <: Dimension`. 
+
+Making a Dimesion inherit from `XDim`, `YDim`, `ZDim` or `TimeDim` will affect
 automatic plot layout and other methods that dispatch on these types. `<: YDim`
 are plotted on the Y axis, `<: XDim` on the X axis, etc.
+
+`label` is used in plots and similar, 
+if the dimension is short for a longer word.
 
 Example:
 ```jldoctest
@@ -433,8 +437,9 @@ function dimmacro(typ, supertype, name::String=string(typ))
             $typ{typeof(val)}(val)
         end
         $typ() = $typ(:)
-        $Dimensions.name(::Type{<:$typ}) = $(QuoteNode(Symbol(name)))
-        $Dimensions.key2dim(::Val{$(QuoteNode(typ))}) = $typ()
+        $Dimensions.name(::Type{<:$typ}) = $(QuoteNode(Symbol(typ)))
+        $Dimensions.label(::Type{<:$typ}) = $name
+        $Dimensions.name2dim(::Val{$(QuoteNode(typ))}) = $typ()
     end |> esc
 end
 
@@ -448,6 +453,7 @@ end
 X [`Dimension`](@ref). `X <: XDim <: IndependentDim`
 
 ## Example:
+
 ```julia
 xdim = X(2:2:10)
 # Or

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -16,7 +16,7 @@ based on the type and element type of the values.
 format(dims, A::AbstractArray) = format((dims,), A)
 function format(dims::NamedTuple, A::AbstractArray)
     dims = map(keys(dims), values(dims)) do k, v
-        rebuild(key2dim(k), v)
+        rebuild(name2dim(k), v)
     end
     return format(dims, A)
 end

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -98,7 +98,7 @@ end
 end
 
 _unalligned_all_selector_error(dims) =
-    throw(ArgumentError("Unalligned dims: use selectors for all $(join(map(string ∘ dim2key, dims), ", ")) dims, or none of them"))
+    throw(ArgumentError("Unalligned dims: use selectors for all $(join(map(name, dims), ", ")) dims, or none of them"))
 
 _unwrapdim(dim::Dimension) = val(dim)
 _unwrapdim(x) = x
@@ -116,13 +116,13 @@ _unwrapdim(x) = x
 @inline _dims2indices(dim::Dimension, x) = Lookups.selectindices(val(dim), x)
 
 function _extent_as_intervals(extent::Extents.Extent{Keys}) where Keys
-    map(map(key2dim, Keys), values(extent)) do k, v
+    map(map(name2dim, Keys), values(extent)) do k, v
         rebuild(k, Lookups.Interval(v...))
     end    
 end
 
 function _extent_as_touches(extent::Extents.Extent{Keys}) where Keys
-    map(map(key2dim, Keys), values(extent)) do k, v
+    map(map(name2dim, Keys), values(extent)) do k, v
         rebuild(k, Touches(v))
     end    
 end

--- a/src/Dimensions/merged.jl
+++ b/src/Dimensions/merged.jl
@@ -39,7 +39,7 @@ Lookups.bounds(d::Dimension{<:MergedLookup}) =
 Lookups.selectindices(lookup::MergedLookup, sel::DimTuple) =
     selectindices(lookup, map(_val_or_nothing, sortdims(sel, dims(lookup))))
 function Lookups.selectindices(lookup::MergedLookup, sel::NamedTuple{K}) where K
-    dimsel = map(rebuild, map(key2dim, K), values(sel))
+    dimsel = map(rebuild, map(name2dim, K), values(sel))
     selectindices(lookup, dimsel) 
 end
 Lookups.selectindices(lookup::MergedLookup, sel::StandardIndices) = sel
@@ -99,7 +99,7 @@ struct Coord{T} <: Dimension{T}
 end
 function Coord(val::T, dims::Tuple) where {T<:AbstractVector}
     length(dims) == length(first(val)) || throw(ArgumentError("Number of dims must match number of points"))
-    lookup = MergedLookup(val, key2dim(dims))
+    lookup = MergedLookup(val, name2dim(dims))
     Coord(lookup)
 end
 Coord(s1::SelOrStandard, s2::SelOrStandard, sels::SelOrStandard...) = Coord((s1, s2, sels...))

--- a/src/Dimensions/set.jl
+++ b/src/Dimensions/set.jl
@@ -28,7 +28,7 @@ _set(dim::Dimension, wrapper::Dimension{<:DimSetters}) =
 _set(dim::Dimension, newdim::Dimension) = _set(newdim, _set(val(dim), val(newdim)))
 # Construct types
 _set(dim::Dimension, ::Type{T}) where T = _set(dim, T())
-_set(dim::Dimension, key::Symbol) = _set(dim, key2dim(key))
+_set(dim::Dimension, key::Symbol) = _set(dim, name2dim(key))
 _set(dim::Dimension, dt::DimType) = basetypeof(dt)(val(dim))
 _set(dim::Dimension, x) = rebuild(dim; val=_set(val(dim), x))
 # Set the lookup

--- a/src/Dimensions/show.jl
+++ b/src/Dimensions/show.jl
@@ -35,7 +35,7 @@ function show_dims(io::IO, mime::MIME"text/plain", dims::DimTuple;
         lines = 3
         dc = colors[1]
         printstyled(io, dimsymbols(1), ' '; color=dc)
-        maxname = maximum(length ∘ string ∘ dim2key, dims) 
+        maxname = maximum(length ∘ string ∘ name, dims) 
         dim_ctx = IOContext(ctx, :dimcolor => dc, :dimname_len=> maxname)
         show(dim_ctx, mime, first(dims))
         lines += 1
@@ -104,7 +104,7 @@ end
 # print a dimension name
 function print_dimname(io, dim::Dimension)
     dimname_len = get(io, :dimname_len, 0)
-    printstyled(io, rpad(dim2key(dim), dimname_len); color=dimcolor(io))
+    printstyled(io, rpad(name(dim), dimname_len); color=dimcolor(io))
 end
 
 

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -706,7 +706,7 @@ julia> mergedims(ds, (X, Y) => :space)
 """
 function mergedims(x, dt1::Tuple, dts::Tuple...)
     pairs = map((dt1, dts...)) do ds
-        ds => Dim{Symbol(map(dim2key, ds)...)}()
+        ds => Dim{Symbol(map(name, ds)...)}()
     end
     mergedims(x, pairs...)
 end

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -283,7 +283,7 @@ function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
                 return AnonDim(NoLookup()) # TODO: handle larger dimension extensions, this is half broken
             end
         else
-            catdim = basedims(key2dim(catdim))
+            catdim = basedims(name2dim(catdim))
         end
         # Dimension Types and Symbols
         if all(x -> hasdim(x, catdim), Xin)

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -348,7 +348,7 @@ function DataAPI.groupby(A::DimArrayOrStack, dimfuncs::DimTuple)
     # Hide that the parent is a DimSlices
     views = OpaqueArray(DimSlices(A, indices))
     # Put the groupby query in metadata
-    meta = map(d -> dim2key(d) => val(d), dimfuncs)
+    meta = map(d -> name(d) => val(d), dimfuncs)
     metadata = Dict{Symbol,Any}(:groupby => length(meta) == 1 ? only(meta) : meta)
     # Return a DimGroupByArray
     return DimGroupByArray(views, format(group_dims, views), (), :groupby, metadata)

--- a/src/name.jl
+++ b/src/name.jl
@@ -39,5 +39,3 @@ Base.Symbol(::Name{X}) where X = X
 Base.string(::Name{X}) where X = string(X)
 
 name(x::Name) = x
-name(x) = name(typeof(x))
-@noinline name(T::Type) = throw(ArgumentError("`name` not implemented for $T"))

--- a/src/name.jl
+++ b/src/name.jl
@@ -40,4 +40,4 @@ Base.string(::Name{X}) where X = string(X)
 
 name(x::Name) = x
 name(x) = name(typeof(x))
-name(x::Type) = ""
+name(::Type{T}) where T = nameof(T)

--- a/src/name.jl
+++ b/src/name.jl
@@ -40,4 +40,4 @@ Base.string(::Name{X}) where X = string(X)
 
 name(x::Name) = x
 name(x) = name(typeof(x))
-name(::Type{T}) where T = nameof(T)
+@noinline name(T::Type) = throw(ArgumentError("`name` not implemented for $T"))

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -28,7 +28,7 @@ Tables.schema(s::AbstractDimStack) = Tables.schema(DimTable(s))
     Tables.getcolumn(t, dimnum(t, dim))
 
 function _colnames(s::AbstractDimStack)
-    dimkeys = map(dim2key, dims(s))
+    dimkeys = map(name, dims(s))
     # The data is always the last column/s
     (dimkeys..., keys(s)...)
 end
@@ -49,7 +49,7 @@ This table will have columns for the array data and columns for each
 as required.
 
 Column names are converted from the dimension types using
-[`DimensionalData.dim2key`](@ref). This means type `Ti` becomes the
+[`DimensionalData.name`](@ref). This means type `Ti` becomes the
 column name `:Ti`, and `Dim{:custom}` becomes `:custom`.
 
 To get dimension columns, you can index with `Dimension` (`X()`) or
@@ -121,7 +121,7 @@ function DimTable(xs::Vararg{AbstractDimArray}; layernames=nothing, mergedims=no
     xs = isnothing(mergedims) ? xs : map(x -> DimensionalData.mergedims(x, mergedims), xs)
     dims_ = dims(first(xs))
     dimcolumns = collect(_dimcolumns(dims_))
-    dimnames = collect(map(dim2key, dims_))
+    dimnames = collect(map(name, dims_))
     dimarraycolumns = collect(map(vec ∘ parent, xs))
     colnames = vcat(dimnames, layernames)
 
@@ -134,9 +134,9 @@ function DimTable(x::AbstractDimArray; layersfrom=nothing, mergedims=nothing)
         nlayers = size(x, d)
         layers = [view(x, rebuild(d, i)) for i in 1:nlayers]
         layernames = if iscategorical(d)
-            Symbol.(Ref(dim2key(d)), '_', lookup(d))
+            Symbol.((name(d),), '_', lookup(d))
         else
-            Symbol.(("$(dim2key(d))_$i" for i in 1:nlayers))
+            Symbol.(("$(name(d))_$i" for i in 1:nlayers))
         end
         return DimTable(layers..., layernames=layernames, mergedims=mergedims)
     else

--- a/test/dimension.jl
+++ b/test/dimension.jl
@@ -1,4 +1,4 @@
-using DimensionalData, Test, Unitful
+using DimensionalData, Test, Unitful, BenchmarkTools
 using DimensionalData.Lookups, DimensionalData.Dimensions
 
 @dim TestDim "Testname"
@@ -6,8 +6,7 @@ using DimensionalData.Lookups, DimensionalData.Dimensions
 @testset "dims creation macro" begin
     @test parent(TestDim(1:10)) == 1:10
     @test val(TestDim(1:10)) == 1:10
-    @test name(TestDim) == :Testname
-    @test label(TestDim) == "Testname"
+    @test name(TestDim) == :TestDim
     @test val(TestDim(:testval)) == :testval
     @test metadata(TestDim(Sampled(1:1; metadata=Metadata(a=1)))) == Metadata(a=1)
     @test units(TestDim) == nothing
@@ -41,6 +40,15 @@ using DimensionalData.Lookups, DimensionalData.Dimensions
     @test TestDim(Sampled(5.0:7.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))[At(6.0)] == 6.0
 end
 
+@testset "name" begin
+    @test name(X()) == :X
+    @test name(Dim{:x}) == :x
+    @test name(TestDim()) == :TestDim
+    @test name(Dim{:test}()) == :test
+    @test (@ballocated name(Dim{:test}())) == 0
+    @test name(Val{TimeDim}()) == :TimeDim
+end
+
 @testset "format" begin
     A = [1 2 3; 4 5 6]
     @test format((X, Y), A) == (X(NoLookup(Base.OneTo(2))), Y(NoLookup(Base.OneTo(3))))
@@ -55,7 +63,7 @@ end
            Y(Categorical(10.0:10.0:30.0, ForwardOrdered(), Metadata("metadata"=>1)))), A) ==
           (X(Categorical([:A, :B], ForwardOrdered(), Metadata(a=5))),
            Y(Categorical(10.0:10.0:30.0, ForwardOrdered(), Metadata("metadata"=>1))))
-     @test format((X(Sampled(Base.OneTo(2); order=ForwardOrdered(), span=Regular(), sampling=Points())), Y), A) == 
+    @test format((X(Sampled(Base.OneTo(2); order=ForwardOrdered(), span=Regular(), sampling=Points())), Y), A) == 
         (X(Sampled(Base.OneTo(2), ForwardOrdered(), Regular(1), Points(), NoMetadata())), 
          Y(NoLookup(Base.OneTo(3))))
 end
@@ -69,7 +77,7 @@ end
     @test val(AnonDim()) == Colon()
     @test lookup(AnonDim(NoLookup())) == NoLookup()
     @test metadata(AnonDim()) == NoMetadata()
-    @test name(AnonDim()) == :Anon
+    @test name(AnonDim()) == :AnonDim
 end
 
 @testset "Basic dim and array initialisation and methods" begin

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,7 +1,7 @@
 using DimensionalData, Interfaces, Test, Dates
 
-@test_throws ArgumentError name(nothing) 
-@test_throws ArgumentError name(Nothing)
+@test_throws MethodError name(nothing) 
+@test_throws MethodError name(Nothing)
 @test dims(1) == nothing
 @test dims(nothing) == nothing
 @test refdims(1) == ()

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,7 +1,7 @@
 using DimensionalData, Interfaces, Test, Dates
 
-@test name(nothing) == ""
-@test name(Nothing) == ""
+@test_throws ArgumentError name(nothing) 
+@test_throws ArgumentError name(Nothing)
 @test dims(1) == nothing
 @test dims(nothing) == nothing
 @test refdims(1) == ()

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -48,15 +48,6 @@ end
     @test key2dim((:test, Ti, Ti())) == (Dim{:test}(), Ti, Ti())
 end
 
-@testset "dim2key" begin
-    @test dim2key(X()) == :X
-    @test dim2key(Dim{:x}) == :x
-    @test dim2key(Tst()) == :Tst
-    @test dim2key(Dim{:test}()) == :test
-    @test (@ballocated dim2key(Dim{:test}())) == 0
-    @test dim2key(Val{TimeDim}()) == :TimeDim
-end
-
 @testset "_wraparg" begin
     @test _wraparg(X()) == (X(),)
     @test _wraparg((X, Y,), X,) == ((Val(X), Val(Y),), Val(X),)

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -38,6 +38,7 @@ end
     @test refdims(s) === ()
     @test metadata(mixed) == NoMetadata()
     @test metadata(mixed, (X, Y, Z)) == (NoMetadata(), Dict(), NoMetadata())
+    @test name(s)== (:one, :two, :three)
 end
 
 @testset "symbol key indexing" begin
@@ -60,8 +61,8 @@ end
 end
 
 @testset "low level base methods" begin
-    @test keys(data(s)) == (:one, :two, :three)
-    @test keys(data(mixed)) == (:one, :two, :extradim)
+    @test keys(s) == (:one, :two, :three)
+    @test keys(mixed) == (:one, :two, :extradim)
     @test eltype(mixed) === @NamedTuple{one::Float64, two::Float32, extradim::Float64}
     @test haskey(s, :one) == true
     @test haskey(s, :zero) == false


### PR DESCRIPTION
This has been bugging me for a while.

`name` was originally defined for informative names, but it became the actual keys for Table columns and DimStack layers.

`name` on dimensions is still this thing that can be modified in the `dims` macro to look bettter, and `dim2key` does the lower level thing for Symbol keys/table columns etc. But `name` is exported and should be much more useful than it is.

This PR removes all of that coomplexity and makes `name` the main function for getting the dimension name Symbol from Dimension, types etc.. `name(Ti) == :Ti`. 

`dim2key` is deprecated to just call `name`.   `key2dim` is also switched to `name2dim` to simplify things, and `name` is defined on `DimStack` to just return a Tuple of Symbol for each layer.

Plot output mostly wont even change because `label` now holds the old `name` of the dimension and `Ti` will still be on plot labels as "Time".
