### PR TITLE
`dimsmatch` on `name` so that `X` matches `Dim{:X}`

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -24,7 +24,7 @@ end
 @inline dimsmatch(f::Function, dim, query::Nothing) = false
 @inline dimsmatch(f::Function, dim::Nothing, query) = false
 @inline dimsmatch(f::Function, dim::Nothing, query::Nothing) = false
-@inline dimsmatch(f::Function, dim::Type{Va{D}}, match::Type{Val{M}}) where {D,M} =
+@inline dimsmatch(f::Function, dim::Type{Val{D}}, match::Type{Val{M}}) where {D,M} =
     dimsmatch(f, D, M)
 @inline function dimsmatch(f::Function, dim::Type{D}, match::Type{M}) where {D,M}
     # Match based on type and inheritance

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -24,6 +24,8 @@ end
 @inline dimsmatch(f::Function, dim, query::Nothing) = false
 @inline dimsmatch(f::Function, dim::Nothing, query) = false
 @inline dimsmatch(f::Function, dim::Nothing, query::Nothing) = false
+@inline dimsmatch(f::Function, dim::Type{Va{D}}, match::Type{Val{M}}) where {D,M} =
+    dimsmatch(f, D, M)
 @inline function dimsmatch(f::Function, dim::Type{D}, match::Type{M}) where {D,M}
     # Match based on type and inheritance
     f(basetypeof(unwrap(D)), basetypeof(unwrap(M))) || 

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -32,7 +32,7 @@ end
     dimsmatch(f, D, M)
 @inline function dimsmatch(f::Function, dim::Type{D}, match::Type{M})::Bool where {D,M}
     # Match based on type and inheritance
-    f(basetypeof(unwrap(D)), basetypeof(unwrap(M))) || 
+    f(basetypeof(unwrap(D)), basetypeof(unwrap(M))) ||
     # Or match based on name so that Dim{:X} matches X
     isconcretetype(D) && isconcretetype(M) && name(D) === name(M)
 end
@@ -79,7 +79,15 @@ function sortdims end
 _asfunc(::Type{typeof(<:)}) = <:
 _asfunc(::Type{typeof(>:)}) = >:
 
-@inline _sortdims(f, tosort, order::Tuple{<:Integer,Vararg}) =map(p -> tosort[p], order)
+@inline function _sortdims(f, tosort, order::Tuple{<:Integer,Vararg})
+    map(order) do i
+        if i in 1:length(tosort) 
+            tosort[i]
+        else
+            nothing
+        end
+    end
+end
 @inline _sortdims(f, tosort, order) = _sortdims_gen(f, tosort, order)
 
 @generated _sortdims_gen(f, tosort::Tuple, order::Tuple) = begin
@@ -205,7 +213,7 @@ julia> dimnum(A, Y)
 """
 function dimnum end
 @inline function dimnum(x, q1, query...)
-    all(hasdim(x, q1, query...)) || _extradimserror(otherdims(x, (q1, query)))
+    all(hasdim(x, q1, query...)) || _extradimserror(otherdims(x, (q1, query...)))
     _dim_query(_dimnum, MaybeFirst(), x, q1, query...)
 end
 @inline dimnum(x, query::Function) =
@@ -284,26 +292,22 @@ julia> otherdims(A, (Y, Z))
 ```
 """
 function otherdims end
-@inline otherdims(x, query) = begin
-    @show x query
-    _dim_query(_otherdims_presort, AlwaysTuple(), x, query)
-end
 @inline otherdims(x, query...) =
-    _dim_query(_otherdims_presort, AlwaysTuple(), x, query)
+    _dim_query(_otherdims, AlwaysTuple(), x, query...)
 
-@inline function _otherdims_presort(f, ds, query) 
-    @show ds query
-    _otherdims(f, ds, _sortdims(_rev_op(f), query, ds))
+@inline _otherdims(f, ds) = ds
+@inline function _otherdims(f, ds, query)
+    sorted = sortdims(f, dims(ds, query), ds)
+    _otherdims_from_nothing(f, ds, sorted)
 end
 # Work with a sorted query where the missing dims are `nothing`
