### PR TITLE
Set all

### DIFF
--- a/src/Dimensions/set.jl
+++ b/src/Dimensions/set.jl
@@ -3,6 +3,8 @@ const DimSetters = Union{LookupSetters,Type,UnionAll,Dimension,Symbol}
 set(dim::Dimension, x::DimSetters) = _set(dim, x)
 set(dims_::DimTuple, args::Union{Dimension,DimTuple,Pair}...; kw...) =
     _set(dims_, args...; kw...)
+set(dims::DimTuple, l::Lookup) = set(dims, map(d -> basedims(d) => l, dims)...)
+set(dims::DimTuple, l::LookupTrait) = set(dims, map(d -> basedims(d) => l, dims)...)
 # Convert args/kw to dims and set
 _set(dims_::DimTuple, args::Dimension...; kw...) = _set(dims_, (args..., kw2dims(kw)...))
 # Convert pairs to wrapped dims and set

--- a/src/Dimensions/set.jl
+++ b/src/Dimensions/set.jl
@@ -1,5 +1,7 @@
 const DimSetters = Union{LookupSetters,Type,UnionAll,Dimension,Symbol}
 
+set(dim::Dimension, ::Type{T}) where T = set(dim, T())
+set(dims::DimTuple, ::Type{T}) where T = set(dims, T())
 set(dim::Dimension, x::DimSetters) = _set(dim, x)
 set(dims_::DimTuple, args::Union{Dimension,DimTuple,Pair}...; kw...) =
     _set(dims_, args...; kw...)

--- a/src/Lookups/lookup_traits.jl
+++ b/src/Lookups/lookup_traits.jl
@@ -216,6 +216,8 @@ struct AutoStep end
 struct AutoBounds end
 struct AutoDim end
 
+Base.step(::AutoSpan) = AutoStep()
+
 """
     Regular <: Span
 

--- a/src/Lookups/set.jl
+++ b/src/Lookups/set.jl
@@ -62,6 +62,28 @@ _set(order::Order, neworder::Order) = neworder
 _set(order::Order, neworder::AutoOrder) = order
 
 # Span
+_set(lookup::AbstractSampled, ::Irregular{AutoBounds}) = begin
+    bnds = if parent(lookup) isa AutoValues || span(lookup) isa AutoSpan
+        AutoBounds()
+    else
+        bounds(lookup)
+    end
+    rebuild(lookup; span=Irregular(bnds))
+end
+_set(lookup::AbstractSampled, ::Regular{AutoStep}) = begin
+    stp = if span(lookup) isa AutoSpan || step(lookup) isa AutoStep
+        if parent(lookup) isa AbstractRange
+            step(parent(lookup))
+        else
+            AutoStep()
+        end
+    else
+        step(lookup)
+    end
+    rebuild(lookup; span=Regular(stp))
+end
+_set(lookup::AbstractSampled, span::Regular{AutoStep}) = 
+    rebuild(lookup; span=Regular(step(lookup)))
 _set(lookup::AbstractSampled, span::Span) = rebuild(lookup; span=span)
 _set(lookup::AbstractSampled, span::AutoSpan) = lookup
 _set(span::Span, newspan::Span) = newspan

--- a/src/Lookups/set.jl
+++ b/src/Lookups/set.jl
@@ -1,5 +1,7 @@
 const LookupSetters = Union{AllMetadata,Lookup,LookupTrait,Nothing,AbstractArray}
+
 set(lookup::Lookup, x::LookupSetters) = _set(lookup, x)
+set(lookup::Lookup, ::Type{T}) where T = _set(lookup, T())
 
 # _set(lookup::Lookup, newlookup::Lookup) = lookup
 _set(lookup::AbstractCategorical, newlookup::AutoLookup) = begin
@@ -82,8 +84,6 @@ _set(lookup::AbstractSampled, ::Regular{AutoStep}) = begin
     end
     rebuild(lookup; span=Regular(stp))
 end
-_set(lookup::AbstractSampled, span::Regular{AutoStep}) = 
-    rebuild(lookup; span=Regular(step(lookup)))
 _set(lookup::AbstractSampled, span::Span) = rebuild(lookup; span=span)
 _set(lookup::AbstractSampled, span::AutoSpan) = lookup
 _set(span::Span, newspan::Span) = newspan

--- a/src/set.jl
+++ b/src/set.jl
@@ -118,7 +118,7 @@ julia> set(da, :custom => DD.Irregular(10, 12), Z => DD.Regular(9.9))
 """
 function set end
 # Types are constructed
-Base.@assume_effects :effect_free set(x, ::Type{T}) where T = set(x, T())
+Base.@assume_effects :effect_free set(x::DimArrayOrStack, ::Type{T}) where T = set(x, T())
 
 # Dimensions and pairs are set for dimensions 
 Base.@assume_effects :effect_free set(A::DimArrayOrStack, args::Union{Dimension,DimTuple,Pair}...; kw...) =

--- a/src/set.jl
+++ b/src/set.jl
@@ -20,6 +20,9 @@ of a [`Lookup`](@ref) to `set` - there is no ambiguity.
 To set fields of a `Lookup` you need to specify the dimension. This can be done
 using `X => val` pairs, `X = val` keyword arguments, or `X(val)` wrapped arguments.
 
+You can also set the fields of all dimensions by simply passing a single [`Lookup`](@ref)
+or lookup trait - it will be set for all dimensions.
+
 When a `Dimension` or `Lookup` is passed to `set` to replace the
 existing ones, fields that are not set will keep their original values.
 
