### PR TITLE
Fix selectindices for `nothing` return type

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -261,7 +261,7 @@ end
     end
     return tuple_exp
 end
-@inline selectindices(ds::Tuple{}, sel::Tuple{}; kw...) = () 
+@inline selectindices(ds::Tuple, sel::Tuple{}; kw...) = () 
 @inline selectindices(dim::Dimension, sel; kw...) = selectindices(val(dim), sel; kw...)
 
 # Deprecated

--- a/test/selector.jl
+++ b/test/selector.jl
@@ -1420,7 +1420,11 @@ end
 
 @testset "selectindices" begin
     @test selectindices(A[X(1)], Contains(7)) == (3,)
+    @test selectindices(A, (At(10), Contains(7))) == (1, 3)
     @test selectindices(dims_, ()) == ()
+    @test selectindices((), ()) == ()
+    @test selectindices(A, (At(90), Contains(7)); err=Lookups._False()) == nothing
+    @test selectindices(A[X(1)], Contains(10); err=Lookups._False()) == nothing
 end
 
 @testset "hasselection" begin


### PR DESCRIPTION
This fixes `selectindices` for tuples so that non-error mode still returns `nothing`. It also performance optimises this.

Unfortunately a `@gernerated` function was needed as I could not get it to fold away with `@assume_effects` and the Revise bug keeps giving false positives. 