### PR TITLE
Breaking: split `set` into `unsafe_set` and `set`

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -35,11 +35,14 @@ include("Dimensions/Dimensions.jl")
 
 using .Dimensions
 using .Dimensions.Lookups
+
 using .Dimensions: StandardIndices, DimOrDimType, DimTuple, DimTupleOrEmpty, DimType, AllDims
-import .Lookups: metadata, set, _set, rebuild, basetypeof, 
+import .Dimensions: dims, refdims, name, lookup, kw2dims, hasdim, label, checkaxes
+
+import .Lookups: Safety, Safe, Unsafe, SelectorOrInterval, Begin, End
+import .Lookups: metadata, reorder, set, _set, rebuild, basetypeof, 
     order, span, sampling, locus, val, index, bounds, intervalbounds,
-    hasselection, units, SelectorOrInterval, Begin, End
-import .Dimensions: dims, refdims, name, lookup, kw2dims, hasdim, label, _astuple
+    hasselection, units
 
 import DataAPI.groupby
 
@@ -48,6 +51,7 @@ export Lookups, Dimensions
 # Deprecated
 const LookupArrays = Lookups
 const LookupArray = Lookup
+
 export LookupArrays, LookupArray
 
 # Dimension

--- a/src/Dimensions/Dimensions.jl
+++ b/src/Dimensions/Dimensions.jl
@@ -23,13 +23,14 @@ using .Lookups
 const LU = Lookups
 const LookupArrays = Lookups
 
-import .Lookups: rebuild, order, span, sampling, locus, val, index, set, _set,
+import .Lookups: rebuild, order, span, sampling, locus, val, index, reorder, set, _set,
     metadata, bounds, intervalbounds, units, basetypeof, unwrap, selectindices, hasselection,
     shiftlocus, maybeshiftlocus, ordered_first, ordered_last, ordered_firstindex, ordered_lastindex, 
     promote_first, _remove
 using .Lookups: StandardIndices, SelTuple, CategoricalEltypes,
     LookupTrait, AllMetadata, LookupSetters, AbstractBeginEndRange,
     SelectorOrInterval, Interval
+import .Lookups: Safety, Safe, Unsafe
 
 using Base: tail, OneTo, @propagate_inbounds
 

--- a/src/Dimensions/dimunitrange.jl
+++ b/src/Dimensions/dimunitrange.jl
@@ -2,13 +2,14 @@ struct DimUnitRange{T,R<:AbstractUnitRange{T},D<:Dimension} <: AbstractUnitRange
     range::R
     dim::D
 end
-
 DimUnitRange{T}(r::DimUnitRange{T}) where {T<:Integer} = r
-function DimUnitRange{T}(r::DimUnitRange) where {T<:Integer}
-    return DimUnitRange(AbstractUnitRange{T}(parent(r)), dims(r))
-end
+DimUnitRange{T}(r::DimUnitRange) where {T<:Integer} =
+    DimUnitRange(AbstractUnitRange{T}(parent(r)), dims(r))
 
-@inline Base.parent(r::DimUnitRange) = r.range
+@inline dims(r::DimUnitRange) = r.dim
+@inline dims(rs::Tuple{DimUnitRange,Vararg{DimUnitRange}}) = map(dims, rs)
+
+Base.parent(r::DimUnitRange) = r.range
 
 function Base.reduced_index(dur::DimUnitRange) 
     r = Base.reduced_index(parent(dur))
@@ -20,9 +21,6 @@ function Base.reduced_index(dur::DimUnitRange)
     end
     return DimUnitRange(r, d1)
 end
-
-@inline dims(r::DimUnitRange) = r.dim
-@inline dims(rs::Tuple{DimUnitRange,Vararg{DimUnitRange}}) = map(dims, rs)
 
 # this is necessary to ensure that keyword syntax for DimArray works correctly
 Base.Slice(r::DimUnitRange) = Base.Slice(parent(r))

