### PR TITLE
Breaking: add iterate and collect

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -75,9 +75,11 @@ export dims, refdims, metadata, name, lookup, bounds, val, layers
 export dimnum, hasdim, hasselection, otherdims
 
 # utils
-export set, rebuild, reorder, modify, broadcast_dims, broadcast_dims!, mergedims, unmergedims
+export set, rebuild, reorder, modify, broadcast_dims, broadcast_dims!,
+    mergedims, unmergedims, maplayers
 
 export groupby, seasons, months, hours, intervals, ranges
+
 
 export @d
 

--- a/src/stack/indexing.jl
+++ b/src/stack/indexing.jl
@@ -42,7 +42,7 @@ end
 @propagate_inbounds function Base.getindex(s::AbstractDimStack{<:Any,<:Any,N}, i::Integer) where N
     if N == 1 && hassamedims(s)
         # This is a few ns faster when possible
-        map(l -> l[i], s)
+        map(l -> l[i], data(s))
     else
         # Otherwise use dimensional indexing
         s[DimIndices(s)[i]]
@@ -117,7 +117,7 @@ for f in (:getindex, :view, :dotview)
         end
         # Handle zero-argument getindex, this will error unless all layers are zero dimensional
         @propagate_inbounds function $_dim_f(s::AbstractDimStack)
-            map(Base.$f, s)
+            map(Base.$f, data(s))
         end
         Base.@assume_effects :foldable @propagate_inbounds function $_dim_f(s::AbstractDimStack{K}, d1::Dimension, ds::Dimension...) where K
             D = (d1, ds...)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -53,7 +53,7 @@ end
 @assume_effects :foldable DD.layers(s::AbstractDimStack, k::Symbol) = s[k]
 
 @assume_effects :foldable data_eltype(nt::NamedTuple{K}) where K = NamedTuple{K,Tuple{map(eltype, Tuple(nt))...}}
-stacktype(s, data, dims, layerdims::NamedTuple{K}) where K = basetypeof(s){K,data_eltype(data),length(dims)}
+stacktype(s, data, dims, layerdims::NamedTuple{K}) where K = basetypeof(s){K,data_eltype(data),length(dims)} 
 
 const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 
@@ -179,9 +179,9 @@ Base.vec(st::AbstractDimStack) = vec(collect(st))
 # One of the first three arguments must be an AbstractDimStack for dispatch to work.
 Base.merge(s::AbstractDimStack) = s
 function Base.merge(
-    x1::AbstractDimStack,
-    x2::Union{AbstractDimStack,NamedTuple},
-    xs::Union{AbstractDimStack,NamedTuple}...;
+    x1::AbstractDimStack, 
+    x2::Union{AbstractDimStack,NamedTuple}, 
+    xs::Union{AbstractDimStack,NamedTuple}...; 
     kw...
 )
     rebuild_from_arrays(x1, merge(map(layers, (x1, x2, xs...))...); kw...)
@@ -190,13 +190,13 @@ function Base.merge(s::AbstractDimStack, pairs; kw...)
     rebuild_from_arrays(s, merge(layers(s), pairs); refdims=())
 end
 function Base.merge(
-    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...;
+    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...; 
 )
     merge(map(layers, (x1, x2, xs...))...)
 end
 function Base.merge(
-    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack,
-    xs::Union{AbstractDimStack,NamedTuple}...;
+    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack, 
+    xs::Union{AbstractDimStack,NamedTuple}...; 
     kw...
 )
     merge(map(layers, (x1, x2, x3, xs...))...)
