### PR TITLE
Maybe Breaking (?): add missing IteratorSize method for dimensions

### DIFF
--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -286,6 +286,7 @@ Base.first(d::Dimension) = val(d)
 Base.first(d::Dimension{<:AbstractArray}) = first(lookup(d))
 Base.last(d::Dimension) = val(d)
 Base.last(d::Dimension{<:AbstractArray}) = last(lookup(d))
+Base.IteratorSize(d::Dimension{<:AbstractArray}) = Base.IteratorSize(parent(d))
 Base.firstindex(d::Dimension) = 1
 Base.lastindex(d::Dimension) = 1
 Base.firstindex(d::Dimension{<:AbstractArray}) = firstindex(lookup(d))

--- a/test/array.jl
+++ b/test/array.jl
@@ -456,6 +456,11 @@ end
     @test_throws ArgumentError fill(5.0, (X(:e), Y(8)))
 end
 
+
+@testset "generator constructor" begin
+    [(x, y) for x in X(10:10:50), y in Y(0.0:0.1:1.0)]
+end
+
 @testset "ones, zeros, trues, falses constructors" begin
     da = @inferred zeros(X(4), Y(40.0:10.0:80.0; order=ForwardOrdered()); metadata=(a=1, b=2))
     @test eltype(da) <: Float64


### PR DESCRIPTION
Tiny fix so that comprehensions over dimensions return a DimArray. @kapple19 I think this might be even nicer than what you were looking for.

```julia
julia> [(x, y) for x in X(1:5), y in Y(1:3)]
╭─────────────────────────────────────╮
│ 5×3 DimArray{Tuple{Int64, Int64},2} │
├─────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────── dims ┐
  ↓ X Sampled{Int64} 1:5 ForwardOrdered Regular Points,
  → Y Sampled{Int64} 1:3 ForwardOrdered Regular Points
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ↓ →  1        2        3
 1     (1, 1)   (1, 2)   (1, 3)
 2     (2, 1)   (2, 2)   (2, 3)
 3     (3, 1)   (3, 2)   (3, 3)
 4     (4, 1)   (4, 2)   (4, 3)
 5     (5, 1)   (5, 2)   (5, 3)
```
~~Needs a test.~~ See #820 