### PR TITLE
fix typos in docs

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -1,6 +1,6 @@
 ## Installation
 
-If want to use this package you need to install it first. You can do it using the following commands:
+If you want to use this package you need to install it first. You can do it using the following commands:
 
 ````julia
 julia>] # ']' should be pressed
@@ -46,3 +46,5 @@ or something a little bit more complicated:
 data = rand(Int8, 2, 10, 3) .|> abs
 B = DimArray(data, (channel=[:left, :right], time=1:10, iter=1:3))
 ````
+
+

--- a/docs/src/dimarrays.md
+++ b/docs/src/dimarrays.md
@@ -169,7 +169,7 @@ Methods where dims, dim types, or `Symbol`s can be used to indicate the array di
 
 ## Performance
 
-Indexing with `Dimension`s has no runtime cost. Lets benchmark it:
+Indexing with `Dimension`s has no runtime cost. Let's benchmark it:
 
 ```@ansi dimarray
 using BenchmarkTools

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -2,7 +2,7 @@
 
 ## Rasters.jl
 
-[Raster.jl](https://rafaqz.github.io/Rasters.jl/stable) extends DD
+[Rasters.jl](https://rafaqz.github.io/Rasters.jl/stable) extends DD
 for geospatial data manipulation, providing file load/save for
 a wide range of raster data sources and common GIS tools like
 polygon rasterization and masking. `Raster` types are aware
@@ -19,7 +19,7 @@ and `Projected` and `Mapped` are `AbstractSample` lookups.
 ## YAXArrays.jl
 
 [YAXArrays.jl](https://juliadatacubes.github.io/YAXArrays.jl/dev/) is another
-spatial data package aimmed more at (very) large datasets. It's functionality
+spatial data package aimed more at (very) large datasets. It's functionality
 is slowly converging with Rasters.jl (both wrapping DiskArray.jl/DimensionalData.jl)
 and we work closely with the developers.
 
@@ -33,20 +33,20 @@ Extends DD with methods for analysis of climate data.
 ## ArviZ.jl
 
 [ArviZ.jl](https://arviz-devs.github.io/ArviZ.jl/dev/) 
-Is a julia package for exploratory analysis of Bayesian models.
+Is a Julia package for exploratory analysis of Bayesian models.
 
 An `ArviZ.Dataset` is an `AbstractDimStack`!
 
 ## JuMP.jl
 
-[JuMP.jl](https://jump.dev/) is a powerful omptimisation DSL. 
+[JuMP.jl](https://jump.dev/) is a powerful optimization DSL. 
 It defines its own named array types but now accepts any `AbstractDimArray` 
 too, through a package extension.
 
 ## CryoGrid.jl
 
 [CryoGrid.jl](https://juliahub.com/ui/Packages/General/CryoGrid)
-A Juia implementation of the CryoGrid permafrost model.
+A Julia implementation of the CryoGrid permafrost model.
 
 `CryoGridOutput` uses `DimArray` for views into output data.
 
@@ -63,7 +63,7 @@ synchronisation during simulations. Notably, this all works on GPUs!
 ## AstroImages.jl
 
 [AstroImages.jl](http://juliaastro.org/dev/modules/AstroImages)
-Provides tools to load and visualise astromical images.
+Provides tools to load and visualise astronomical images.
 `AstroImage` is `<: AbstractDimArray`.
 
 ## TimeseriesTools.jl

--- a/docs/src/object_modification.md
+++ b/docs/src/object_modification.md
@@ -10,7 +10,7 @@ Everything else must be _rebuilt_ and assigned to a variable.
 ## `modify`
 
 Modify the inner arrays of a `AbstractDimArray` or `AbstractDimStack`, with
-[`modify`](@ref). This can be usefule to e.g. replace all arrays with `CuArray`
+[`modify`](@ref). This can be useful to e.g. replace all arrays with `CuArray`
 moving the data to the GPU, `collect` all inner arrays to `Array` without losing
 the outer `DimArray` wrappers, and similar things.
 
@@ -72,12 +72,12 @@ dimensions into a single combined dimension with a lookup holding
 `Tuples` of the values of both dimensions.
 
 
-## `rebulid`
+## `rebuild`
 
 [`rebuild`](@ref) is one of the core functions of DimensionalData.jl.
 Basically everything uses it somewhere. And you can to, with a few caveats.
 
-`reuild` assumes you _know what yo uare doing_. You can quite eaily set
+`rebuild` assumes you _know what you are doing_. You can quite eaily set
 values to things that don't make sense. The constructor may check a few things,
 like the number of dimensions matches the axes of the array. But not much else.
 
@@ -101,7 +101,7 @@ metadata(A1)
 
 The most common use internally is the arg version on `Dimension`.
 This is _very_ useful in dimension-based algorithmsas a way
-to transfrom a dimension wrapper from one object to another:
+to transform a dimension wrapper from one object to another:
 
 ```@ansi helpers
 d = X(1)