-@inline _otherdims(f, ds::Tuple, query::Tuple) =
-    (_dimifmatching(f, first(ds), first(query))..., _otherdims(f, tail(ds), tail(query))...)
-@inline _otherdims(f, dims::Tuple{}, ::Tuple{}) = ()
+@inline _otherdims_from_nothing(f, ds::Tuple, query::Tuple) =
+    (_dimifnothing(f, first(ds), first(query))..., _otherdims_from_nothing(f, tail(ds), tail(query))...)
+@inline _otherdims_from_nothing(f, ::Tuple{}, ::Tuple{}) = ()
 
-@inline _dimifmatching(f, dim, query) = dimsmatch(f, dim, query) ? () : (dim,)
+@inline _dimifnothing(f, dim, query) = () 
+@inline _dimifnothing(f, dim, query::Nothing) = (dim,)
 
-_rev_op(::typeof(<:)) = >:
-_rev_op(::typeof(>:)) = <:
 
 """
     setdims(X, newdims) => AbstractArray
@@ -558,7 +562,7 @@ function comparedims end
     type && basetypeof(a) != basetypeof(b) && _dimsmismatcherror(a, b)
     valtype && typeof(parent(a)) != typeof(parent(b)) && _valtypeerror(a, b)
     val && parent(lookup(a)) != parent(lookup(b)) && _valerror(a, b)
-    if order 
+    if order
         (isnolookup(a) || isnolookup(b) || LU.order(a) == LU.order(b)) || _ordererror(a, b)
     end
     if ignore_length_one && (Base.length(a) == 1 || Base.length(b) == 1)
@@ -585,7 +589,7 @@ end
 @inline _comparedims(T::Type{Bool}, a::Dimension, b::AnonDim; kw...) = true
 @inline _comparedims(T::Type{Bool}, a::AnonDim, b::Dimension; kw...) = true
 @inline function _comparedims(::Type{Bool}, a::Dimension, b::Dimension;
-    type=true, valtype=false, val=false, length=true, order=false, ignore_length_one=false, 
+    type=true, valtype=false, val=false, length=true, order=false, ignore_length_one=false,
     warn::Union{Nothing,String}=nothing,
 )
     if type && basetypeof(a) != basetypeof(b)
@@ -600,7 +604,7 @@ end
         isnothing(warn) || _valwarn(a, b, warn)
         return false
     end
-    if order && !(isnolookup(a) || isnolookup(b) || LU.order(a) == LU.order(b)) 
+    if order && !(isnolookup(a) || isnolookup(b) || LU.order(a) == LU.order(b))
         isnothing(warn) || _orderwarn(a, b, warn)
         return false
     end

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -24,8 +24,12 @@ end
 @inline dimsmatch(f::Function, dim, query::Nothing) = false
 @inline dimsmatch(f::Function, dim::Nothing, query) = false
 @inline dimsmatch(f::Function, dim::Nothing, query::Nothing) = false
-@inline dimsmatch(f::Function, dim::Type{D}, match::Type{M}) where {D,M} =
-    f(basetypeof(unwrap(D)), basetypeof(unwrap(M)))
+@inline function dimsmatch(f::Function, dim::Type{D}, match::Type{M}) where {D,M}
+    # Match based on type and inheritance
+    f(basetypeof(unwrap(D)), basetypeof(unwrap(M))) || 
+    # Or match based on name so that Dim{:X} matches X
+    isconcretetype(D) && isconcretetype(M) && name(D) === name(M)
+end
 
 """
     name2dim(s::Symbol) => Dimension

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -24,7 +24,11 @@ end
 @inline dimsmatch(f::Function, dim, query::Nothing) = false
 @inline dimsmatch(f::Function, dim::Nothing, query) = false
 @inline dimsmatch(f::Function, dim::Nothing, query::Nothing) = false
-@inline dimsmatch(f::Function, dim::Type{Val{D}}, match::Type{Val{M}}) where {D,M} =
+@inline dimsmatch(f::Function, dim::Type{<:Val{D}}, match::Type{<:Val{M}}) where {D,M} =
+    dimsmatch(f, D, M)
+@inline dimsmatch(f::Function, dim::Type{D}, match::Type{<:Val{M}}) where {D,M} =
+    dimsmatch(f, D, M)
+@inline dimsmatch(f::Function, dim::Type{<:Val{D}}, match::Type{M}) where {D,M} =
     dimsmatch(f, D, M)
 @inline function dimsmatch(f::Function, dim::Type{D}, match::Type{M}) where {D,M}
     # Match based on type and inheritance

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -564,12 +564,10 @@ _unique(A::AbstractDimArray, dims::Colon) = unique(parent(A); dims=:)
 
 Base.diff(A::AbstractDimVector; dims=1) = _diff(A, dimnum(A, dims))
 Base.diff(A::AbstractDimArray; dims) = begin
