### PR TITLE
AlgebraOfGraphics documentation

### DIFF
--- a/docs/Project-v1.11.toml
+++ b/docs/Project-v1.11.toml
@@ -1,0 +1,25 @@
+[deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
+Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+Interfaces = "85a1e053-f937-4924-92a5-1367d23b7b87"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[sources]
+DimensionalData = {path = ".."}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/docs/src/plots.md
+++ b/docs/src/plots.md
@@ -56,3 +56,157 @@ Makie.series(A; color=[:red, :blue, :orange], markersize=15)
 ```
 
 A lot more is planned for Makie.jl plots in future!
+
+# AlgebraOfGraphics.jl
+
+`AlgebraOfGraphics` is a grammar-of-graphics front end for `Makie`.
+
+## `DimArray`: Some noisy sinuisoidal data...
+
+```@example AoG_DimArrays_1D
+using DimensionalData
+using CairoMakie, AlgebraOfGraphics
+
+sin2pi(t) = sinpi(2t)
+c = 1.0
+
+signal_components = rebuild(
+    [
+        sin2pi(c*t/λ + φ) + 0.5rand()
+        for t in Ti(0 : 0.01 : 5),
+            λ in Dim{:λ}(1:3),
+            φ in Dim{:φ}(0 : 0.1 : 0.5)
+    ];
+    name = :A
+)
+
+data_layer = data(signal_components)
+mapping_1d = mapping(:Ti => "Time (seconds)", :A => "Amplitude")
+layers_1d = data_layer * mapping_1d
+liner = visual(Lines, linestyle = :dot, alpha = 0.5)
+line_vis = layers_1d * liner
+```
+
+### ...colored by wavelength and gridded by phase
+
+```@example AoG_DimArrays_1D
+wavelength = :λ => (λ -> "$λ m") => "Wavelength"
+gridding = mapping(color = wavelength, layout = :φ => nonnumeric)
+line_vis * gridding |> draw
+```
+
+### ...smoothed
+
+```@example AoG_DimArrays_1D
+layer_1d_for_smoothing = layers_1d * gridding
+smoother = AlgebraOfGraphics.smooth(span = 0.2)
+layer_1d_for_smoothing * smoother |> draw
+```
+
+### ...smoothing compared with data
+
+```@example AoG_DimArrays_1D
+layer_1d_for_smoothing * (smoother + liner) |> draw
+```
+
+### ...for only some wavelengths and phases
+
+(Does not work yet.)
+
+```@example AoG_DimArrays_1D
+vis = data_layer
+vis *= mapping_1d
+# vis *= mapping(color = Dim{:λ}) # not subsetting, but demo prospective semantics
+# vis *= mapping(color = Dim{:λ}(1:2))
+# vis *= mapping(color = Dim{:λ}(1:2) => nonnumeric)
+vis *= mapping(color = wavelength) # subsetting doesn't work yet
+# vis *= mapping(layout = Dim{:φ}) # not subsetting, but demo prospective semantics
+# vis *= mapping(layout = Dim{:φ}(0.0 : 0.1 : 0.3))
+# vis *= mapping(layout = Dim{:φ}(0.0 : 0.1 : 0.3) => nonnumeric)
+vis *= mapping(layout = :φ => nonnumeric) # subsetting doesn't work yet
+vis *= (smoother + liner)
+draw(vis)
+```
+
+## `DimStack`: A complex function's...
+
+```@example AoG_DimArrays_2D
+using DimensionalData
+using CairoMakie, AlgebraOfGraphics
+
+f(z::Complex) = ((im*z)^17 - 1) / (im*z - 1)
+f(x::Real, y::Real) = f(x + im*y)
+
+cartesian_data = [
+    f(x, y)
+    for x in X(2range(-1, 1, 301)),
+        y in Y(2range(-1, 1, 301))
+]
+
+polar_data = DimStack((
+    A_log = cartesian_data .|> abs .|> log10,
+    φ = cartesian_data .|> angle .|> rad2deg,
+    u = cartesian_data .|> real,
+    v = cartesian_data .|> imag
+))
+
+data_layer = data(polar_data)
+domain_mapping = data_layer * mapping(:X, :Y)
+```
+
+### ...analytic landscape
+
+```@example AoG_DimArrays_2D
+# Alabel = rich("A", subscript("log")) # doesn't work
+Alabel = "A_log"
+analytic_landscape = mapping(:A_log => Alabel) * visual(Surface, colormap = :jet)
+domain_mapping * analytic_landscape |> draw(axis = (; type = Axis3))
+```
+
+### ...phase portrait
+
+```@example AoG_DimArrays_2D
+phase_portrait = mapping(:φ) * visual(Heatmap)
+# phase_portrait *= visual(colormap = :phase) # doesn't parse the colormap
+domain_mapping * phase_portrait |> draw
+```
+
+### ...modulus contours
+
+```@example AoG_DimArrays_2D
+modulus_contours = mapping(:A_log) * visual(Contour, colormap = :grays)
+# modulus_contours *= visual(nan_color = :white) # doesn't work for complex functions with zero modulus, i.e. A_log = log10(0)
+domain_mapping * modulus_contours |> draw
+```
+
+### ...phase contours
+
+```@example AoG_DimArrays_2D
+phase_contours = mapping(:φ) * visual(Contour, colormap = :grays)
+domain_mapping * phase_contours |> draw
+```
+
+### ...phase portrait with contours
+
+```@example AoG_DimArrays_2D
+enhanced_phase_portrait = phase_portrait + modulus_contours + phase_contours
+domain_mapping * enhanced_phase_portrait |> draw
+```
+
+### ...and some other silly examples
+
+```@example AoG_DimArrays_2D
+data_layer * mapping(:u, :v, color = :X) * visual(Scatter) |> draw
+```
+
+```@example AoG_DimArrays_2D
+data_layer * mapping(:u, :v, :X, color = :φ) * visual(Scatter) |> draw(
+    axis = (; type = Axis3)
+)
+```
+
+```@example AoG_DimArrays_2D
+data_layer * mapping(:X, :Y, :φ, color = :A_log) * visual(Scatter) |> draw(
+    axis = (; type = Axis3)
+)
+```

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -286,6 +286,7 @@ Base.first(d::Dimension) = val(d)
 Base.first(d::Dimension{<:AbstractArray}) = first(lookup(d))
 Base.last(d::Dimension) = val(d)
 Base.last(d::Dimension{<:AbstractArray}) = last(lookup(d))
+Base.IteratorSize(d::Dimension{<:AbstractArray}) = Base.IteratorSize(parent(d))
 Base.firstindex(d::Dimension) = 1
 Base.lastindex(d::Dimension) = 1
 Base.firstindex(d::Dimension{<:AbstractArray}) = firstindex(lookup(d))


### PR DESCRIPTION
I got carried away writing examples 😅 was quite fun.
Not considered polished yet.
I've left some lines commented out, noting anything not working.
Some things will have to follow up on AoG like colormap not passing.
Other things are scoped by DD like #823.

I wasn't sure if you'd want to publish examples in the docs asap which would mean changing my examples to work on the latest DimensionalData and AlgebraOfGraphics tags.
Let me know if so, and I can change my examples and remove the `docs/Project-v1.11.toml` file which helped me demonstrate your new method for enabling `Dim`s in array comprehensions.

Local docs build produces a lot of docs errors from other Markdown files... as far as I could see. The stack traces were overpopulating my REPL. Running my code blocks directly to the REPL works.