### PR TITLE
Allow BasicDimArrays like DimPoints, DimIndices, etc in DimStack

### DIFF
--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -297,13 +297,13 @@ _maybestack(s::AbstractDimStack, xs::Tuple) = NamedTuple{keys(s)}(xs)
 # Without the `@nospecialise` here this method is also compile with the above method
 # on every call to _maybestack. And `rebuild_from_arrays` is expensive to compile.
 function _maybestack(
-    s::AbstractDimStack, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+    s::AbstractDimStack, das::Tuple{AbstractBasicDimArray,Vararg{AbstractBasicDimArray}}
 )
     # Avoid compiling this in the simple cases in the above method
     Base.invokelatest(() -> rebuild_from_arrays(s, das))
 end
 function _maybestack(
-    s::AbstractDimStack{<:NamedTuple{K}}, das::Tuple{AbstractDimArray,Vararg{AbstractDimArray}}
+    s::AbstractDimStack{<:NamedTuple{K}}, das::Tuple{AbstractBasicDimArray,Vararg{AbstractBasicDimArray}}
 ) where K
     Base.invokelatest(() -> rebuild_from_arrays(s, das))
 end
@@ -410,9 +410,9 @@ struct DimStack{K,T,N,L,D<:Tuple,R<:Tuple,LD,M,LM} <: AbstractDimStack{K,T,N,L}
         new{K,T,N,L,D,R,typeof(values(layerdims)),M,typeof(values(layermetadata))}(data, dims, refdims, layerdims, metadata, layermetadata)
     end
 end
-DimStack(@nospecialize(das::AbstractDimArray...); kw...) = DimStack(collect(das); kw...)
-DimStack(@nospecialize(das::Tuple{Vararg{AbstractDimArray}}); kw...) = DimStack(collect(das); kw...)
-function DimStack(@nospecialize(das::AbstractArray{<:AbstractDimArray});
+DimStack(@nospecialize(das::AbstractBasicDimArray...); kw...) = DimStack(collect(das); kw...)
+DimStack(@nospecialize(das::Tuple{Vararg{AbstractBasicDimArray}}); kw...) = DimStack(collect(das); kw...)
+function DimStack(@nospecialize(das::AbstractArray{<:AbstractBasicDimArray});
     metadata=NoMetadata(), refdims=(),
 )
     keys_vec = uniquekeys(das)
@@ -425,7 +425,7 @@ function DimStack(@nospecialize(das::AbstractArray{<:AbstractDimArray});
 
     DimStack(data, dims, refdims, layerdims, metadata, layermetadata)
 end
-function DimStack(A::AbstractDimArray;
+function DimStack(A::AbstractBasicDimArray;
     layersfrom=nothing, metadata=metadata(A), refdims=refdims(A), kw...
 )
     layers = if isnothing(layersfrom)
@@ -438,7 +438,7 @@ function DimStack(A::AbstractDimArray;
     end
     return DimStack(layers; refdims=refdims, metadata=metadata, kw...)
 end
-function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractDimArray}}};
+function DimStack(das::NamedTuple{<:Any,<:Tuple{Vararg{AbstractBasicDimArray}}};
     data=map(parent, das), dims=combinedims(collect(das)), layerdims=map(basedims, das),
     refdims=(), metadata=NoMetadata(), layermetadata=map(DD.metadata, das)
 )

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -358,3 +358,27 @@ end
     @test ds[Z = 1:2] == ds
 
 end
+
+@testset "DimStack with DimIndices" begin
+
+    @testset "Constructors" begin
+        di = DimIndices(da1)
+        @test DimStack((one=A, two=2A, three=3A, four = di), dimz) ==
+            DimStack((one=da1, two=da2, three=da3, four = di), dimz) ==
+            DimStack((one=da1, two=da2, three=da3, four = di))
+    end
+
+    da = rand(X(1:10), Y(2:10))
+    di = DimIndices(da)
+    dp = DimPoints(da)
+
+    @test_nowarn DimStack((; indices = di, points = dp))
+
+    ds = @test_nowarn DimStack((; data = da, indices = di, points = dp))
+
+    @test ds.data == da
+    @test ds.indices == di
+    @test ds.points == dp
+
+    @test ds[1] == (data = da[1], indices = di[1], points = dp[1])
+end


### PR DESCRIPTION
this allows:

```julia
DimStack((; data = da, points = DimPoints(da)))`

very useful if you are trying to calculate e.g slope with stencils, since you then have the coordinates available to you.