### PR TITLE
contains checks if index is valid

### DIFF
--- a/src/Lookups/selector.jl
+++ b/src/Lookups/selector.jl
@@ -399,7 +399,8 @@ function contains(
 )
     v = val(sel)
     i = searchsortedlast(l, v; by=_by)
-    if _in(v, l[i])
+   
+    if i in eachindex(l) && _in(v, l[i])
         return i
     else
         return _notcontained_or_nothing(err, v)


### PR DESCRIPTION
fixes a bug where contains throws an error if sel is not in l , even when err is set to false.