### PR TITLE
Update codecov action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
-          fail_ci_if_error: false
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false


### PR DESCRIPTION
This should hopefully fix the uploading of the code coverage.
Currently the code coverage has not been updated for 3 months. 
I am not sure, whether you would have to setup a codecov token or you would have to install the codecov app. 
But let's first see, whether this just works. 