### PR TITLE
Add a mention of NaNStatistics support

### DIFF
--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -60,3 +60,10 @@ Provides tools to load and visualise astronomical images.
 [TimeseriesTools.jl](https://juliahub.com/ui/Packages/General/TimeseriesTools)
 Uses `DimArray` for time-series data.
 
+## NaNStatistics.jl
+
+Most functions in
+[NaNStatistics.jl](https://github.com/brenhinkeller/NaNStatistics.jl) support
+`DimArray`'s, see [the
+README](https://github.com/brenhinkeller/NaNStatistics.jl?tab=readme-ov-file#dimensionaldata-support)
+for details.


### PR DESCRIPTION
The latest release has an extension to support `DimArray`'s: https://github.com/brenhinkeller/NaNStatistics.jl/releases/tag/v0.6.48