--- a/src/Dimensions/format.jl
+++ b/src/Dimensions/format.jl
@@ -45,8 +45,9 @@ _format(::Type{D}, axis::AbstractRange) where D<:Dimension = D(NoLookup(axes(axi
 _format(dim::Dimension{Colon}, axis::AbstractRange) = rebuild(dim, NoLookup(axes(axis, 1)))
 function _format(dim::Dimension, axis::AbstractRange)
     newlookup = format(val(dim), basetypeof(dim), axes(axis, 1))
-    checkaxis(newlookup, axis)
-    return rebuild(dim, newlookup)
+    newdim = rebuild(dim, newlookup)
+    checkaxis(newdim, axis)
+    return newdim
 end
 
 format(val::AbstractArray, D::Type, axis::AbstractRange) = format(AutoLookup(), D, val, axis)
@@ -141,8 +142,10 @@ _format(locus::Locus, D::Type, values) = locus
 
 _order(values) = first(values) <= last(values) ? ForwardOrdered() : ReverseOrdered()
 
-checkaxis(lookup::Transformed, axis) = nothing
-checkaxis(lookup, axis) = first(axes(lookup)) == axis || _checkaxiserror(lookup, axis)
+checkaxis(lookup::Union{Dimension,Lookup}, axis::AbstractUnitRange) = 
+    first(axes(lookup)) == axis || _checkaxiserror(lookup, axis)
+
+checkaxes(lookups::Tuple, axes::Tuple) = all(map(checkaxis, lookups, axes))
 
 @noinline _explicitpoints_error() =
     throw(ArgumentError("Cannot use Explicit span with Points sampling"))
@@ -150,9 +153,9 @@ checkaxis(lookup, axis) = first(axes(lookup)) == axis || _checkaxiserror(lookup,
     throw(ArgumentError("lookup step $(step(span)) does not match lookup step $(step(values))"))
 @noinline _arraynosteperror() =
     throw(ArgumentError("`Regular` must specify `step` size with values other than `AbstractRange`"))
-@noinline _checkaxiserror(lookup, axis) =
+@noinline _checkaxiserror(dimorlookup::Union{Dimension,Lookup}, axis) =
     throw(DimensionMismatch(
-        "axes of $(basetypeof(lookup)) of $(first(axes(lookup))) do not match array axis of $axis"
+        "axes of $(basetypeof(dimorlookup)) of $(first(axes(dimorlookup))) do not match array axis of $axis"
     ))
 @noinline _valformaterror(v, D::Type) =
     throw(ArgumentError(

--- a/src/Dimensions/utils.jl
+++ b/src/Dimensions/utils.jl
@@ -11,3 +11,5 @@ for f in (:shiftlocus, :maybeshiftlocus)
         end
     end
 end
+
+reorder(dim::Dimension, o::Order) = rebuild(reorder(lookup(dim), o))

--- a/src/Lookups/set.jl
+++ b/src/Lookups/set.jl
@@ -1,70 +1,113 @@
+abstract type Safety end
+struct Safe <: Safety end
+struct Unsafe <: Safety end
+
 const LookupSetters = Union{AllMetadata,Lookup,LookupTrait,Nothing,AbstractArray}
 
-set(lookup::Lookup, x::LookupSetters) = _set(lookup, x)
-set(lookup::Lookup, ::Type{T}) where T = _set(lookup, T())
+set(lookup::Lookup, x::LookupSetters) = _set(Safe(), lookup, x)
+set(lookup::Lookup, ::Type{T}) where T = _set(Safe(), lookup, T())
+set(a::LookupTrait, b::LookupTrait) = _set(Safe(), a, b)
 
-# _set(lookup::Lookup, newlookup::Lookup) = lookup
-_set(lookup::AbstractCategorical, newlookup::AutoLookup) = begin
-    lookup = _set(lookup, parent(newlookup))
-    o = _set(order(lookup), order(newlookup))
-    md = _set(metadata(lookup), metadata(newlookup))
+unsafe_set(lookup::Lookup, x::LookupSetters) = _set(Unsafe(), lookup, x)
+unsafe_set(lookup::Lookup, ::Type{T}) where T = _set(Unsafe(), lookup, T())
+unsafe_set(a::LookupTrait, b::LookupTrait) where T = _set(Unsafe(), a, b)
+
+# Types are constructed
+# Note: this is the only `_set` where `x` is untyped
+_set(s::Safety, x, ::Type{T}) where T = _set(s, x, T())
+# Set with no keywords or arguments does nothing
+_set(::Safety, x) = x
+
+_set(s::Unsafe, lookup::AbstractCategorical, newlookup::AutoLookup) =
+    _set(s, lookup, parent(newlookup))
+_set(::Safety, lookup::AbstractCategorical, newlookup::AutoValues) = lookup
+_set(s::Safe, lookup::AbstractCategorical, newlookup::AutoLookup) = begin
+    lookup = _set(Unsafe(), lookup, newlookup)
+    o = _set(s, order(lookup), order(newlookup))
+    md = _set(s, metadata(lookup), metadata(newlookup))
     rebuild(lookup; order=o, metadata=md)
 end
-_set(lookup::Lookup, newlookup::AbstractCategorical) = begin
-    lookup = _set(lookup, parent(newlookup))
-    o = _set(order(lookup), order(newlookup))
-    md = _set(metadata(lookup), metadata(newlookup))
+_set(s::Unsafe, lookup::Lookup, newlookup::AbstractCategorical) =
+    _set(s, lookup, parent(newlookup))
+_set(s::Safe, lookup::Lookup, newlookup::AbstractCategorical) = begin
+    lookup = _set(Unsafe(), lookup, newlookup)
+    o = _set(s, order(lookup), order(newlookup))
+    md = _set(s, metadata(lookup), metadata(newlookup))
     rebuild(newlookup; data=parent(lookup), order=o, metadata=md)
 end
-_set(lookup::AbstractSampled, newlookup::AutoLookup) = begin
-    # Update lookup values
-    lookup = _set(lookup, parent(newlookup))
-    o = _set(order(lookup), order(newlookup))
-    sa = _set(sampling(lookup), sampling(newlookup))
-    sp = _set(span(lookup), span(newlookup))
-    md = _set(metadata(lookup), metadata(newlookup))
-    rebuild(lookup; data=parent(lookup), order=o, span=sp, sampling=sa, metadata=md)
-end
-_set(lookup::Lookup, newlookup::AbstractSampled) = begin
+_set(s::Unsafe, lookup::AbstractSampled, newlookup::AutoLookup) =
+    _set(s, lookup, parent(newlookup))
+# _set(s::Safe, lookup::AbstractSampled, newlookup::AutoLookup) = begin
+#     # Update lookup values
+#     lookup = _set(Unsafe(), lookup, newlookup)
+#     o = _set(s, order(lookup), order(newlookup))
+#     sa = _set(s, sampling(lookup), sampling(newlookup))
+#     sp = _set(s, span(lookup), span(newlookup))
+#     md = _set(s, metadata(lookup), metadata(newlookup))
+#     rebuild(lookup; data=parent(lookup), order=o, span=sp, sampling=sa, metadata=md)
+# end
+_set(s::Unsafe, lookup::Lookup, newlookup::AbstractSampled) = 
+    _set(s, lookup, parent(newlookup))
+_set(s::Safe, lookup::Lookup, newlookup::AbstractSampled) = begin
     # Update each field separately. The old lookup may not have these fields, or may have
     # a subset with the rest being traits. The new lookup may have some auto fields.
-    lookup = _set(lookup, parent(newlookup))
-    o = _set(order(lookup), order(newlookup))
-    sp = _set(span(lookup), span(newlookup))
-    sa = _set(sampling(lookup), sampling(newlookup))
-    md = _set(metadata(lookup), metadata(newlookup))
+    lookup = _set(Unsafe(), lookup, newlookup)
+    o = _set(s, order(lookup), order(newlookup))
+    sp = _set(s, span(lookup), span(newlookup))
+    sa = _set(s, sampling(lookup), sampling(newlookup))
+    md = _set(s, metadata(lookup), metadata(newlookup))
     # Rebuild the new lookup with the merged fields
     rebuild(newlookup; data=parent(lookup), order=o, span=sp, sampling=sa, metadata=md)
 end
-_set(lookup::AbstractArray, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
-_set(lookup::Lookup, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
-_set(lookup::Lookup, newlookup::NoLookup) = newlookup
+_set(::Safety, lookup::AbstractArray, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
+_set(::Safety, lookup::Lookup, newlookup::NoLookup{<:AutoValues}) = NoLookup(axes(lookup, 1))
+_set(::Safety, lookup::Lookup, newlookup::NoLookup) = newlookup
 
 # Set the lookup values
-_set(lookup::Lookup, values::Val) = rebuild(lookup; data=values)
-_set(lookup::Lookup, values::Colon) = lookup
-_set(lookup::Lookup, values::AutoLookup) = lookup
-_set(lookup::Lookup, values::AbstractArray) = rebuild(lookup; data=values)
+_set(::Safety, lookup::Lookup, values::Colon) = lookup
+_set(::Safety, lookup::Lookup, values::AutoLookup) = lookup
+# _set(::Unsafe, lookup::Lookup, values::AbstractArray) = rebuild(lookup; data=values)
 
-_set(lookup::Lookup, values::AutoValues) = lookup
-_set(lookup::Lookup, values::AbstractRange) =
-    rebuild(lookup; data=_set(parent(lookup), values), order=orderof(values))
-# Update the Sampling lookup of Sampled dims - it must match the range.
-_set(lookup::AbstractSampled, values::AbstractRange) = begin
-    i = _set(parent(lookup), values)
-    o = orderof(values)
-    sp = Regular(step(values))
-    rebuild(lookup; data=i, span=sp, order=o)
+_set(::Safety, lookup::Lookup, values::AutoValues) = lookup
+# Need both for ambiguity
+_set(::Safe, lookup::Lookup, values::AbstractVector) = rebuild(lookup; data=values)
+_set(::Unsafe, lookup::Lookup, values::AbstractVector) = rebuild(lookup; data=values)
+_set(s::Safe, lookup::AbstractCategorical, values::AbstractVector) =
+    rebuild(lookup; data=_set(s, parent(lookup), values), order=orderof(values))
+# Safe detects order and updates span
+_set(s::Safe, lookup::AbstractSampled, values::AbstractRange) = begin
+    data = _set(s, parent(lookup), values)
+    order = orderof(values)
+    span = Regular(step(values))
+    rebuild(lookup; data, span, order)
+end
+_set(s::Safe, lookup::AbstractSampled, values::AbstractVector) = begin
+    data = _set(s, parent(lookup), values)
+    order = orderof(values)
+    span = if sampling(lookup) isa Start
+        Irregular((first(values), nothing))
+    elseif sampling(lookup) isa End
+        Irregular((nothing, last(values)))
+    else
+        Irregular((nothing, nothing))
+    end
+    return rebuild(lookup; data, span, order)
 end
 
 # Order
-_set(lookup::Lookup, neworder::Order) = rebuild(lookup; order=_set(order(lookup), neworder))
-_set(lookup::NoLookup, neworder::Order) = lookup
-_set(order::Order, neworder::Order) = neworder 
-_set(order::Order, neworder::AutoOrder) = order
+_set(s::Safe, lookup::AbstractNoLookup, neworder::Order) = lookup
+_set(s::Unsafe, lookup::AbstractNoLookup, neworder::Order) = lookup
+# Unsafe leaves the lookup values as-is
+_set(s::Unsafe, lookup::Lookup, neworder::Order) = 
+    rebuild(lookup; order=_set(s, order(lookup), neworder))
+_set(::Safe, lookup::Lookup, neworder::AutoOrder) = lookup
+# Safe reorders them to match `neworder`
+_set(::Safe, lookup::Lookup, neworder::Order) = reorder(lookup, neworder)
+_set(s::Safety, order::Order, neworder::Order) = neworder 
+_set(s::Safety, order::Order, neworder::AutoOrder) = order
 
 # Span
-_set(lookup::AbstractSampled, ::Irregular{AutoBounds}) = begin
+_set(::Safety, lookup::AbstractSampled, ::Irregular{AutoBounds}) = begin
     bnds = if parent(lookup) isa AutoValues || span(lookup) isa AutoSpan
         AutoBounds()
     else
@@ -72,7 +115,7 @@ _set(lookup::AbstractSampled, ::Irregular{AutoBounds}) = begin
     end
     rebuild(lookup; span=Irregular(bnds))
 end
-_set(lookup::AbstractSampled, ::Regular{AutoStep}) = begin
+_set(s::Safety, lookup::AbstractSampled, ::Regular{AutoStep}) = begin
     stp = if span(lookup) isa AutoSpan || step(lookup) isa AutoStep
         if parent(lookup) isa AbstractRange
             step(parent(lookup))
@@ -84,43 +127,47 @@ _set(lookup::AbstractSampled, ::Regular{AutoStep}) = begin
     end
     rebuild(lookup; span=Regular(stp))
 end
-_set(lookup::AbstractSampled, span::Span) = rebuild(lookup; span=span)
-_set(lookup::AbstractSampled, span::AutoSpan) = lookup
-_set(span::Span, newspan::Span) = newspan
-_set(span::Span, newspan::AutoSpan) = span
+_set(::Safety, lookup::AbstractSampled, span::Span) = rebuild(lookup; span=span)
+_set(::Safety, lookup::AbstractSampled, span::AutoSpan) = lookup
+_set(::Safety, span::Span, newspan::Span) = newspan
+_set(::Safety, span::Span, newspan::AutoSpan) = span
 
 # Sampling
-_set(lookup::AbstractSampled, newsampling::Sampling) =
-    rebuild(lookup; sampling=_set(sampling(lookup), newsampling))
-_set(lookup::AbstractSampled, sampling::AutoSampling) = lookup
-_set(sampling::Sampling, newsampling::Sampling) = newsampling
-_set(sampling::Sampling, newsampling::AutoSampling) = sampling
-_set(sampling::Sampling, newsampling::Intervals) =
-    _set(newsampling, _set(locus(sampling), locus(newsampling)))
+# TODO does this need to fix bounds?
+_set(s::Safety, lookup::AbstractSampled, newsampling::Sampling) =
+    rebuild(lookup; sampling=_set(s, sampling(lookup), newsampling))
+_set(::Safety, lookup::AbstractSampled, sampling::AutoSampling) = lookup
+_set(::Safety, sampling::Sampling, newsampling::Sampling) = newsampling
+_set(::Safety, sampling::Sampling, newsampling::AutoSampling) = sampling
+_set(s::Safety, sampling::Sampling, newsampling::Intervals) =
+    _set(s, newsampling, _set(s, locus(sampling), locus(newsampling)))
 
 # Locus
-_set(lookup::AbstractSampled, locus::Locus) =
-    rebuild(lookup; sampling=_set(sampling(lookup), locus))
-_set(sampling::Points, locus::Union{AutoPosition,Center}) = Points()
-_set(sampling::Points, locus::Locus) = _locuserror()
-_set(sampling::Intervals, locus::Locus) = Intervals(locus)
-_set(sampling::Intervals, locus::AutoPosition) = sampling
+_set(s::Unsafe, lookup::AbstractSampled, locus::Locus) =
+    rebuild(lookup; sampling=_set(s, sampling(lookup), locus))
+_set(::Safe, lookup::AbstractSampled, locus::Locus) = shiftlocus(l1, locus)
+_set(::Safety, sampling::Points, locus::Union{AutoPosition,Center}) = Points()
+_set(::Safety, sampling::Points, locus::Locus) = _locuserror()
+_set(::Safety, sampling::Intervals, locus::Locus) = Intervals(locus)
+_set(::Safety, sampling::Intervals, locus::AutoPosition) = sampling
 
-_set(locus::Locus, newlocus::Locus) = newlocus
-_set(locus::Locus, newlocus::AutoPosition) = locus
+_set(::Safety, locus::Locus, newlocus::Locus) = newlocus
+_set(::Safety, locus::Locus, newlocus::AutoPosition) = locus
 
 # Metadata
-_set(lookup::Lookup, newmetadata::AllMetadata) = rebuild(lookup; metadata=newmetadata)
-_set(metadata::AllMetadata, newmetadata::AllMetadata) = newmetadata
+_set(::Safety, lookup::Lookup, newmetadata::AllMetadata) = 
+    rebuild(lookup; metadata=newmetadata)
+_set(::Safety, metadata::AllMetadata, newmetadata::AllMetadata) = newmetadata
 
 # Lookup values
-_set(values::AbstractArray, newvalues::AbstractArray) = newvalues
-_set(values::AbstractArray, newvalues::AutoLookup) = values
-_set(values::AbstractArray, newvalues::Colon) = values
-_set(values::Colon, newvalues::AbstractArray) = newvalues
-_set(values::Colon, newvalues::Colon) = values
+_set(::Safety, values::AbstractArray, newvalues::AbstractArray) = newvalues
+_set(::Safety, values::AbstractArray, newvalues::AutoLookup) = values
+_set(::Safety, values::AbstractArray, newvalues::Colon) = values
+_set(::Safety, values::Colon, newvalues::AbstractArray) = newvalues
+_set(::Safety, values::Colon, newvalues::Colon) = values
 
-_set(A, x) = _cantseterror(A, x)
+# Other things error
+# _set(::Safety, A, x) = _cantseterror(A, x)
 
 @noinline _locuserror() = throw(ArgumentError("Can't set a locus for `Points` sampling other than `Center` - the lookup values are the exact points"))
 @noinline _cantseterror(a, b) = throw(ArgumentError("Can not set any fields of $(typeof(a)) to $(typeof(b))"))


### PR DESCRIPTION
This PR aims to make `set` much more reliable and useful to users, and keep the faster and always type stable `unsafe_set` for internal use