### PR TITLE
fix `@d` for only `.=`

### DIFF
--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -266,7 +266,7 @@ function _find_broadcast_vars(expr::Expr)
         return expr2, arg_list
     # Dot assignment broadcast syntax `x .= ...`
     elseif expr.head == :.= 
-        # Destinaion array
+        # Destination array
         dest_var = Symbol(gensym(), :_d)
         push!(arg_list, dest_var => expr.args[1])
         dest_expr = Expr(:call, mdb, esc(dest_var), :dims, :options)
@@ -274,7 +274,7 @@ function _find_broadcast_vars(expr::Expr)
         expr2, arg_list2 = _find_broadcast_vars(expr.args[2])
         source_expr = if isempty(arg_list2)
             var2 = Symbol(gensym(), :_d)
-            push!(arg_list, var2 => arg)
+            push!(arg_list, var2 => expr.args[2])
             esc(var2)
         else
             append!(arg_list, arg_list2)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -434,6 +434,8 @@ end
         dv2 = rand(X(2:4))
         dv3 = rand(X(7:9))
         @test_throws DimensionMismatch dv1 .= dv2 .* dv3
+        @d dv1 .= dv2 strict = false
+        @test dv1 == parent(dv2)
         @d dv1 .= dv2 .* dv3 strict=false
         @test dv1 == parent(dv2) .* parent(dv3)
     end


### PR DESCRIPTION
This fixes `@d da1 .= da2`, which would error because `arg` was used but not defined.

Hope this makes sense, I really have no clue what I'm doing here :)