@@ -378,7 +378,7 @@ struct DimStack{K,T,N,L,D<:Tuple,R<:Tuple,LD<:NamedTuple{K},M,LM<:Union{Nothing,
         data, dims, refdims, layerdims::LD, metadata, layermetadata
     ) where LD<:NamedTuple{K} where K
         T = data_eltype(data)
-        N = length(dims)
+        N = length(dims)        
         DimStack{K,T,N}(data, dims, refdims, layerdims, metadata, layermetadata)
     end
     function DimStack{K,T,N}(

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -29,8 +29,8 @@ abstract type AbstractDimStack{K,T,N,L} end
 const AbstractVectorDimStack = AbstractDimStack{K,T,1} where {K,T}
 const AbstractMatrixDimStack = AbstractDimStack{K,T,2} where {K,T}
 
-DimArray(st::AbstractDimStack) =
-    DimArray([st[D] for D in DimIndices(st)]; dims=dims(st), metadata=metadata(st))
+(::Type{T})(st::AbstractDimStack) where T<:AbstractDimArray =
+    T([st[D] for D in DimIndices(st)]; dims=dims(st), metadata=metadata(st))
 
 data(s::AbstractDimStack) = getfield(s, :data)
 dims(s::AbstractDimStack) = getfield(s, :dims)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -29,6 +29,9 @@ abstract type AbstractDimStack{K,T,N,L} end
 const AbstractVectorDimStack = AbstractDimStack{K,T,1} where {K,T}
 const AbstractMatrixDimStack = AbstractDimStack{K,T,2} where {K,T}
 
+DimArray(st::AbstractDimStack) =
+    DimArray([st[D] for D in DimIndices(st)]; dims=dims(st), metadata=metadata(st))
+
 data(s::AbstractDimStack) = getfield(s, :data)
 dims(s::AbstractDimStack) = getfield(s, :dims)
 name(s::AbstractDimStack) = keys(s)
@@ -50,7 +53,7 @@ end
 @assume_effects :foldable DD.layers(s::AbstractDimStack, k::Symbol) = s[k]
 
 @assume_effects :foldable data_eltype(nt::NamedTuple{K}) where K = NamedTuple{K,Tuple{map(eltype, Tuple(nt))...}}
-stacktype(s, data, dims, layerdims::NamedTuple{K}) where K = basetypeof(s){K,data_eltype(data),length(dims)} 
+stacktype(s, data, dims, layerdims::NamedTuple{K}) where K = basetypeof(s){K,data_eltype(data),length(dims)}
 
 const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 
@@ -141,6 +144,7 @@ Base.eltype(::AbstractDimStack{<:Any,T}) where T = T
 Base.ndims(::AbstractDimStack{<:Any,<:Any,N}) where N = N
 Base.CartesianIndices(s::AbstractDimStack) = CartesianIndices(dims(s))
 Base.LinearIndices(s::AbstractDimStack) = LinearIndices(CartesianIndices(map(l -> axes(l, 1), lookup(s))))
+Base.IteratorSize(::AbstractDimStack{<:Any,<:Any,N}) where N = Base.HasShape{N}()
 function Base.eachindex(s::AbstractDimStack)
     li = LinearIndices(s)
     first(li):last(li)
@@ -161,20 +165,23 @@ Base.checkbounds(T::Type, s::AbstractDimStack, I...) = checkbounds(T, CartesianI
 
 @inline Base.keys(s::AbstractDimStack{K}) where K = K
 @inline Base.propertynames(s::AbstractDimStack{K}) where K = K
-Base.setindex(s::AbstractDimStack, val::AbstractBasicDimArray, name) =
+@inline Base.setindex(s::AbstractDimStack, val::AbstractBasicDimArray, name::Symbol) =
     rebuild_from_arrays(s, Base.setindex(layers(s), val, name))
 Base.NamedTuple(s::AbstractDimStack) = NamedTuple(layers(s))
-
-# Remove these, but explain
-Base.iterate(::AbstractDimStack, args...) = error("Use iterate(layers(s)) rather than `iterate(s)`") #iterate(layers(s), args...)
+Base.collect(st::AbstractDimStack) = parent([st[D] for D in DimIndices(st)])
+Base.Array(st::AbstractDimStack) = collect(st)
+Base.vec(st::AbstractDimStack) = vec(collect(st))
+@propagate_inbounds Base.iterate(st::AbstractDimStack) = iterate(st, 1)
+@propagate_inbounds Base.iterate(st::AbstractDimStack, i) = 
+    i > length(st) ? nothing : (st[DimIndices(st)[i]], i + 1)
 
 # `merge` for AbstractDimStack and NamedTuple.
 # One of the first three arguments must be an AbstractDimStack for dispatch to work.
 Base.merge(s::AbstractDimStack) = s
 function Base.merge(
-    x1::AbstractDimStack, 
-    x2::Union{AbstractDimStack,NamedTuple}, 
-    xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::AbstractDimStack,
+    x2::Union{AbstractDimStack,NamedTuple},
+    xs::Union{AbstractDimStack,NamedTuple}...;
     kw...
 )
     rebuild_from_arrays(x1, merge(map(layers, (x1, x2, xs...))...); kw...)
@@ -183,20 +190,24 @@ function Base.merge(s::AbstractDimStack, pairs; kw...)
     rebuild_from_arrays(s, merge(layers(s), pairs); refdims=())
 end
 function Base.merge(
-    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...;
 )
     merge(map(layers, (x1, x2, xs...))...)
 end
 function Base.merge(
-    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack, 
-    xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack,
+    xs::Union{AbstractDimStack,NamedTuple}...;
     kw...
 )
     merge(map(layers, (x1, x2, x3, xs...))...)
 end
 
-Base.map(f, s::AbstractDimStack) = _maybestack(s,map(f, values(s)))
-function Base.map(
+Base.map(f, s::AbstractDimStack) = error("Use maplayers(f, stack)) instad of map(f, stack)")
+Base.map(f, ::Union{AbstractDimStack,NamedTuple}, xs::Union{AbstractDimStack,NamedTuple}...) =
+    error("Use maplayers(f, stack)) instad of map(f, stack)")
+
+maplayers(f, s::AbstractDimStack) = _maybestack(s, map(f, values(s)))
+function maplayers(
     f, x1::Union{AbstractDimStack,NamedTuple}, xs::Union{AbstractDimStack,NamedTuple}...
 )
     stacks = (x1, xs...)
@@ -367,7 +378,7 @@ struct DimStack{K,T,N,L,D<:Tuple,R<:Tuple,LD<:NamedTuple{K},M,LM<:Union{Nothing,
         data, dims, refdims, layerdims::LD, metadata, layermetadata
     ) where LD<:NamedTuple{K} where K
         T = data_eltype(data)
-        N = length(dims)        
+        N = length(dims)
         DimStack{K,T,N}(data, dims, refdims, layerdims, metadata, layermetadata)
     end
     function DimStack{K,T,N}(

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -204,7 +204,7 @@ end
 
 Base.map(f, s::AbstractDimStack) = error("Use maplayers(f, stack)) instad of map(f, stack)")
 Base.map(f, ::Union{AbstractDimStack,NamedTuple}, xs::Union{AbstractDimStack,NamedTuple}...) =
-    error("Use maplayers(f, stack)) instad of map(f, stack)")
+    error("Use maplayers(f, stack, args...)) instad of map(f, stack, args...)")
 
 maplayers(f, s::AbstractDimStack) = _maybestack(s, map(f, values(s)))
 function maplayers(

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -52,8 +52,10 @@ end
 @assume_effects :foldable DD.layers(s::AbstractDimStack{K}, i::Integer) where K = s[K[i]]
 @assume_effects :foldable DD.layers(s::AbstractDimStack, k::Symbol) = s[k]
 
-@assume_effects :foldable data_eltype(nt::NamedTuple{K}) where K = NamedTuple{K,Tuple{map(eltype, Tuple(nt))...}}
-stacktype(s, data, dims, layerdims::NamedTuple{K}) where K = basetypeof(s){K,data_eltype(data),length(dims)} 
+@assume_effects :foldable data_eltype(nt::NamedTuple{K}) where K =
+    NamedTuple{K,Tuple{map(eltype, Tuple(nt))...}}
+stacktype(s, data, dims, layerdims::NamedTuple{K}) where K =
+    basetypeof(s){K,data_eltype(data),length(dims)}
 
 const DimArrayOrStack = Union{AbstractDimArray,AbstractDimStack}
 
@@ -65,18 +67,25 @@ function rebuild(
     s::AbstractDimStack, data, dims=dims(s), refdims=refdims(s),
     layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
 )
-    stacktype(s, data, dims, layerdims)(data, dims, refdims, layerdims, metadata, layermetadata)
+    T = stacktype(s, data, dims, layerdims)
+    return T(data, dims, refdims, layerdims, metadata, layermetadata)
 end
-function rebuild(s::AbstractDimStack; data=data(s), dims=dims(s), refdims=refdims(s),
-    layerdims=layerdims(s), metadata=metadata(s), layermetadata=layermetadata(s)
+function rebuild(s::AbstractDimStack; 
+    data=data(s),
+    dims=dims(s),
+    refdims=refdims(s),
+    layerdims=layerdims(s),
+    metadata=metadata(s),
+    layermetadata=layermetadata(s)
 )
-    stacktype(s, data, dims, layerdims)(data, dims, refdims, layerdims, metadata, layermetadata)
+    T = stacktype(s, data, dims, layerdims)
+    return T(data, dims, refdims, layerdims, metadata, layermetadata)
 end
 
 function rebuildsliced(f::Function, s::AbstractDimStack, layers, I)
     layerdims = map(basedims, layers)
     dims, refdims = slicedims(f, s, I)
-    rebuild(s; data=map(parent, layers), dims=dims, refdims=refdims, layerdims=layerdims)
+    return rebuild(s; data=map(parent, layers), dims, refdims, layerdims)
 end
 
 """
@@ -129,7 +138,7 @@ Base.parent(s::AbstractDimStack) = data(s)
 # Only compare data and dim - metadata and refdims can be different
 Base.:(==)(s1::AbstractDimStack, s2::AbstractDimStack) =
     data(s1) == data(s2) && dims(s1) == dims(s2) && layerdims(s1) == layerdims(s2)
-Base.read(s::AbstractDimStack) = map(read, s)
+Base.read(s::AbstractDimStack) = maplayers(read, s)
 
 # Array-like
 Base.size(s::AbstractDimStack) = map(length, dims(s))
@@ -139,11 +148,12 @@ Base.length(s::AbstractDimStack) = prod(size(s))
 Base.axes(s::AbstractDimStack) = map(first ∘ axes, dims(s))
 Base.axes(s::AbstractDimStack, dims::DimOrDimType) = axes(s, dimnum(s, dims))
 Base.axes(s::AbstractDimStack, dims::Integer) = axes(s)[dims]
-Base.similar(s::AbstractDimStack, args...) = map(A -> similar(A, args...), s)
+Base.similar(s::AbstractDimStack, args...) = maplayers(A -> similar(A, args...), s)
 Base.eltype(::AbstractDimStack{<:Any,T}) where T = T
 Base.ndims(::AbstractDimStack{<:Any,<:Any,N}) where N = N
 Base.CartesianIndices(s::AbstractDimStack) = CartesianIndices(dims(s))
-Base.LinearIndices(s::AbstractDimStack) = LinearIndices(CartesianIndices(map(l -> axes(l, 1), lookup(s))))
+Base.LinearIndices(s::AbstractDimStack) = 
+    LinearIndices(CartesianIndices(map(l -> axes(l, 1), lookup(s))))
 Base.IteratorSize(::AbstractDimStack{<:Any,<:Any,N}) where N = Base.HasShape{N}()
 function Base.eachindex(s::AbstractDimStack)
     li = LinearIndices(s)
@@ -172,16 +182,16 @@ Base.collect(st::AbstractDimStack) = parent([st[D] for D in DimIndices(st)])
 Base.Array(st::AbstractDimStack) = collect(st)
 Base.vec(st::AbstractDimStack) = vec(collect(st))
 @propagate_inbounds Base.iterate(st::AbstractDimStack) = iterate(st, 1)
-@propagate_inbounds Base.iterate(st::AbstractDimStack, i) = 
+@propagate_inbounds Base.iterate(st::AbstractDimStack, i) =
     i > length(st) ? nothing : (st[DimIndices(st)[i]], i + 1)
 
 # `merge` for AbstractDimStack and NamedTuple.
 # One of the first three arguments must be an AbstractDimStack for dispatch to work.
 Base.merge(s::AbstractDimStack) = s
 function Base.merge(
-    x1::AbstractDimStack, 
-    x2::Union{AbstractDimStack,NamedTuple}, 
-    xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::AbstractDimStack,
+    x2::Union{AbstractDimStack,NamedTuple},
+    xs::Union{AbstractDimStack,NamedTuple}...;
     kw...
 )
     rebuild_from_arrays(x1, merge(map(layers, (x1, x2, xs...))...); kw...)
@@ -190,13 +200,13 @@ function Base.merge(s::AbstractDimStack, pairs; kw...)
     rebuild_from_arrays(s, merge(layers(s), pairs); refdims=())
 end
 function Base.merge(
-    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::NamedTuple, x2::AbstractDimStack, xs::Union{AbstractDimStack,NamedTuple}...;
 )
     merge(map(layers, (x1, x2, xs...))...)
 end
 function Base.merge(
-    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack, 
-    xs::Union{AbstractDimStack,NamedTuple}...; 
+    x1::NamedTuple, x2::NamedTuple, x3::AbstractDimStack,
+    xs::Union{AbstractDimStack,NamedTuple}...;
     kw...
 )
     merge(map(layers, (x1, x2, x3, xs...))...)
@@ -224,7 +234,7 @@ ConstructionBase.getproperties(s::AbstractDimStack) = layers(s)
 ConstructionBase.setproperties(s::AbstractDimStack, patch::NamedTuple) =
     ConstructionBase.constructorof(typeof(s))(ConstructionBase.setproperties(layers(s), patch))
 
-Adapt.adapt_structure(to, s::AbstractDimStack) = map(A -> Adapt.adapt(to, A), s)
+Adapt.adapt_structure(to, s::AbstractDimStack) = maplayers(A -> Adapt.adapt(to, A), s)
 
 function mergedims(st::AbstractDimStack, dim_pairs::Pair...)
     dim_pairs = map(dim_pairs) do (as, b)
@@ -378,7 +388,7 @@ struct DimStack{K,T,N,L,D<:Tuple,R<:Tuple,LD<:NamedTuple{K},M,LM<:Union{Nothing,
         data, dims, refdims, layerdims::LD, metadata, layermetadata
     ) where LD<:NamedTuple{K} where K
         T = data_eltype(data)
-        N = length(dims)        
+        N = length(dims)
         DimStack{K,T,N}(data, dims, refdims, layerdims, metadata, layermetadata)
     end
     function DimStack{K,T,N}(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,10 +85,10 @@ modify(CuArray, A)
 This also works for all the data layers in a `DimStack`.
 """
 function modify end
-modify(f, s::AbstractDimStack) = map(a -> modify(f, a), s)
+modify(f, s::AbstractDimStack) = maplayers(a -> modify(f, a), s)
 # Stack optimisation to avoid compilation to build all the `AbstractDimArray` 
 # layers, and instead just modify the parent data directly.
-modify(f, s::AbstractDimStack{<:NamedTuple}) = 
+modify(f, s::AbstractDimStack{<:Any,<:NamedTuple}) = 
     rebuild(s; data=map(a -> modify(f, a), parent(s)))
 function modify(f, A::AbstractDimArray)
     newdata = f(parent(A))

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -87,7 +87,7 @@ end
 end
 
 @testset "similar" begin
-    @test all(map(similar(mixed), mixed) do s, m
+    @test all(maplayers(similar(mixed), mixed) do s, m
         dims(s) == dims(m) && dims(s) === dims(m) && eltype(s) === eltype(m)
     end)
     @test eltype(similar(s, Int)) === @NamedTuple{one::Int, two::Int, three::Int}
@@ -221,14 +221,15 @@ end
     end
 end
 
-@testset "map" begin
-    @test values(map(a -> a .* 2, s))[1] == values(DimStack(2da1, 2da2, 2da3))[1]
-    @test dims(map(a -> a .* 2, s)) == dims(DimStack(2da1, 2da2, 2da3))
-    @test map(a -> a[1], s) == (one=1.0, two=2.0, three=3.0)
-    @test values(map(a -> a .* 2, s)) == values(DimStack(2da1, 2da2, 2da3))
-    @test map(+, s, s, s) == map(a -> a .* 3, s)
-    @test_throws ArgumentError map(+, s, mixed)
-    @test map((s, a) -> s => a[1], (one="one", two="two", three="three"), s) == (one="one" => 1.0, two="two" => 2.0, three="three" => 3.0)
+@testset "maplayers" begin
+    @test values(maplayers(a -> a .* 2, s))[1] == values(DimStack(2da1, 2da2, 2da3))[1]
+    @test dims(maplayers(a -> a .* 2, s)) == dims(DimStack(2da1, 2da2, 2da3))
+    @test maplayers(a -> a[1], s) == (one=1.0, two=2.0, three=3.0)
+    @test values(maplayers(a -> a .* 2, s)) == values(DimStack(2da1, 2da2, 2da3))
+    @test maplayers(+, s, s, s) == maplayers(a -> a .* 3, s)
+    @test_throws ArgumentError maplayers(+, s, mixed)
+    @test maplayers((s, a) -> s => a[1], (one="one", two="two", three="three"), s) == 
+        (one="one" => 1.0, two="two" => 2.0, three="three" => 3.0)
 end
 
 @testset "methods with no arguments" begin


### PR DESCRIPTION
@asinghvi17 this should do what you want

Closes  #810

```julia
using DimensionalData
A = [1.0 2.0 3.0;
     4.0 5.0 6.0]
x, y, z = X([:a, :b]), Y(10.0:10.0:30.0; metadata=Dict()), Z()
dimz = x, y
da1 = DimArray(A, (x, y); name=:one, metadata=Metadata())
da2 = DimArray(Float32.(2A), (x, y); name=:two)
da3 = DimArray(Int.(3A), (x, y); name=:three)
da4 = DimArray(cat(4A, 5A, 6A, 7A; dims=3), (x, y, z); name=:extradim)

s = DimStack((da1, da2, da3))
mixed = DimStack(da1, da2, da4)
``` 

```julia
julia> [x for x in mixed]
╭──────────────────────────────────────────────────────────────────────────────╮
│ 2×3×4 DimArray{@NamedTuple{one::Float64, two::Float32, extradim::Float64},3} │
├──────────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────── dims ┐
  ↓ X Categorical{Symbol} [:a, :b] ForwardOrdered,
  → Y Sampled{Float64} 10.0:10.0:30.0 ForwardOrdered Regular Points,
  ↗ Z
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
[:, :, 1]
 ↓ →  10.0                                       20.0                                        30.0
  :a    (one = 1.0, two = 2.0, extradim = 4.0)     (one = 2.0, two = 4.0, extradim = 8.0)      (one = 3.0, two = 6.0, extradim = 12.0)
  :b    (one = 4.0, two = 8.0, extradim = 16.0)    (one = 5.0, two = 10.0, extradim = 20.0)    (one = 6.0, two = 12.0, extradim = 24.0)

julia> collect(mixed)
2×3×4 Array{@NamedTuple{one::Float64, two::Float32, extradim::Float64}, 3}:
[:, :, 1] =
 (one = 1.0, two = 2.0, extradim = 4.0)   (one = 2.0, two = 4.0, extradim = 8.0)    (one = 3.0, two = 6.0, extradim = 12.0)
 (one = 4.0, two = 8.0, extradim = 16.0)  (one = 5.0, two = 10.0, extradim = 20.0)  (one = 6.0, two = 12.0, extradim = 24.0)

[:, :, 2] =
 (one = 1.0, two = 2.0, extradim = 5.0)   (one = 2.0, two = 4.0, extradim = 10.0)   (one = 3.0, two = 6.0, extradim = 15.0)
 (one = 4.0, two = 8.0, extradim = 20.0)  (one = 5.0, two = 10.0, extradim = 25.0)  (one = 6.0, two = 12.0, extradim = 30.0)

[:, :, 3] =
 (one = 1.0, two = 2.0, extradim = 6.0)   (one = 2.0, two = 4.0, extradim = 12.0)   (one = 3.0, two = 6.0, extradim = 18.0)
 (one = 4.0, two = 8.0, extradim = 24.0)  (one = 5.0, two = 10.0, extradim = 30.0)  (one = 6.0, two = 12.0, extradim = 36.0)

[:, :, 4] =
 (one = 1.0, two = 2.0, extradim = 7.0)   (one = 2.0, two = 4.0, extradim = 14.0)   (one = 3.0, two = 6.0, extradim = 21.0)
 (one = 4.0, two = 8.0, extradim = 28.0)  (one = 5.0, two = 10.0, extradim = 35.0)  (one = 6.0, two = 12.0, extradim = 42.0)

julia> vec(mixed) # row table!
24-element Vector{@NamedTuple{one::Float64, two::Float32, extradim::Float64}}:
 (one = 1.0, two = 2.0, extradim = 4.0)
 (one = 4.0, two = 8.0, extradim = 16.0)
 (one = 2.0, two = 4.0, extradim = 8.0)
 (one = 5.0, two = 10.0, extradim = 20.0)
 (one = 3.0, two = 6.0, extradim = 12.0)
 (one = 6.0, two = 12.0, extradim = 24.0)
 (one = 1.0, two = 2.0, extradim = 5.0)
 (one = 4.0, two = 8.0, extradim = 20.0)
 (one = 2.0, two = 4.0, extradim = 10.0)
 (one = 5.0, two = 10.0, extradim = 25.0)
 (one = 3.0, two = 6.0, extradim = 15.0)
 ⋮
 (one = 4.0, two = 8.0, extradim = 24.0)
 (one = 2.0, two = 4.0, extradim = 12.0)
 (one = 5.0, two = 10.0, extradim = 30.0)
 (one = 3.0, two = 6.0, extradim = 18.0)
 (one = 6.0, two = 12.0, extradim = 36.0)
 (one = 1.0, two = 2.0, extradim = 7.0)
 (one = 4.0, two = 8.0, extradim = 28.0)
 (one = 2.0, two = 4.0, extradim = 14.0)
 (one = 5.0, two = 10.0, extradim = 35.0)
 (one = 3.0, two = 6.0, extradim = 21.0)
 (one = 6.0, two = 12.0, extradim = 42.0)
``` 