### PR TITLE
extend DiskArrays.pad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,3 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false

--- a/ext/DimensionalDataDiskArraysExt.jl
+++ b/ext/DimensionalDataDiskArraysExt.jl
@@ -9,6 +9,8 @@ using DimensionalData
 import DimensionalData: AbstractBasicDimArray
 import DiskArrays
 
+const DD = DimensionalData
+
 DiskArrays.haschunks(da::AbstractBasicDimArray) = DiskArrays.haschunks(parent(da))
 DiskArrays.eachchunk(da::AbstractBasicDimArray) = DiskArrays.eachchunk(parent(da))
 
@@ -29,32 +31,38 @@ end
     DiskArrays.pad(x::AbstractDimArray, padding::Tuple{Vararg{Tuple{<:Integer,<:Integer}}}; kw...) =
         DiskArrays.pad(x, map(rebbuild, dims(x, padding)))
     DiskArrays.pad(x::AbstractDimArray, padding::NamedTuple; kw...) =
-        DiskArrays.pad(x, DimensionalData.kw2dims(padding); kw...)
-    DiskArrays.pad(x::AbstractDimArray, pairs::Pair...; kw...) =
-        DiskArrays.pad(x, DimensionalData.pair2dims(pairs); kw...)
-    function DiskArrays.pad(x::AbstractDimArray, padding::DimTuple; kw...)
-        tuple_padding = map(dims(x)) do d
-            hasdim(padding, d) ? map(Int, val(dim(padding, d))) : (0, 0)
+        DiskArrays.pad(x, DD.kw2dims(padding); kw...)
+    DiskArrays.pad(x::AbstractDimArray, p1::Pair, pairs::Pair...; kw...) =
+        DiskArrays.pad(x, DD.Dimensions.pairs2dims(p1, pairs...); kw...)
+    function DiskArrays.pad(x::AbstractDimArray, padding::DD.DimTuple; kw...)
+        tuple_padding = map(DD.dims(x)) do d
+            hasdim(padding, d) ? map(Int, val(DD.dims(padding, d))) : (0, 0)
         end
-        dims = map(padding) do dp
-            DiskArrays.pad(dims(x, dp), val(dp))
+        paddeddims = map(DD.dims(x)) do d
+            if hasdim(padding, d) 
+                DiskArrays.pad(d, val(DD.dims(padding, d)))
+            else
+                d
+            end
         end
-        data = DiskArrays.pad(parent(x), tuple_padding; kw...)
-        return rebuild(x; data, dims)
+        paddeddata = DiskArrays.pad(parent(x), tuple_padding; kw...)
+        return rebuild(x; data=paddeddata, dims=paddeddims)
     end
-    DiskArrays.pad(d::Dimension, padding::Tuple{<:Integer,<:Integer}) = 
-        DiskArrays.pad(lookup(d), padding)
-    function DiskArrays.pad(l::Lookup, padding::Tuple{<:Integer,<:Integer})
-        isregular(l) || throw(ArgumentError("Can only pad `Regular` lookups"))
+    DiskArrays.pad(d::DD.Dimension, padding::Tuple{<:Integer,<:Integer}) = 
+        rebuild(d, DiskArrays.pad(lookup(d), padding))
+    DiskArrays.pad(l::DD.AbstractNoLookup, (startpad, stoppad)::Tuple{<:Integer,<:Integer}) =
+        NoLookup(Base.OneTo(length(l) + startpad + stoppad))
+    function DiskArrays.pad(l::DD.Lookup, padding::Tuple{<:Integer,<:Integer})
+        (DD.issampled(l) && DD.isregular(l)) || throw(ArgumentError("Can only pad `Regular` `AbstractSampled` lookups"))
         rebuild(l; data=_pad(parent(l), step(l), padding))
         # Use ranges for math because they have TwicePrecision magic
         # Define a range down to the lowest value,
         # but anchored at the existing value
     end
 
-    _pad(l::AbstractRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
+    _pad(l::AbstractRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer}) =
         (first(l) - startpad * step(l)):step(l):(last(l) + stoppad * step(l))
