### PR TITLE
Breaking: include DataType in CategoricalEltypes

### DIFF
--- a/src/Lookups/lookup_arrays.jl
+++ b/src/Lookups/lookup_arrays.jl
@@ -470,7 +470,7 @@ abstract type AbstractCategorical{T,O} <: Aligned{T,O} end
 order(lookup::AbstractCategorical) = lookup.order
 metadata(lookup::AbstractCategorical) = lookup.metadata
 
-const CategoricalEltypes = Union{AbstractChar,Symbol,AbstractString}
+const CategoricalEltypes = Union{AbstractChar,Symbol,AbstractString,DataType}
 
 function Adapt.adapt_structure(to, l::AbstractCategorical)
     rebuild(l; data=Adapt.adapt(to, parent(l)), metadata=NoMetadata())


### PR DESCRIPTION
Does what it says on the tin :)

Specifically designed to make using RasterDataSources climate types as lookups (as in https://github.com/rafaqz/Rasters.jl/pull/826) even more slick. 