### PR TITLE
Remove duplicate Aqua tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,7 @@ using DimensionalData, Test, Aqua, SafeTestsets
     Aqua.test_project_extras(DimensionalData)
     Aqua.test_stale_deps(DimensionalData)
     Aqua.test_deps_compat(DimensionalData)
-    Aqua.test_project_extras(DimensionalData)
-    Aqua.test_stale_deps(DimensionalData)
+
     
     
     @time @safetestset "interface" begin include("interface.jl") end


### PR DESCRIPTION
These two tests are duplicates of the lines above and should therefore not be needed.