@@ -110,7 +110,7 @@ rebuild(d, 1:10)
 
 `rebuild` applications are listed here. `AbstractDimArray` and
 `AbstractDimStack` _always_ accept these keywords or arguments,
-but those in [ ] brackes may be thrown away if not needed.
+but those in [ ] brackets may be thrown away if not needed.
 Keywords in ( ) will error if used where they are not accepted.
 
 | Type                       | Keywords                                                    | Arguments            |
@@ -138,12 +138,12 @@ the process.
 ## `set`
 
 [`set`](@ref) gives us a way to set the values of the immutable objects
-in DD, like `Dimension` and `LookupAray`. Unlike `rebuild` it tries its best
+in DD, like `Dimension` and `LookupArray`. Unlike `rebuild` it tries its best
 to _do the right thing_. You don't have to specify what field you want to set.
 just pass in the object you want to be part of the lookup. Usually, there is
 no possible ambiguity.
 
-`set` is still improving. Sometimes itmay not do the right thing.
+`set` is still improving. Sometimes it may not do the right thing.
 If you think this is the case, make a github issue.
 
 :::: tabs

--- a/docs/src/plots.md
+++ b/docs/src/plots.md
@@ -16,7 +16,7 @@ Plots.jl support is deprecated, as development is moving to Makie.jl
 Makie.jl functions also mostly work with [`AbstractDimArray`](@ref) and will `permute` and 
 [`reorder`](@ref) axes into the right places, especially if `X`/`Y`/`Z`/`Ti` dimensions are used.
 
-In makie a `DimMatrix` will plot as a heatmap by defualt, but it will have labels 
+In makie a `DimMatrix` will plot as a heatmap by default, but it will have labels 
 and axes in the right places:
 
 ```@example Makie

--- a/docs/src/selectors.md
+++ b/docs/src/selectors.md
@@ -198,7 +198,7 @@ A[At(DateTime(3047, 9))]
 == NoLookup
 
 [`NoLookup(x)`](@ref) no lookup values provided, so `Selector`s will not work.
-Whe you create a `DimArray` without a lookup array, `NoLookup` will be used.
+When you create a `DimArray` without a lookup array, `NoLookup` will be used.
 It is also not show in repl printing.
 
 Here we create a [`NoLookup`](@ref):
@@ -241,7 +241,7 @@ from the arrays and ranges used.
         nothing` are the unknown outer bounds of the lookup. They are not needed
         for `Points` as the outer values are the outer bounds. But they can be
         specified manually for `Intervals`
-    - Emtpy dimensions or dimension types are assigned `NoLookup()` ranges that
+    - Empty dimensions or dimension types are assigned `NoLookup()` ranges that
         can't be used with selectors as they hold no values.
 
 ## `DimSelector`
@@ -267,7 +267,7 @@ B[DimSelectors(A)]
 ````
 
 If the lookups aren't aligned we can use `Near` instead of `At`,
-which like doing a nearest neighor interpolation:
+which like doing a nearest neighbor interpolation:
 
 ````@ansi selectors
 C = rand(X(1.0:0.007:2.0), Y(10.0:0.9:30))

--- a/docs/src/stacks.md
+++ b/docs/src/stacks.md
@@ -30,7 +30,7 @@ st[:c]
 
 == subsetting layers
 
-We can subset layers with a `Tupe` of `Symbol`:
+We can subset layers with a `Tuple` of `Symbol`:
 
 ````@ansi stack
 st[(:a, :c)]
@@ -39,7 +39,7 @@ st[(:a, :c)]
 == inverted subsets
 
 `Not` works on `Symbol` keys just like it does on `Selector`:
-It inverts the keys to give you a `DImStack` with all the other layers:
+It inverts the keys to give you a `DimStack` with all the other layers:
 
 ````@ansi stack
 st[Not(:b)]

--- a/docs/src/tables.md
+++ b/docs/src/tables.md
@@ -1,7 +1,7 @@
 # Tables and DataFrames
 
 [Tables.jl](https://github.com/JuliaData/Tables.jl) provides an 
-ecosystem-wide interface to tabular data in julia, giving interop with 
+ecosystem-wide interface to tabular data in Julia, giving interoperability with 
 [DataFrames.jl](https://dataframes.juliadata.org/stable/), 
 [CSV.jl](https://csv.juliadata.org/stable/) and hundreds of other 
 packages that implement the standard.


### PR DESCRIPTION
Just noticed the docs had some typos, so I fixed those I (and ChatGPT) could find.