### PR TITLE
Add `broadcast_dims` page to docs

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -72,6 +72,7 @@ export default defineConfig({
           { text: 'DimArrays', link: '/dimarrays' },
           { text: 'DimStacks', link: '/stacks' },
           { text: 'GroupBy', link: '/groupby' },
+          { text: 'Dimension-aware broadcast', link: '/broadcast_dims.md' },
           { text: 'Getting information', link: '/get_info' },
           { text: 'Object modification', link: '/object_modification' },
         ]},


### PR DESCRIPTION
I don't know if this is in conflict with #722, but I just noticed doc pages for `broadcast_dims` is not found from the sidebar, so this small change should improve discoverability.