### PR TITLE
Tree

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -66,6 +66,8 @@ export AbstractDimStack, DimStack
 
 export AbstractDimTable, DimTable
 
+export AbstractDimTree, DimTree
+
 export DimIndices, DimSelectors, DimPoints, #= deprecated =# DimKeys
 
 # getter methods
@@ -102,6 +104,9 @@ include("stack/stack.jl")
 include("stack/indexing.jl")
 include("stack/methods.jl")
 include("stack/show.jl")
+# DataTrees
+include("tree/tree.jl")
+include("tree/show.jl")
 # Other
 include("tables.jl")
 # Combined (easier to work on these in one file)

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -454,5 +454,7 @@ function DimStack(data::NamedTuple, dims::Tuple;
     all(map(d -> axes(d) == axes(first(data)), data)) || _stack_size_mismatch()
     DimStack(data, format(dims, first(data)), refdims, layerdims, metadata, layermetadata)
 end
+DimStack(st::AbstractDimStack) = 
+    DimStack(data(st), dims(st), refdims(st), layerdims(st), metadata(st), layermetadata(st))
 
 layerdims(s::DimStack{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,Nothing}, name::Symbol) = dims(s)

--- a/src/tree/show.jl
+++ b/src/tree/show.jl
@@ -25,28 +25,31 @@ end
 function show_branches(io, mime, tree::AbstractDimTree)
     blockwidth = get(io, :blockwidth, 0)
     if !isempty(groups(tree))
-        newblockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
+        blockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
         println(io)
         for key in keys(groups(tree))
             print_group(io, groups(tree, key), key)
         end
     end
+    return blockwidth
 end
 
 function show_trunk(io, mime, tree::AbstractDimTree)
-    p = getindex(tree, :parent)
+    blockwidth = get(io, :blockwidth, 0)
+    p = getfield(tree, :parent)
     if !isnothing(p)
-        newblockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
+        blockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
         println(io)
-        for key in keys(groups(tree))
-            print_group(io, groups(tree, key), key)
-        end
+        print_group(io, p, nothing)
     end
+    return blockwidth
 end
 
 function print_group(io, group::AbstractDimTree, key)
-    pkey = rpad(key, _keylen(keys(group)))
-    printstyled(io, "  :$pkey", color=dimcolors(7))
+    if !isnothing(key)
+        pkey = rpad(key, _keylen(keys(group)))
+        printstyled(io, "  :$pkey", color=dimcolors(7))
+    end
     # printstyled(io, " layers: "; color=:light_black)
     field_dims = DD.dims(group)
     colors = map(dimcolors, eachindex(field_dims))

--- a/src/tree/show.jl
+++ b/src/tree/show.jl
@@ -1,0 +1,68 @@
+# Base show
+function Base.summary(io::IO, tree::AbstractDimTree)
+    print(io, nameof(typeof(tree)))
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", tree::AbstractDimTree)
+    blockwidth = show_main(io, mime, tree)
+    ctx = IOContext(io, :blockwidth => blockwidth)
+    show_branches(ctx, mime, tree)
+    show_trunk(ctx, mime, tree)
+    show_after(ctx, mime, tree)
+    return nothing
+end
+
+# Show customisation interface
+function show_main(io, mime, tree::AbstractDimTree)
+    lines, blockwidth, displaywidth = print_top(io, mime, tree)
+    blockwidth = print_layers_block(io, mime, tree; blockwidth, displaywidth)
+    _, blockwidth = print_metadata_block(io, mime, metadata(tree); 
+        displaywidth, blockwidth=min(displaywidth-2, blockwidth)
+    )
+    return blockwidth
+end
+
+function show_branches(io, mime, tree::AbstractDimTree)
+    blockwidth = get(io, :blockwidth, 0)
+    if !isempty(groups(tree))
+        newblockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
+        println(io)
+        for key in keys(groups(tree))
+            print_group(io, groups(tree, key), key)
+        end
+    end
+end
+
+function show_trunk(io, mime, tree::AbstractDimTree)
+    p = getindex(tree, :parent)
+    if !isnothing(p)
+        newblockwidth = print_block_separator(io, "branches", blockwidth, blockwidth)
+        println(io)
+        for key in keys(groups(tree))
+            print_group(io, groups(tree, key), key)
+        end
+    end
+end
+
+function print_group(io, group::AbstractDimTree, key)
+    pkey = rpad(key, _keylen(keys(group)))
+    printstyled(io, "  :$pkey", color=dimcolors(7))
+    # printstyled(io, " layers: "; color=:light_black)
+    field_dims = DD.dims(group)
+    colors = map(dimcolors, eachindex(field_dims))
+    printstyled(io, " dims: "; color=:light_black)
+    if !isempty(field_dims)
+        for (i, (dim, color)) in enumerate(zip(field_dims, colors))
+            Dimensions.print_dimname(IOContext(io, :dimcolor => color), dim)
+            i != length(field_dims) && print(io, ", ")
+        end
+        printstyled(io, " size: "; color=:light_black)
+        print_sizes(io, size(field_dims); colors)
+    end
+    print(io, '\n')
+end
+
+function show_after(io, mime, tree::AbstractDimTree)
+    blockwidth = get(io, :blockwidth, 0)
+    print_block_close(io, blockwidth)
+end

--- a/src/tree/tree.jl
+++ b/src/tree/tree.jl
@@ -1,0 +1,143 @@
+abstract type AbstractDimTree end
+
+data(dt::AbstractDimTree) = getfield(dt, :data)
+data(dt::AbstractDimTree, key::Symbol) = data(dt)[key]
+# TODO fix the order
+function dims(dt::AbstractDimTree) 
+    ds = getfield(dt, :dims)
+    p = getfield(dt, :parent)
+    if isnothing(p)
+        ds
+    else
+        (dims(p)..., ds...)
+    end
+end
+groups(dt::AbstractDimTree) = getfield(dt, :groups)
+groups(dt::AbstractDimTree, key::Symbol) = groups(dt)[key] 
+setgroup(dt::AbstractDimTree, key::Symbol, group::AbstractDimStack) =
+    setgroup(dt, key, DimTree(group))
+function setgroup(dt::AbstractDimTree, key::Symbol, group::AbstractDimTree)
+    if dt == group
+        group = copy(group)
+    end
+    comparedims(dims(dt), dims(group))
+    # Set the parent in the group
+    setfield!(group, :dims, otherdims(group, dims(dt)))
+    setfield!(group, :parent, dt)
+    # Add the group to the parent
+    groups(dt)[key] = group
+    return group
+end
+layermetadata(dt::AbstractDimTree) = getfield(dt, :layermetadata)
+layermetadata(dt::AbstractDimTree, key::Symbol) = layermetadata(dt)[key]
+layerdims(dt::AbstractDimTree) = getfield(dt, :layerdims)
+layerdims(dt::AbstractDimTree, key::Symbol) = layerdims(dt)[key]
+layers(dt::AbstractDimTree) = Dict(pairs(dt))
+
+(::Type{T})(dt::AbstractDimTree) where {T<:AbstractDimStack} =
+    T(dt[keys(dt)])
+
+Base.pairs(dt) = (k => dt[k] for k in keys(dt))
+function Base.copy(dt::AbstractDimTree) 
+    rebuild(dt; 
+        keys=copy(keys(dt)),
+        data=copy(data(dt)),
+        layerdims=copy(layerdims(dt)),
+        layermetadata=copy(layermetadata(dt)),
+        groups=copy(groups(dt)),
+        parent=isnothing(getfield(dt, :parent)) ? nothing : copy(getfield(dt, :parent)),
+    )
+end
+Base.keys(dt::AbstractDimTree) = getfield(dt, :keys)
+function Base.getindex(dt::AbstractDimTree, name::Symbol)
+    data = DD.data(dt, name)
+    dims = DD.dims(dt, layerdims(dt, name))
+    refdims = DD.refdims(dt)
+    metadata = layermetadata(dt, name)
+    DimArray(data, dims; refdims, name, metadata) 
+end
+function Base.getindex(
+    dt::AbstractDimTree, names::Union{AbstractArray{Symbol},NTuple{<:Any,Symbol}}
+)
+    N = Tuple(names)
+    data = map(n -> DD.data(dt, n), names) |> NamedTuple{N}
+    layerdims = map(names) do n
+        DD.layerdims(dt, n)
+    end |> NamedTuple{N}
+    layermetadata = map(names) do n
+        DD.layermetadata(dt, n)
+    end |> NamedTuple{N}
+    dims = reduce(names; init=Symbol[]) do acc, n
+        union(acc, collect(DD.layerdims(dt, n)))
+    end |> Tuple
+    return DimStack(data, dims; 
+        refdims=DD.refdims(dt),
+        metadata=metadata(dt),
+        layerdims,
+        layermetadata,
+    ) 
+end
+Base.getproperty(dt::AbstractDimTree, name::Symbol) =
+    dt[name]
+
+"""
+    DimTree 
+
+A nested tree of dimensional arrays.
+
+`DimTree` is loosely typed and based on `Dict` rather
+than `NamedTuple` of `DimStack`, so it is much slower to index
+but very fast to compile.
+
+Trees can be nested indefinately, and leef nodes inherit dimension
+from the tree. 
+
+Branches may have duplicates of the same dimension with different 
+lookup values. This can enable use for tiles or pyramids.
+"""
+@kwdef mutable struct DimTree <: AbstractDimTree
+    data::Dict{Symbol,AbstractArray} = Dict{Symbol,AbstractArray}()
+    dims::Tuple = ()
+    keys::Vector{Symbol} = Symbol[]
+    refdims::Tuple = ()
+    layerdims::Dict{Symbol,Tuple}
+    layermetadata::Dict{Symbol,Any} = Dict(keys(layerdims) .=> NoMetadata()) 
+    groups::Dict{Symbol,AbstractDimTree} = Dict{Symbol,AbstractDimTree}()
+    metadata::Any = NoMetadata()
+    parent::Union{Nothing,AbstractDimTree} = nothing
+end
+DimTree(data, dims; keys=keys(data), kw...) = 
+    DimTree(; data, dims, keys, kw...)
+function DimTree(stack::AbstractDimStack)
+    keys = collect(Base.keys(stack))
+    data = Dict{Symbol,AbstractArray}(pairs(parent(stack)))
+    DimTree(data, dims(stack); 
+        keys,
+        metadata = metadata(stack),
+        layerdims = Dict{Symbol,Tuple}(pairs(layerdims(stack))),
+        layermetadata = Dict{Symbol,Any}(pairs(layermetadata(stack))),
+    )
+end
+function rebuild(dt::AbstractDimTree; 
+    data=data(dt), 
+    dims=dims(dt),
+    refdims=refdims(dt), 
+    metadata=metadata(dt), 
+    layerdims=layerdims(dt), 
+    layermetadata=layermetadata(dt),
+    keys=keys(dt),
+    parent=getfield(dt, :parent),
+    groups=groups(dt),
+)
+    basetypeof(dt)(; 
+        data, 
+        dims, 
+        refdims,
+        metadata,
+        layerdims,
+        layermetadata,
+        keys,
+        parent,
+        groups,
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ using DimensionalData, Test, Aqua, SafeTestsets
 
     @time @safetestset "array" begin include("array.jl") end
     @time @safetestset "stack" begin include("stack.jl") end
+    @time @safetestset "tree" begin include("tree.jl") end
     @time @safetestset "indexing" begin include("indexing.jl") end
     @time @safetestset "methods" begin include("methods.jl") end
     @time @safetestset "broadcast" begin include("broadcast.jl") end

--- a/test/tree.jl
+++ b/test/tree.jl
@@ -1,0 +1,19 @@
+using DimensionalData, Test
+
+xdim, ydim = X(1:10), Y(1:15)
+a = rand(xdim, ydim)
+b = rand(Float32, xdim, ydim)
+c = rand(Int, xdim, ydim)
+st = DimStack((; a, b, c))
+
+dt = DimensionalData.DimTree(st)
+@test dt.b === st.b
+
+DimensionalData.setgroup(dt, :g1, dt)
+DimensionalData.setgroup(dt, :g2, st)
+
+dims(DimStack(DimensionalData.groups(dt, :g2)))
+ === 
+st
+
+DimensionalData.groups(dt)

--- a/test/tree.jl
+++ b/test/tree.jl
@@ -12,8 +12,6 @@ dt = DimensionalData.DimTree(st)
 DimensionalData.setgroup(dt, :g1, dt)
 DimensionalData.setgroup(dt, :g2, st)
 
-dims(DimStack(DimensionalData.groups(dt, :g2)))
- === 
-st
-
-DimensionalData.groups(dt)
+# We get an identical DimStack back out after conversion to/from DimTree
+@test DimStack(DimensionalData.groups(dt, :g1)) === 
+      DimStack(DimensionalData.groups(dt, :g2)) === st


### PR DESCRIPTION
This PR adds a `AbsractDimTree` and `DimTree` for a mutable, fast-compiled and nested alternative to DimStack.

This object is intended to represent complicated HDF5/NetCDF/Zarr etc projects easily, and to allow easily constructing and modifying them itereratively.

Dimensions are nested in that parent dimensions flow throw to child DimTrees, but can be duplicated in sibling DimTrees. This means DimTree could represent multiple resolutions of X/Y arrays over the same time dimension as needed in cloud optimized pyramids, or multiple matrices that together cover the globle for e.g. oceanography applications like MeshArrays.jl.

DimTree will _not_ have fast data access like DimArray/DimStack. Currently indexing is not defined at all other than `Symbol` for layers, but probably interval selectors should work for spatial/temporal subsetting of the whole tree. I guess this would need to drop groups that fall outside the selection.

Algorithms needing performance can easily convert DimTree to DimStack (droppping parent/child objects) so that access is fast.