-    @show dims
     _diff(A, dimnum(A, dims))
 end
 
 @inline function _diff(A::AbstractDimArray{<:Any,N}, dims::Integer) where {N}
-    @show dims
     r = axes(A)
     # Copied from Base.diff
     r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -563,9 +563,13 @@ _unique(A::AbstractDimArray, dims) = unique(parent(A); dims=dimnum(A, dims))
 _unique(A::AbstractDimArray, dims::Colon) = unique(parent(A); dims=:)
 
 Base.diff(A::AbstractDimVector; dims=1) = _diff(A, dimnum(A, dims))
-Base.diff(A::AbstractDimArray; dims) = _diff(A, dimnum(A, dims))
+Base.diff(A::AbstractDimArray; dims) = begin
+    @show dims
+    _diff(A, dimnum(A, dims))
+end
 
 @inline function _diff(A::AbstractDimArray{<:Any,N}, dims::Integer) where {N}
+    @show dims
     r = axes(A)
     # Copied from Base.diff
     r0 = ntuple(i -> i == dims ? UnitRange(1, last(r[i]) - 1) : UnitRange(r[i]), N)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -222,7 +222,7 @@ function mergedims(st::AbstractDimStack, dim_pairs::Pair...)
     isempty(dim_pairs) && return st
     # Extend missing dimensions in all layers
     extended_layers = map(layers(st)) do layer
-        if all(map((ds...) -> all(hasdim(layer, ds)), map(first, dim_pairs)))
+        if all(map((ds...) -> all(hasdim(layer, ds)), map(first, dim_pairs)...))
             layer
         else
             DimExtensionArray(layer, dims(st))

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -152,8 +152,18 @@ end
         @test dims(A, :two) == Dim{:two}(NoLookup(Base.OneTo(5)))
     end
 
-    # @test_throws ArgumentError dims(da, Ti)
-    # @test_throws ArgumentError dims(dimz, Ti)
+    @testset "non matching single queries return nothing" begin
+        @test dims(da, :Ti) == nothing
+        @test dims(da, Ti) == nothing
+        @test dims(da, 3) == nothing
+    end
+
+    @testset "non matching tuple queries return empty tuples" begin
+        @test dims(da, (:Ti,)) == ()
+        @test dims(da, (Ti,)) == ()
+        @test dims(da, (3,)) == ()
+    end
+
     @test_throws ArgumentError dims(nothing, X)
 
     @test dims(dimz) === dimz
@@ -200,7 +210,6 @@ end
 end
 
 @testset "dimnum" begin
-    dims(da)
     @test dimnum(da, Y()) == dimnum(da, 2) == 2
     @test dimnum(da, Base.Fix2(isa,Y)) == (2,)
     @test (@ballocated dimnum($da, Y())) == 0
@@ -221,6 +230,12 @@ end
         @test dimnum((Dim{:a}(), Y(), Dim{:b}()), (:b, :a, Y)) == (3, 1, 2)
         dimz = (Dim{:a}(), Y(), Dim{:b}())
         @test (@ballocated dimnum($dimz, :b, :a, Y)) == 0
+    end
+
+    @testset "not present dimensions error" begin
+        @test_throws ArgumentError dimnum(da, Z())
+        @test_throws ArgumentError dimnum(da, 3)
+        @test_throws ArgumentError dimnum(da, 0)
     end
 end
 
@@ -273,7 +288,7 @@ end
     @test otherdims(A, X, Y) == dims(A, (Z,))
     @test otherdims(A, Y) == dims(A, (X, Z))
     @test otherdims(A, Z) == dims(A, (X, Y))
-    @test otherdims(A) == dims(A, (X, Y, Z))
+    @test otherdims(A) == dims(A)
     @test otherdims(A, DimensionalData.ZDim) == dims(A, (X, Y))
     @test otherdims(A, (X, Z)) == dims(A, (Y,))
     f1 = A -> otherdims(A, (X, Z))
@@ -289,6 +304,13 @@ end
         @test otherdims((Dim{:a}(), Dim{:b}(), Ti()), (:a, :c)) == (Dim{:b}(), Ti())
     end
     @test_throws ArgumentError otherdims(nothing, X)