@@ -115,7 +118,8 @@ julia> set(da, :custom => DD.Irregular(10, 12), Z => DD.Regular(9.9))
 """
 function set end
 # Types are constructed
-Base.@assume_effects :effect_free set(x::DimArrayOrStack, ::Type{T}) where T = set(x, T())
+Base.@assume_effects :effect_free set(x, ::Type{T}) where T = set(x, T())
+
 # Dimensions and pairs are set for dimensions 
 Base.@assume_effects :effect_free set(A::DimArrayOrStack, args::Union{Dimension,DimTuple,Pair}...; kw...) =
     rebuild(A, data(A), set(dims(A), args...; kw...))

--- a/src/set.jl
+++ b/src/set.jl
@@ -114,19 +114,26 @@ julia> set(da, :custom => DD.Irregular(10, 12), Z => DD.Regular(9.9))
 ```
 """
 function set end
-set(A::DimArrayOrStack, x::T) where {T<:Union{Lookup,LookupTrait}} = _onlydimerror(x)
-set(x::DimArrayOrStack, ::Type{T}) where T = set(x, T())
-
-set(A::AbstractDimStack, x::Lookup) = Lookups._cantseterror(A, x)
-set(A::AbstractDimArray, x::Lookup) = Lookups._cantseterror(A, x)
-set(A, x) = Lookups._cantseterror(A, x)
-set(A::DimArrayOrStack, args::Union{Dimension,DimTuple,Pair}...; kw...) =
+# Types are constructed
+Base.@assume_effects :effect_free set(x::DimArrayOrStack, ::Type{T}) where T = set(x, T())
+# Dimensions and pairs are set for dimensions 
+Base.@assume_effects :effect_free set(A::DimArrayOrStack, args::Union{Dimension,DimTuple,Pair}...; kw...) =
     rebuild(A, data(A), set(dims(A), args...; kw...))
-set(A::AbstractDimArray, newdata::AbstractArray) = begin
+# Single traits are set for all dimensions
+Base.@assume_effects :effect_free set(A::DimArrayOrStack, x::LookupTrait) = 
+    set(A, map(d -> basedims(d) => x, dims(A))...)
+# Single lookups are set for all dimensions
+Base.@assume_effects :effect_free set(A::AbstractDimArray, x::Lookup) = 
+    set(A, map(d -> basedims(d) => x, dims(A))...)
+Base.@assume_effects :effect_free set(A::AbstractDimStack, x::Lookup) = 
+    set(A, map(d -> basedims(d) => x, dims(A))...)
+# Arrays are set as data for AbstractDimArray
+Base.@assume_effects :effect_free set(A::AbstractDimArray, newdata::AbstractArray) = begin
     axes(A) == axes(newdata) || _axiserr(A, newdata)
     rebuild(A; data=newdata)
 end
-set(s::AbstractDimStack, newdata::NamedTuple) = begin
+# NamedTuples are set as data for AbstractDimStack
+Base.@assume_effects :effect_free set(s::AbstractDimStack, newdata::NamedTuple) = begin
     dat = data(s)
     keys(dat) === keys(newdata) || _keyerr(keys(dat), keys(newdata))
     map(dat, newdata) do d, nd
@@ -134,7 +141,8 @@ set(s::AbstractDimStack, newdata::NamedTuple) = begin
     end
     rebuild(s; data=newdata)
 end
+# Other things error
+Base.@assume_effects :effect_free set(A, x) = Lookups._cantseterror(A, x)
 
-@noinline _onlydimerror(x) = throw(ArgumentError("Can only set $(typeof(x)) for a dimension. Specify which dimension you mean with `X => property`"))
 @noinline _axiserr(a, b) = throw(ArgumentError("passed in axes $(axes(b)) do not match the currect axes $(axes(a))"))
 @noinline _keyerr(ka, kb) = throw(ArgumentError("keys $ka and $kb do not match"))

--- a/test/set.jl
+++ b/test/set.jl
@@ -40,7 +40,7 @@ end
     @test index(set(s, Dim{:row}([:x, :y, :z])), :row) == [:x, :y, :z] 
 end
 
-@testset "DimArray dim Dimension" begin
+@testset "DimArray Dimension" begin
     @test typeof(dims(set(da, X=:a, Y=:b))) <: Tuple{<:Dim{:a},<:Dim{:b}}
     @test typeof(dims(set(da2, Dim{:row}(Y()), Dim{:column}(X())))) <: Tuple{<:Y,<:X}
     @test typeof(dims(set(da, X => Ti(), Y => Z()))) <: Tuple{<:Ti,<:Z}
@@ -60,6 +60,11 @@ end
 end
 
 @testset "dim lookup" begin
+    @test lookup(set(da2, NoLookup())) == 
+         (NoLookup(Base.OneTo(3)), NoLookup(Base.OneTo(4)))
+    @test lookup(set(da2, Categorical)) == 
+        (Categorical(10.0:10.0:30.0, ForwardOrdered(), NoMetadata()), 
+         Categorical(-2.0:1.0:1.0, ForwardOrdered(), NoMetadata())) 
     @test lookup(set(da2, :column => NoLookup(), :row => Sampled(sampling=Intervals(Center())))) == 
         (Sampled(10.0:10.0:30.0, ForwardOrdered(), Regular(10.0), Intervals(Center()), NoMetadata()), NoLookup(Base.OneTo(4)))
     @test lookup(set(da2, column=NoLookup())) == 


### PR DESCRIPTION
Allow setting all dimensions of an object at once, like `set(A, NoLookup)`

Also some minor fixes to `Span` set being broken