### PR TITLE
Respect `axis = (; type = ...)` when type is a LScene

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -138,15 +138,23 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
 
             axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
 
-            axis_type = if haskey(axis, :type)
-                to_value(axis.type)
+            axis_type = if haskey(axis_kw, :type)
+                to_value(axis_kw[:type])
             else
                 Makie.args_preferred_axis(Makie.Plot{$f2}, args...)
             end
 
             p = if axis_type isa Type && axis_type <: Union{LScene, Makie.PolarAxis}
-                # surface is an LScene so we cant pass attributes
-                p = Makie.$f2(args...; figure = figure_kw, attributes...)
+                # LScene can only take a limited set of attributes
+                # so we extract those that can be passed.
+                # TODO: do the same for polaraxis,
+                # or filter out shared attributes from axis_kw somehow.
+                lscene_attrs = Dict{Symbol, Any}()
+                lscene_attrs[:type] = axis_type
+                haskey(axis_kw, :scenekw) && (lscene_attrs[:scenekw] = axis_kw[:scenekw])
+                haskey(axis_kw, :show_axis) && (lscene_attrs[:show_axis] = axis_kw[:show_axis])
+                # surface is an LScene so we cant pass some axis attributes
+                p = Makie.$f2(args...; figure = figure_kw, axis = lscene_attrs, merged_attributes...)
                 # And instead set axisnames manually
                 if p.axis isa LScene && !isnothing(p.axis.scene[OldAxis])
                     p.axis.scene[OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))

--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -144,7 +144,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
                 Makie.args_preferred_axis(Makie.Plot{$f2}, args...)
             end
 
-            p = if axis_type isa Type && axis_type <: Union{LScene, Makie.PolarAxis}
+            p = if axis_type isa Type && axis_type <: Union{Makie.LScene, Makie.PolarAxis}
                 # LScene can only take a limited set of attributes
                 # so we extract those that can be passed.
                 # TODO: do the same for polaraxis,
@@ -156,8 +156,8 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
                 # surface is an LScene so we cant pass some axis attributes
                 p = Makie.$f2(args...; figure = figure_kw, axis = lscene_attrs, merged_attributes...)
                 # And instead set axisnames manually
-                if p.axis isa LScene && !isnothing(p.axis.scene[OldAxis])
-                    p.axis.scene[OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))
+                if p.axis isa Makie.LScene && !isnothing(p.axis.scene[Makie.OldAxis])
+                    p.axis.scene[Makie.OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))
                 end
                 p
             else # axis_type isa Nothing, axis_type isa Makie.Axis or GeoAxis or similar

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -377,6 +377,12 @@ end
     # fig, ax, _ = M.volumeslices(A3abc; x=:c)
     # fig, ax, _ = M.volumeslices(A3abc; z=:a)
     # M.volumeslices!(ax, A3abc;z=:a)
+
+    @testset "LScene support" begin
+        f, a, p = M.heatmap(A2ab; axis = (; type = LScene, show_axis = false))
+        @test a isa Makie.LScene
+        @test isnothing(a.scene[OldAxis])
+    end
 end
 
 @testset "AlgebraOfGraphics" begin

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -379,9 +379,9 @@ end
     # M.volumeslices!(ax, A3abc;z=:a)
 
     @testset "LScene support" begin
-        f, a, p = M.heatmap(A2ab; axis = (; type = LScene, show_axis = false))
-        @test a isa Makie.LScene
-        @test isnothing(a.scene[OldAxis])
+        f, a, p = M.heatmap(A2ab; axis = (; type = M.LScene, show_axis = false))
+        @test a isa M.LScene
+        @test isnothing(a.scene[M.OldAxis])
     end
 end
 


### PR DESCRIPTION
Previously not respected.  See test for example.