+
+    @testset "non matching single queries return all dims" begin
+        @test otherdims(da, :Ti) == dims(da)
+        @test otherdims(da, Ti) == dims(da)
+        @test otherdims(da, 3) == dims(da)
+        @test otherdims(da, 0) == dims(da)
+    end
 end
 
 @testset "combinedims" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -226,7 +226,7 @@ end
 @testset "hasdim" begin
     @test hasdim(da, X()) == true
     @test hasdim(da, :X) == true
-    @test hasdim(da, isforward) == (true, true)
+    @test hasdim(da, isforward) == (true, true) 
     @test (@ballocated hasdim($da, X())) == 0
     @test hasdim(da, Ti) == false
     @test (@ballocated hasdim($da, Ti)) == 0
@@ -430,8 +430,8 @@ end
             ((X(Sampled([142.0], ForwardOrdered(), Regular(2.0), Intervals(Start()), NoMetadata())),
               Y(Sampled([30.0, 20.0], ReverseOrdered(), Regular(-10.0), Intervals(Center()), NoMetadata()))), ())
         # This should never happen, not sure why it was tested?
-        @test_broken slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ())
-        @test slicedims((), (1, 1)) == slicedims((), (), (1, 1)) == ((), ())
+        @test_broken slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ()) 
+        @test slicedims((), (1, 1)) == slicedims((), (), (1, 1)) == ((), ()) 
     end
 
     @testset "Irregular Points" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -31,10 +31,11 @@ dimz = dims(da)
     @test (@inferred dimsmatch(nothing, Z())) == false
     @test (@inferred dimsmatch(nothing, nothing)) == false
 
+    @test (@ballocated dimsmatch((Z(), ZDim), (ZDim, Dimension))) == 0
     @test (@ballocated dimsmatch(ZDim, Dimension)) == 0
     @test (@ballocated dimsmatch((Z(), ZDim), (ZDim, XDim))) == 0
 
-    @testset "no type match but name matches"
+    @testset "no type match but name matches" begin
         @test (@ballocated dimsmatch(Z, Dim{:Z})) == 0
         @test (@ballocated dimsmatch((Z(), Dim{:Ti}()), (Dim{:Z}(), Ti()))) == 0
     end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -33,6 +33,11 @@ dimz = dims(da)
 
     @test (@ballocated dimsmatch(ZDim, Dimension)) == 0
     @test (@ballocated dimsmatch((Z(), ZDim), (ZDim, XDim))) == 0
+
+    @testset "no type match but name matches"
+        @test (@ballocated dimsmatch(Z, Dim{:Z})) == 0
+        @test (@ballocated dimsmatch((Z(), Dim{:Ti}()), (Dim{:Z}(), Ti()))) == 0
+    end
 end
 
 @testset "key2dim" begin
@@ -221,7 +226,7 @@ end
 @testset "hasdim" begin
     @test hasdim(da, X()) == true
     @test hasdim(da, :X) == true
-    @test hasdim(da, isforward) == (true, true) 
+    @test hasdim(da, isforward) == (true, true)
     @test (@ballocated hasdim($da, X())) == 0
     @test hasdim(da, Ti) == false
     @test (@ballocated hasdim($da, Ti)) == 0
@@ -425,8 +430,8 @@ end
             ((X(Sampled([142.0], ForwardOrdered(), Regular(2.0), Intervals(Start()), NoMetadata())),
               Y(Sampled([30.0, 20.0], ReverseOrdered(), Regular(-10.0), Intervals(Center()), NoMetadata()))), ())
         # This should never happen, not sure why it was tested?
-        @test_broken slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ()) 
-        @test slicedims((), (1, 1)) == slicedims((), (), (1, 1)) == ((), ()) 
+        @test_broken slicedims((), (1:2, 3)) == slicedims((), (), (1:2, 3)) == ((), ())
+        @test slicedims((), (1, 1)) == slicedims((), (), (1, 1)) == ((), ())
     end
 
     @testset "Irregular Points" begin


### PR DESCRIPTION
Closes  #459

@lazarusA @felixcremer I think we talked about this... turns out its ridiculously simple.

But this PR means `X` will match with `Dim{:X}` and similar as the have the same name anyway, would go in the same dataframe column and use the same keyword syntax, etc.

The weird part is that `Dim{:X}` still wont plot on the `X` axis - we need to switch to traits for that and its harder. But this is a start to that I guess.

Maybe we should switch to trait-based plotting and axis association in this same breaking change?