-    _pad(l::AbstractUnitRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
+    _pad(l::AbstractUnitRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer}) =
         (first(l) - startpad):(last(l) + stoppad)
     function _pad(l::AbstractVector, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
         # First pad as a range

--- a/ext/DimensionalDataDiskArraysExt.jl
+++ b/ext/DimensionalDataDiskArraysExt.jl
@@ -9,16 +9,65 @@ using DimensionalData
 import DimensionalData: AbstractBasicDimArray
 import DiskArrays
 
-# cache was only introduced in DiskArrays v0.4, so
-# we lock out the method definition if the method does
-# not exist.
+DiskArrays.haschunks(da::AbstractBasicDimArray) = DiskArrays.haschunks(parent(da))
+DiskArrays.eachchunk(da::AbstractBasicDimArray) = DiskArrays.eachchunk(parent(da))
+
+# Only define methods if they are available, 
+# to avoid dropping older DiskArrays versions
+# TODO remove these checks
+@static if isdefined(DiskArrays, :isdisk)
+    DiskArrays.isdisk(x::AbstractDimArray) = DiskArrays.isdisk(parent(x))
+    DiskArrays.isdisk(x::AbstractDimStack) = any(map(DiskArrays.isdisk, layers(x)))
+end
+
 @static if isdefined(DiskArrays, :cache)
     DiskArrays.cache(x::Union{AbstractDimStack,AbstractDimArray}; kw...) = 
         modify(A -> DiskArrays.cache(A; kw...), x)
 end
 
-DiskArrays.haschunks(da::AbstractBasicDimArray) = DiskArrays.haschunks(parent(da))
-DiskArrays.eachchunk(da::AbstractBasicDimArray) = DiskArrays.eachchunk(parent(da))
+@static if isdefined(DiskArrays, :pad)
+    DiskArrays.pad(x::AbstractDimArray, padding::Tuple{Vararg{Tuple{<:Integer,<:Integer}}}; kw...) =
+        DiskArrays.pad(x, map(rebbuild, dims(x, padding)))
+    DiskArrays.pad(x::AbstractDimArray, padding::NamedTuple; kw...) =
+        DiskArrays.pad(x, DimensionalData.kw2dims(padding); kw...)
+    DiskArrays.pad(x::AbstractDimArray, pairs::Pair...; kw...) =
+        DiskArrays.pad(x, DimensionalData.pair2dims(pairs); kw...)
+    function DiskArrays.pad(x::AbstractDimArray, padding::DimTuple; kw...)
+        tuple_padding = map(dims(x)) do d
+            hasdim(padding, d) ? map(Int, val(dim(padding, d))) : (0, 0)
+        end
+        dims = map(padding) do dp
+            DiskArrays.pad(dims(x, dp), val(dp))
+        end
+        data = DiskArrays.pad(parent(x), tuple_padding; kw...)
+        return rebuild(x; data, dims)
+    end
+    DiskArrays.pad(d::Dimension, padding::Tuple{<:Integer,<:Integer}) = 
+        DiskArrays.pad(lookup(d), padding)
+    function DiskArrays.pad(l::Lookup, padding::Tuple{<:Integer,<:Integer})
+        isregular(l) || throw(ArgumentError("Can only pad `Regular` lookups"))
+        rebuild(l; data=_pad(parent(l), step(l), padding))
+        # Use ranges for math because they have TwicePrecision magic
+        # Define a range down to the lowest value,
+        # but anchored at the existing value
+    end
 
+    _pad(l::AbstractRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
+        (first(l) - startpad * step(l)):step(l):(last(l) + stoppad * step(l))
+    _pad(l::AbstractUnitRange, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
+        (first(l) - startpad):(last(l) + stoppad)
+    function _pad(l::AbstractVector, step, (startpad, stoppad)::Tuple{<:Integer,<:Integer})
+        # First pad as a range
+        range = parent(_pad(first(l):last(l), step, (startpad, stoppad)))
+        # Then convert back to vector
+        data = collect(range)
+        # And fill the middle with the values from the original vector
+        # This prevents floating point error changing the original values
+        data[startpad+1:end-stoppad] .= l
+        # Rebuild the lookup with the padded data
+        return rebild(l; data)
+    end
+end
+        
 
 end

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -87,9 +87,9 @@ end
 end
 
 @testset "DiskArrays" begin
-    raw_data = rand(100, 100)
-    chunked_data = DiskArrays.TestTypes.ChunkedDiskArray(raw_data, (10, 10))
-    da = DimArray(chunked_data, (X, Y))
+    raw_data = rand(100, 100, 2)
+    chunked_data = DiskArrays.TestTypes.ChunkedDiskArray(raw_data, (10, 10, 2))
+    da = DimArray(chunked_data, (X(1.0:100), Y(collect(10:10:1000); span=Regular(10)), Z()))
 
     @testset "cache" begin
         @test parent(da) isa DiskArrays.TestTypes.ChunkedDiskArray
@@ -101,4 +101,15 @@ end
         @test DiskArrays.haschunks(da) == DiskArrays.haschunks(chunked_data)
         @test DiskArrays.eachchunk(da) == DiskArrays.eachchunk(chunked_data)
     end
+    @testset "isdisk" begin
+        @test DiskArrays.isdisk(da)
+        @test !DiskArrays.isdisk(rand(X(5), Y(4)))
+    end
+    @testset "pad" begin
+        p = DiskArrays.pad(da, (; X=(2, 3), Y=(40, 50)); fill=1.0)
+        @test size(p) == (105, 190, 2)
+        @test dims(p) == map(DimensionalData.format, (X(-1.0:100.0), Y(collect(-30:10:1050); span=Regular(10)), Z(NoLookup(Base.OneTo(2)))))
+        @test sum(p) ≈ sum(da) + prod(size(p)) - prod(size(da))
+    end
+
 end

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -90,6 +90,7 @@ end
     raw_data = rand(100, 100, 2)
     chunked_data = DiskArrays.TestTypes.ChunkedDiskArray(raw_data, (10, 10, 2))
     da = DimArray(chunked_data, (X(1.0:100), Y(collect(10:10:1000); span=Regular(10)), Z()))
+    st = DimStack((a = da, b = da))
 
     @testset "cache" begin
         @test parent(da) isa DiskArrays.TestTypes.ChunkedDiskArray
@@ -107,9 +108,12 @@ end
     end
     @testset "pad" begin
         p = DiskArrays.pad(da, (; X=(2, 3), Y=(40, 50)); fill=1.0)
-        @test size(p) == (105, 190, 2)
-        @test dims(p) == map(DimensionalData.format, (X(-1.0:100.0), Y(collect(-30:10:1050); span=Regular(10)), Z(NoLookup(Base.OneTo(2)))))
+        pst = DiskArrays.pad(st, (; X=(2, 3), Y=(40, 50)); fill=1.0)
+        @test size(p) == size(pst) == (105, 190, 2)
+        @test dims(p) == dims(pst) == map(DimensionalData.format, (X(-1.0:100.0), Y(collect(-30:10:1050); span=Regular(10)), Z(NoLookup(Base.OneTo(2)))))
         @test sum(p) ≈ sum(da) + prod(size(p)) - prod(size(da))
+        maplayers(pst) do A
+            @test sum(A) ≈ sum(da) + prod(size(A)) - prod(size(da))
+        end
     end
-
 end

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -109,8 +109,11 @@ end
     @testset "pad" begin
         p = DiskArrays.pad(da, (; X=(2, 3), Y=(40, 50)); fill=1.0)
         pst = DiskArrays.pad(st, (; X=(2, 3), Y=(40, 50)); fill=1.0)
-        @test size(p) == size(pst) == (105, 190, 2)
-        @test dims(p) == dims(pst) == map(DimensionalData.format, (X(-1.0:100.0), Y(collect(-30:10:1050); span=Regular(10)), Z(NoLookup(Base.OneTo(2)))))
+        dims(p)
+        @test size(p) == size(pst) == 
+            map(length, dims(p)) == map(length, dims(pst)) == 
+            size(da) .+ (5, 90, 0) == (105, 190, 2)
+        @test dims(p) == dims(pst) == map(DimensionalData.format, (X(-1.0:103.0), Y(collect(-390:10:1500); span=Regular(10)), Z(NoLookup(Base.OneTo(2)))))
         @test sum(p) ≈ sum(da) + prod(size(p)) - prod(size(da))
         maplayers(pst) do A
             @test sum(A) ≈ sum(da) + prod(size(A)) - prod(size(da))


### PR DESCRIPTION
This PR extends the new `DiskArrays.pad` for all `AbstractDimArray` so we can also extend regular dimensions at the same time we pad the array.

I'm not sure what should happen for non DiskArrays parent arrays - currently they will work but be slow. Using PaddedViews.j instead is an option when `!isdisk(parent(dimarray))`.

See DiskArrays PR: https://github.com/JuliaIO/DiskArrays.jl/pull/219