### PR TITLE
Breaking: better DimStack indexing, again

### DIFF
--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -253,7 +253,7 @@ function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
     copyto!(top, CartesianIndices(top), A, CartesianIndices(itop))
     bottom = Array{eltype(A)}(undef, length(ibottom)) 
     copyto!(bottom, CartesianIndices(bottom), A, CartesianIndices(ibottom))
-    vals = vcat(parent(A)[itop], parent(A)[ibottom])
+    vals = vcat(A[itop], A[ibottom])
     lu = only(lookups)
     if lu isa NoLookup
         Base.print_matrix(io, vals)

--- a/src/interface_tests.jl
+++ b/src/interface_tests.jl
@@ -82,9 +82,9 @@ stack_tests = (;
         ),
         refdims_base = "`refdims` returns a tuple of Dimension or empty" =>
             A -> refdims(A) isa Tuple{Vararg{Dimension}},
-        ndims = "number of dims matches dimensions of array" =>
+        ndims = "number of dims matches ndims of stack" =>
             A -> length(dims(A)) == ndims(A),
-        size = "length of dims matches dimensions of array" =>
+        size = "length of dims matches size of stack" =>
             A -> map(length, dims(A)) == size(A),
         rebuild_parent = "rebuild parent from args" =>
             A -> parent(rebuild(A, map(a -> reverse(a; dims=1), parent(A)))) == map(a -> reverse(a; dims=1), parent(A)),

--- a/src/stack/indexing.jl
+++ b/src/stack/indexing.jl
@@ -101,42 +101,15 @@ for f in (:getindex, :view, :dotview)
             $_dim_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
         end
         # Ambiguities
-        # @propagate_inbounds function Base.$f(
-        #     ::AbstractDimStack, 
-        #     ::_DimIndicesAmb,
-        #     ::Union{Tuple{Dimension,Vararg{Dimension}},AbstractArray{<:Dimension},AbstractArray{<:Tuple{Dimension,Vararg{Dimension}}},DimIndices,DimSelectors,Dimension},
-        #     ::_DimIndicesAmb...
-        # )
-        #     $_dim_f(s, _simplify_dim_indices(D..., kw2dims(values(kw))...)...)
-        # end
-
         @propagate_inbounds function Base.$f(s::DimensionalData.AbstractVectorDimStack, 
-            D::Union{AbstractVector{<:DimensionalData.Dimensions.Dimension},
+            i::Union{AbstractVector{<:DimensionalData.Dimensions.Dimension},
             AbstractVector{<:Tuple{DimensionalData.Dimensions.Dimension, Vararg{DimensionalData.Dimensions.Dimension}}}, 
             DimensionalData.DimIndices{T,1} where T, DimensionalData.DimSelectors{T,1} where T}
         )
-            $_dim_f(s, _simplify_dim_indices(D...)...)
+            $_dim_f(s, _simplify_dim_indices(i)...)
         end
-        # @propagate_inbounds function Base.$f(
-        #     s::AbstractDimStack, 
-        #     d1::Union{AbstractArray{Union{}}, DimIndices{<:Integer}, DimSelectors{<:Integer}}, 
-        #     D::Vararg{Union{AbstractArray{Union{}}, DimIndices{<:Integer}, DimSelectors{<:Integer}}}
-        # )
-        #     $_dim_f(s, _simplify_dim_indices(d1, D...))
-        # end
-        # @propagate_inbounds function Base.$f(
-        #     s::AbstractDimStack, 
-        #     D::Union{AbstractArray{Union{}},DimIndices{<:Integer},DimSelectors{<:Integer}}
-        # )
-        #     $_dim_f(s, _simplify_dim_indices(D...))
-        # end
 
 
-        @propagate_inbounds function $_dim_f(
-            A::AbstractDimStack, a1::Union{Dimension,DimensionIndsArrays}, args::Union{Dimension,DimensionIndsArrays}...
-        )
-            return merge_and_index(Base.$f, A, (a1, args...))
-        end
         @propagate_inbounds function $_dim_f(
             A::AbstractDimStack, a1::Union{Dimension,DimensionIndsArrays}, args::Union{Dimension,DimensionIndsArrays}...
         )

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -65,19 +65,23 @@ end
     @test eltype(mixed) === @NamedTuple{one::Float64, two::Float32, extradim::Float64}
     @test haskey(s, :one) == true
     @test haskey(s, :zero) == false
-    @test_throws ErrorException length(s) == 3
     @test size(mixed) === (2, 3, 4) # size is as for Array
     @test size(mixed, Y) === 3
     @test size(mixed, 3) === 4
+    @test length(mixed) === 24
+    @test firstindex(mixed) === 1
+    @test lastindex(mixed) === 24
+    @test eachindex(mixed) === 1:24
     @test axes(mixed) == (Base.OneTo(2), Base.OneTo(3), Base.OneTo(4))
     @test eltype(axes(mixed)) <: Dimensions.DimUnitRange
     @test dims(axes(mixed)) == dims(mixed)
     @test axes(mixed, X) == Base.OneTo(2)
     @test dims(axes(mixed, X)) == dims(mixed, X)
     @test axes(mixed, 2) == Base.OneTo(3)
+    @test lastindex(mixed, 2) == 3
     @test dims(axes(mixed, 2)) == dims(mixed, 2)
-    @test_throws ErrorException first(s) == da1 # first/last are for the NamedTuple
-    @test_throws ErrorException last(s) == da3
+    @test first(mixed) == mixed[Begin] 
+    @test last(mixed) == mixed[End]
     @test NamedTuple(s) == (one=da1, two=da2, three=da3)
 end
 


### PR DESCRIPTION
This PR adds type parameters `K,T,N` to stacks for better dispatch and type stabiity in both Array-like and NamedTuple-lke behaviors.

It it incliudes a bunch of performance fixes and more complete tests.

 
Pacakges extending `AbstractDimStack{L}` will now need to extend `AbstractDimStack{K,T,N,L}`. There are new helper methods `stacktype` and `data_eltype` to help getting these paremeters. `data_eltype` can be extended for alternate stack data objects besides `NamedTuple`.

There is also a new standard behavour: indexing with dimensional objects like a vector of dimension tuples will  do a `mergedims`, because you can index a subset of the dimensions. But indexing with `colon` or Vector of Int/CartesianIndex will return a raw vector of NamedTuple, not a mergedims DimStack - so there is a way to avoid the overhead of buiding the merged lookups.


@sethaxen this will require some changes to Arviz, maybe you want to review. It would be good to make sure I've covered everything and don't need to make any more breaking changes.