### PR TITLE
Make CondaPkg use MicroMamba in the tests

### DIFF
--- a/test/xarray.jl
+++ b/test/xarray.jl
@@ -1,4 +1,5 @@
 ENV["JULIA_CONDAPKG_ENV"] = "@dimensionaldata-tests"
+ENV["JULIA_CONDAPKG_BACKEND"] = "MicroMamba"
 
 using DimensionalData, Test, PythonCall
 import DimensionalData.Dimensions: NoLookup, NoMetadata


### PR DESCRIPTION
This is the default, it just seems to be required after the latest CondaPkg update.