### PR TITLE
Fix `map` mini piracy

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -105,10 +105,10 @@ end
 - There are less problems with type stability in `map` as we can just 
     take dims from the first, there are no length 1 dims.
 =#
-function Base.map(f, As::AbstractDimArray...)
-    comparedims(As...)
-    newdata = map(f, map(parent, As)...)
-    rebuild(first(As); data=newdata)
+function Base.map(f, A1::AbstractDimArray, As::AbstractDimArray...)
+    comparedims(A1, As...)
+    newdata = map(f, map(parent, (A1, As...))...)
+    return rebuild(A1; data=newdata)
 end
 
 

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -224,10 +224,6 @@ function Base.merge(
     merge(map(layers, (x1, x2, x3, xs...))...)
 end
 
-Base.map(f, s::AbstractDimStack) = error("Use maplayers(f, stack)) instead of map(f, stack)")
-Base.map(f, ::Union{AbstractDimStack,NamedTuple}, xs::Union{AbstractDimStack,NamedTuple}...) =
-    error("Use maplayers(f, stack, args...)) instead of map(f, stack, args...)")
-
 maplayers(f, s::AbstractDimStack) =
     _maybestack(s, unrolled_map(f, values(s)))
 function maplayers(


### PR DESCRIPTION
There was a tiny bit of piracy on `map` for both arrays and stacks.

Here fixed by removing the deprecated method, and the no args splat method for DimArray.

Piracy is now tested with Aqua.jl