### PR TITLE
Fix handling of keyword arguments in sort functions

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -176,11 +176,11 @@ end
 # These just return the parent for now
 function Base.sort(A::AbstractDimVector; kw...)
     newdims = (set(only(dims(A)), NoLookup()),)
-    newdata = sort(parent(A), kw...)
+    newdata = sort(parent(A); kw...)
     return rebuild(A, newdata, newdims)
 end
 function Base.sort(A::AbstractDimArray; dims, kw...)
-    newdata = sort(parent(A), dims=dimnum(A, dims), kw...)
+    newdata = sort(parent(A); dims=dimnum(A, dims), kw...)
     replacement_dims = map(DD.dims(A, _astuple(dims))) do d
         set(d, NoLookup())
     end
@@ -189,7 +189,7 @@ function Base.sort(A::AbstractDimArray; dims, kw...)
 end
 
 function Base.sortslices(A::AbstractDimArray; dims, kw...)
-    newdata = sortslices(parent(A), dims=dimnum(A, dims), kw...)
+    newdata = sortslices(parent(A); dims=dimnum(A, dims), kw...)
     replacement_dims = map(DD.dims(A, _astuple(dims))) do d
         set(d, NoLookup())
     end


### PR DESCRIPTION
Changing a comma to a semicolon makes a fine difference when splatting keyword arguments. Previously, `kw` was not given to `sort(::Matrix, ...)` as keyword arguments but as positional arguments in the form of pairs. Hence, code like
```julia
A = DimArray(rand(5, 5), (X, Y))
sortslices(A, dims = 1, by = sum)
```
to sort a `DimArray` by row-sum did not work before but works now.