### PR TITLE
add a check for valtypename

### DIFF
--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -332,7 +332,7 @@ broadcast_options(A::BroadcastOptionsDimArray) = A.options
 @inline function _comparedims_broadcast(A, dims...)
     isstrict = _is_strict(A)
     comparedims(dims...; 
-        ignore_length_one=isstrict, order=isstrict, val=isstrict, length=false
+        ignore_length_one=isstrict, order=isstrict, val=isstrict, valtypename=isstrict, length=false
     )
 end
 


### PR DESCRIPTION
Solves https://github.com/rafaqz/DimensionalData.jl/issues/878

E.g.
```julia
using DimensionalData, DimensionalData.Lookups
z = Z(1:2)
z2 = Z([1,2])
zcat = Z(Categorical(1:2))

rand(z) .* rand(z2) # still works
rand(z) .* rand(zcat) # now errors
```

With the error message `ERROR: DimensionMismatch: Lookup types for Z do not match: Sampled and Categorical.`