### PR TITLE
set lookups as Unordered after Vector{Int} indexing

### DIFF
--- a/src/Lookups/indexing.jl
+++ b/src/Lookups/indexing.jl
@@ -5,8 +5,11 @@ for f in (:getindex, :view, :dotview)
         @propagate_inbounds Base.$f(l::Lookup, i::Union{Int,CartesianIndex}) =
             Base.$f(parent(l), i)
         # AbstractArray, Colon and CartesianIndices: the lookup is rebuilt around a new parent
-        @propagate_inbounds Base.$f(l::Lookup, i::Union{AbstractArray,Colon}) = 
+        @propagate_inbounds Base.$f(l::Lookup, i::Union{AbstractVector,Colon}) = 
             rebuild(l; data=Base.$f(parent(l), i))
+        @propagate_inbounds function Base.$f(l::Union{Sampled,Categorical}, i::AbstractVector{Int})
+            rebuild(l; data=Base.$f(parent(l), i), order=Unordered())
+        end
         # Selector gets processed with `selectindices`
         @propagate_inbounds Base.$f(l::Lookup, i::SelectorOrInterval) = Base.$f(l, selectindices(l, i))
         @propagate_inbounds function Base.$f(l::Lookup, i)


### PR DESCRIPTION
See what breaks...