### PR TITLE
make print_matrix use a lazy array

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -351,7 +351,7 @@ data from a file. Can be used as keyword arguments for indexing.
 Dimension types take precedence over same named `Dim` types when indexing
 with symbols, or e.g. creating Tables.jl keys.
 
-```jldoctest
+```jldoctest; setup = :(using DimensionalData)
 julia> dim = Dim{:custom}(['a', 'b', 'c'])
 custom ['a', 'b', 'c']
 ```

--- a/src/Dimensions/show.jl
+++ b/src/Dimensions/show.jl
@@ -52,8 +52,8 @@ function show_dims(io::IO, mime::MIME"text/plain", dims::DimTuple;
     end
 end
 
-Base.show(io::IO, mime::MIME"text/plain", dims::DimTuple) =
-    show_dims(io, mime, dims)
+Base.show(io::IO, dims::DimTuple) = show_dims(io, MIME"text/plain"(), dims)
+Base.show(io::IO, mime::MIME"text/plain", dims::DimTuple) = show_dims(io, mime, dims)
 function Base.show(io::IO, mime::MIME"text/plain", dim::Dimension)
     get(io, :compact, false) && return show_compact(io, mime, dim)
     print_dimname(io, dim)

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -241,6 +241,7 @@ function print_name(io::IO, name)
     end
 end
 
+# A lazy array wrapper to print lookup values as an extra row and/or column
 struct LazyLabelledPrintMatrix{A,LL<:Lookup,LT<:Lookup} <: AbstractArray{Any,2}
     data::A
     rowlabels::LL
@@ -251,6 +252,7 @@ function LazyLabelledPrintMatrix(A::AbstractBasicDimArray{<:Any,1})
 end
 function LazyLabelledPrintMatrix(A::AbstractBasicDimArray{<:Any,2})
     LazyLabelledPrintMatrix(parent(A), lookup(A, 1), lookup(A, 2))
+end
 
 function Base.size(A::LazyLabelledPrintMatrix)
     n = ndims(A.data)
@@ -313,6 +315,7 @@ end
     end
 end
 
+# A wrapper to print objects with dimension colors or arrows
 struct ShowWith <: AbstractString
     val::Any
     mode::Symbol

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -237,81 +237,84 @@ function print_name(io::IO, name)
     end
 end
 
+struct LazyLabelledPrintArray{N,LL<:Lookup,LT<:Lookup} <: AbstractArray{Any,2}
+    data::AbstractArray{<:Any,N}
+    rowlabels::LL
+    collabels::LT
+end
+
+function Base.size(A::LazyLabelledPrintArray)
+    n = ndims(A.data)
+    if n == 1
+        return length(A.data), A.rowlabels isa NoLookup ? 1 : 2
+    else
+        labelsize = A.rowlabels isa NoLookup ? 0 : 1, A.collabels isa NoLookup ? 0 : 1
+        return map(+, labelsize, size(A.data))
+    end
+end
+
+@propagate_inbounds function Base.getindex(A::LazyLabelledPrintArray, i::Integer, j::Integer)
+    @boundscheck checkbounds(A, i, j)
+    if ndims(A.data) == 1
+        if A.rowlabels isa NoLookup
+            A.data[i]
+        else
+            if i == 1
+                showrowlabel(A.rowlabels[i])
+            elseif i == 2
+                A.data[i]
+            end
+        end
+    else # N == 2
+        if A.rowlabels isa NoLookup
+            if A.collabels isa NoLookup
+                A.data[i, j]
+            else
+                if i == 1
+                    showcollabel(A.collabels[j])
+                else
+                    A.data[i, j - 1]
+                end
+            end
+        else
+            if j == 1
+                if i == 1
+                    showarrows()
+                else
+                    showrowlabel(A.rowlabels[i - 1])
+                end
+            else
+                if A.collabels isa NoLookup
+                    A.data[i - 1, j]
+                else
+                    if i == 1
+                        showcollabel(A.collabels[j - 1])
+                    else
+                        A.data[i - 1, j - 1]
+                    end
+                end
+            end
+        end
+    end
+end
+
 Base.print_matrix(io::IO, A::AbstractBasicDimArray) = _print_matrix(io, parent(A), lookup(A))
 # Labelled matrix printing is modified from AxisKeys.jl, thanks @mcabbot
 function _print_matrix(io::IO, A::AbstractArray{<:Any,1}, lookups::Tuple)
-    f1, l1, s1 = firstindex(A, 1), lastindex(A, 1), size(A, 1)
-    if get(io, :limit, false)
-        h, _ = displaysize(io)
-        itop =    s1 < h ? (f1:l1) : (f1:f1 + (h ÷ 2) - 1)
-        ibottom = s1 < h ? (1:0)   : (f1 + s1 - (h ÷ 2) - 1:f1 + s1 - 1)
-    else
-        itop    = f1:l1
-        ibottom = 1:0
-    end
-    top = Array{eltype(A)}(undef, length(itop))
-    copyto!(top, CartesianIndices(top), A, CartesianIndices(itop))
-    bottom = Array{eltype(A)}(undef, length(ibottom)) 
-    copyto!(bottom, CartesianIndices(bottom), A, CartesianIndices(ibottom))
-    vals = vcat(A[itop], A[ibottom])
     lu = only(lookups)
     if lu isa NoLookup
-        Base.print_matrix(io, vals)
+        Base.print_matrix(io, A)
     else
-        labels = vcat(map(show1, parent(lu)[itop]), map(show1, parent(lu)[ibottom]))
-        Base.print_matrix(io, hcat(labels, vals))
+        Base.print_matrix(io, LazyLabelledPrintArray(A, lu, lu))
     end
     return nothing
 end
 function _print_matrix(io::IO, A::AbstractArray{<:Any,2}, lookups::Tuple)
-    lu1, lu2 = lookups
-    f1, f2 = firstindex(lu1), firstindex(lu2)
-    l1, l2 = lastindex(lu1), lastindex(lu2)
-    if get(io, :limit, false)
-        h, w = displaysize(io)
-        wn = w ÷ 3 # integers take 3 columns each when printed, floats more
-        s1, s2 = size(A)
-        itop    = s1 < h  ? (f1:l1)     : (f1:h ÷ 2 + f1 - 1)
-        ibottom = s1 < h  ? (f1:f1 - 1) : (f1 + s1 - h ÷ 2 - 1:f1 + s1 - 1)
-        ileft   = s2 < wn ? (f2:l2)     : (f2:f2 + wn ÷ 2 - 1)
-        iright  = s2 < wn ? (f2:f2 - 1) : (f2 + s2 - wn ÷ 2:f2 + s2 - 1)
+    if isnolookup(lookups)
+        Base.print_matrix(io, A)
     else
-        itop    = f1:l1
-        ibottom = f1:f1-1
-        ileft   = f2:l2
-        iright  = f2:f2-1
+        Base.print_matrix(io, LazyLabelledPrintArray(A, lookups...))
     end
-
-    # A bit convoluted so it plays nice with GPU arrays
-    topleft = Matrix{eltype(A)}(undef, map(length, (itop, ileft)))
-    copyto!(topleft, CartesianIndices(topleft), A, CartesianIndices((itop, ileft)))
-    bottomleft = Matrix{eltype(A)}(undef, map(length, (ibottom, ileft))) 
-    copyto!(bottomleft, CartesianIndices(bottomleft), A, CartesianIndices((ibottom, ileft)))
-    if !(lu1 isa NoLookup)
-        topleft = hcat(map(show1, parent(lu1)[itop]), topleft)
-        bottomleft = hcat(map(show1, parent(lu1)[ibottom]), bottomleft)
-    end
-    leftblock = vcat(topleft, bottomleft)
-    topright = Matrix{eltype(A)}(undef, map(length, (itop, iright)))
-    copyto!(topright, CartesianIndices(topright), A, CartesianIndices((itop, iright)))
-    bottomright= Matrix{eltype(A)}(undef, map(length, (ibottom, iright))) 
-    copyto!(bottomright, CartesianIndices(bottomright), A, CartesianIndices((ibottom, iright)))
-    rightblock = vcat(topright, bottomright)
-    bottomblock = hcat(leftblock, rightblock)
-
-    A_dims = if lu2 isa NoLookup
-        bottomblock
-    else
-        toplabels = map(show2, parent(lu2)[ileft]), map(show2, parent(lu2)[iright])
-        toprow = if lu1 isa NoLookup
-            vcat(toplabels...)
-        else
-            vcat(showarrows(), toplabels...)
-        end |> permutedims
-        vcat(toprow, bottomblock)
-    end
-
-    Base.print_matrix(io, A_dims)
     return nothing
 end
 
@@ -321,23 +324,24 @@ struct ShowWith <: AbstractString
     color::Union{Int,Symbol}
 end
 ShowWith(val; mode=:nothing, color=:light_black) = ShowWith(val, mode, color)
+
+showrowlabel(x) = ShowWith(x, :nothing, dimcolors(1))
+showcollabel(x) = ShowWith(x, :nothing, dimcolors(2))
+showarrows() = ShowWith(1.0, :print_arrows, :nothing)
+
 function Base.show(io::IO, mime::MIME"text/plain", x::ShowWith; kw...)
     if x.mode == :print_arrows
         printstyled(io, dimsymbols(1); color=dimcolors(1))
         print(io, " ")
         printstyled(io, dimsymbols(2); color=dimcolors(2))
-    elseif x.mode == :hide
-        print(io, " ")
     else
         s = sprint(show, mime, x.val; context=io, kw...)
         printstyled(io, s; color=x.color)
     end
 end
-showdefault(x) = ShowWith(x, :nothing, :default)
-show1(x) = ShowWith(x, :nothing, dimcolors(1))
-show2(x) = ShowWith(x, :nothing, dimcolors(2))
-showhide(x) = ShowWith(x, :hide, :nothing)
-showarrows() = ShowWith(1.0, :print_arrows, :nothing)
+function Base.show(io::IO, x::ShowWith)
+    printstyled(io, string(x.val); color = x.color, hidden = x.mode == :hide)
+end
 
 function Base.alignment(io::IO, x::ShowWith)
     # Base bug means we need to special-case this...
@@ -351,9 +355,6 @@ Base.length(x::ShowWith) = length(string(x.val))
 Base.textwidth(x::ShowWith) = textwidth(string(x.val))
 Base.ncodeunits(x::ShowWith) = ncodeunits(string(x.val))
 function Base.print(io::IO, x::ShowWith)
-    printstyled(io, string(x.val); color = x.color, hidden = x.mode == :hide)
-end
-function Base.show(io::IO, x::ShowWith)
     printstyled(io, string(x.val); color = x.color, hidden = x.mode == :hide)
 end
 

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -249,7 +249,6 @@ struct ShowWith <: AbstractString
 end
 ShowWith(val; mode=:nothing, color=:light_black) = ShowWith(val, mode, color)
 
-showdefault(x) = ShowWith(x, :nothing, :default)
 showrowlabel(x) = ShowWith(x, :nothing, dimcolors(1))
 showcollabel(x) = ShowWith(x, :nothing, dimcolors(2))
 showarrows() = ShowWith(1.0, :print_arrows, :nothing)
@@ -284,7 +283,7 @@ Base.iterate(x::ShowWith) = iterate(string(x.val))
 Base.iterate(x::ShowWith, i::Int) = iterate(string(x.val), i::Int)
 
 # A lazy array wrapper to print lookup values as an extra row and/or column
-struct LazyLabelledPrintMatrix{A,LL,LT} <: AbstractArray{ShowWith,2}
+struct LazyLabelledPrintMatrix{A,LL,LT} <: AbstractArray{Any,2}
     data::A
     rowlabels::LL
     collabels::LT
@@ -311,24 +310,24 @@ end
     oi = i + firstindex(A.data, 1) - 1
     if ndims(A.data) == 1 
         if A.rowlabels isa NoLookup
-            showdefault(A.data[oi])
+            A.data[oi]
         else
             if j == 1
                 showrowlabel(A.rowlabels[oi])
             elseif j == 2
-                showdefault(A.data[oi])
+                A.data[oi]
             end
         end
     else # N == 2
         oj = j + firstindex(A.data, 2) - 1
         if A.rowlabels isa NoLookup
             if A.collabels isa NoLookup
-                showdefault(A.data[oi, oj])
+                A.data[oi, oj]
             else
                 if i == 1
                     showcollabel(A.collabels[oj])
                 else # i > 1
-                    showdefault(A.data[oi - 1, oj])
+                    A.data[oi - 1, oj]
                 end
             end
         else # !(A.rowlabels isa NoLookup)
@@ -336,7 +335,7 @@ end
                 if j == 1
                     showrowlabel(A.rowlabels[oi])
                 else # j > 1
-                    showdefault(A.data[oi, oj - 1])
+                    A.data[oi, oj - 1]
                 end
             else
                 if j == 1
@@ -349,7 +348,7 @@ end
                     if i == 1
                         showcollabel(A.collabels[oj - 1])
                     else # i > 1
-                        showdefault(A.data[oi - 1, oj - 1])
+                        A.data[oi - 1, oj - 1]
                     end
                 end
             end

--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -69,7 +69,7 @@ Index a `DimArray` with `DimIndices`.
 Notice that unlike CartesianIndices, it doesn't matter if the dimensions
 are not in the same order. Or even if they are not all contained in each.
 
-```jldoctest; setup = :(using Random; Random.seed!(123))
+```jldoctest; setup = :(using DimensionalData, Random; Random.seed!(123))
 julia> A = rand(Y(0.0:0.3:1.0), X('a':'f'))
 ╭─────────────────────────╮
 │ 4×6 DimArray{Float64,2} │
@@ -90,7 +90,7 @@ julia> di = DimIndices((X(1:2:4), Y(1:2:4)))
   ↓ X 1:2:3,
   → Y 1:2:3
 └─────────────────────────────────────────────┘
- ↓ →  1                            3
+ ↓ →  1              3
  1     ↓ X 1, → Y 1   ↓ X 1, → Y 3
  3     ↓ X 3, → Y 1   ↓ X 3, → Y 3
 
@@ -217,7 +217,7 @@ Here we can interpolate a `DimArray` to the lookups of another `DimArray`
 using `DimSelectors` with `Near`. This is essentially equivalent to
 nearest neighbour interpolation.
 
-```jldoctest; setup = :(using Random; Random.seed!(123))
+```jldoctest; setup = :(using DimensionalData, Random; Random.seed!(123))
 julia> A = rand(X(1.0:3.0:30.0), Y(1.0:5.0:30.0), Ti(1:2));
 
 julia> target = rand(X(1.0:10.0:30.0), Y(1.0:10.0:30.0));

--- a/src/stack/methods.jl
+++ b/src/stack/methods.jl
@@ -56,7 +56,7 @@ The generator has `size` and `axes` equivalent to those of the provided `dims`.
 
 # Examples
 
-```jldoctest
+```jldoctest; setup = :(using DimensionalData)
 julia> ds = DimStack((
            x=DimArray(randn(2, 3, 4), (X([:x1, :x2]), Y(1:3), Z)),
            y=DimArray(randn(2, 3, 5), (X([:x1, :x2]), Y(1:3), Ti))

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -19,6 +19,8 @@ end
     end
     odimz = (X(OffsetArray(100:100:300, -1:1)), Y(OffsetArray([:a, :b, :c, :d], 5:8)))
     oda = DimArray(oa, odimz)
+    size(DimensionalData.LazyLabelledPrintMatrix(oda[Y=End]))
+    size(oda[Y=End])
     @testset "Indexing and selectors work with offsets" begin
         @test axes(oda) == (-1:1, 5:8)
         @test oda[-1, 5] == oa[-1, 5] == 1

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,5 +1,6 @@
 using DimensionalData, Test, Dates
 using DimensionalData.Lookups, DimensionalData.Dimensions
+using DimensionalData: LazyLabelledPrintMatrix, ShowWith, showrowlabel, showcollabel, showarrows
 
 # define dims with both long name and Type name
 @dim Lon "Longitude"
@@ -14,6 +15,50 @@ z = Z('a':'d')
 ds = (x, y, z, t, n)
 A = DimArray(rand(length.(ds)...), ds; refdims=(Dim{:refdim}(1),), name=:test)
 ds = dims(A)
+
+@testset "LazyLabelledPrintMatrix" begin
+    A = LazyLabelledPrintMatrix(zeros(X(5)))
+    @test size(A) == (5, 1)
+    @test collect(A) == [0.0 0.0 0.0 0.0 0.0]'
+    A = LazyLabelledPrintMatrix(zeros(X(10:10:50)) .+ (1.0:1:5.0))
+    @test size(A) == (5, 2)
+    @test collect(A) == [
+        showrowlabel(10) 1.0
+        showrowlabel(20) 2.0
+        showrowlabel(30) 3.0
+        showrowlabel(40) 4.0
+        showrowlabel(50) 5.0
+    ]
+    A = LazyLabelledPrintMatrix(zeros(X(5), Y(10:10:30)))
+    @test size(A) == (6, 3)
+    @test collect(A) == [
+         showcollabel(10) showcollabel(20) showcollabel(30)
+         0.0              0.0              0.0
+         0.0              0.0              0.0
+         0.0              0.0              0.0
+         0.0              0.0              0.0
+         0.0              0.0              0.0
+    ]
+    A = LazyLabelledPrintMatrix(zeros(X(1:5), Y(3)))
+    @test size(A) == (5, 4)
+    @test collect(A) == [
+         showrowlabel(1) 0.0              0.0              0.0
+         showrowlabel(2) 0.0              0.0              0.0
+         showrowlabel(3) 0.0              0.0              0.0
+         showrowlabel(4) 0.0              0.0              0.0
+         showrowlabel(5) 0.0              0.0              0.0
+    ]
+    A = LazyLabelledPrintMatrix(zeros(X(1:5), Y(10:10:30)))
+    @test size(A) == (6, 4)
+    @test collect(A) == [
+         showarrows()    showcollabel(10) showcollabel(20) showcollabel(30)
+         showrowlabel(1) 0.0              0.0              0.0
+         showrowlabel(2) 0.0              0.0              0.0
+         showrowlabel(3) 0.0              0.0              0.0
+         showrowlabel(4) 0.0              0.0              0.0
+         showrowlabel(5) 0.0              0.0              0.0
+    ]
+end
 
 @testset "dims" begin
     sv = sprint(show, MIME("text/plain"), X())


### PR DESCRIPTION
This PR switches `show` to being completely lazy rather than creating a whole new array.

This also happens to fix printing of `undef`.

Closes # 761