### PR TITLE
always rebuild DimGroupbyArray to a normal AbstractDimArray

### DIFF
--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -250,16 +250,25 @@ function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
         ibottom = 1:0
     end
     top = Array{eltype(A)}(undef, length(itop))
-    copyto!(top, CartesianIndices(top), A, CartesianIndices(itop))
+    for (i1, i2) in zip(eachindex(top), itop)
+        if isdefined(A, i2) 
+            top[i1] = A[i2]
+        end
+    end
     bottom = Array{eltype(A)}(undef, length(ibottom)) 
-    copyto!(bottom, CartesianIndices(bottom), A, CartesianIndices(ibottom))
+    for (i1, i2) in zip(eachindex(bottom), ibottom)
+        if isdefined(A, i2) 
+            top[i1] = A[i2]
+        end
+    end
     vals = vcat(A[itop], A[ibottom])
     lu = only(lookups)
     if lu isa NoLookup
         Base.print_matrix(io, vals)
     else
         labels = vcat(map(show1, parent(lu)[itop]), map(show1, parent(lu)[ibottom]))
-        Base.print_matrix(io, hcat(labels, vals))
+        A2 = hcat(labels, vals)
+        Base.print_matrix(io, A2)
     end
     return nothing
 end

--- a/test/groupby.jl
+++ b/test/groupby.jl
@@ -82,7 +82,11 @@ end
     month_length = DimArray(daysinmonth, dims(A, Ti))
     g_tempo = DimensionalData.groupby(month_length, Ti=>seasons(; start=December))
     sum_days = sum.(g_tempo, dims=Ti)
+    @test sum_days isa DimArray
     weights = map(./, g_tempo, sum_days)
+    @test sum_days isa DimArray
     G = DimensionalData.groupby(A, Ti=>seasons(; start=December))
     G_w = broadcast_dims.(*, weights, G)
+    @test G_w isa DimArray
+    @test G_w[1] isa DimArray
 end


### PR DESCRIPTION
This was a mistake, having `rebuild` ever return a DimGroupByArray introduces a whole range of bugs, like `similar` returning a `DimGroupByArray` of `undef` that fails in `show`. 

`DimGroupByArray` should only ever be the result of `groupby`.

I'm not sure if this is breaking, there are probably no cases in the wild where this will change anything, and in practice its pretty much a bug.