### PR TITLE
Fix dimension ordering when converting a DataArray to DimArray

### DIFF
--- a/ext/DimensionalDataPythonCall.jl
+++ b/ext/DimensionalDataPythonCall.jl
@@ -53,20 +53,20 @@ function PythonCall.pyconvert(::Type{DimArray}, x::Py, d=nothing)
 
     dim_names = Symbol.(collect(x.dims))
     coord_names = Symbol.(collect(x.coords.keys()))
-    lookups_dict = Dict{Symbol, Any}()
-    for dim in dim_names
+    lookups_vec = Pair{Symbol, Any}[]
+    for dim in reverse(dim_names) # Iterate in reverse order because of row/col major
         if dim in coord_names
             coord = getproperty(x, dim).data
             coord_type = dtype2type(string(coord.dtype.name))
             coord_ndim = pyconvert(Int, coord.ndim)
 
-            lookups_dict[dim] = pyconvert(Array{coord_type, coord_ndim}, coord)
+            push!(lookups_vec, dim => pyconvert(Array{coord_type, coord_ndim}, coord))
         else
-            lookups_dict[dim] = NoLookup()
+            push!(lookups_vec, dim => NoLookup())
         end
     end
 
-    lookups = NamedTuple(lookups_dict)
+    lookups = NamedTuple(lookups_vec)
 
     metadata = pyconvert(Dict, x.attrs)
 

--- a/test/xarray.jl
+++ b/test/xarray.jl
@@ -38,6 +38,14 @@ x2 = xr.DataArray(data2,
 
     @test_throws ArgumentError pyconvert(DimArray, xr)
     @test pyconvert(DimArray, xr, 42) == 42
+
+    # Sanity test for higher-dimensional arrays
+    x3 = xr.DataArray(rand(2, 5, 5, 3),
+                      dims=("w", "x", "y", "z"),
+                      coords=Dict("w" => [1, 2], "z" => [1, 2, 3]))
+    y = pyconvert(DimArray, x3)
+    @test lookup(y, :w) == [1, 2]
+    @test lookup(y, :z) == [1, 2, 3]
 end
 
 @testset "Dataset to DimStack" begin


### PR DESCRIPTION
Previously the code would temporarily store the dimension => lookup mapping in a Dict, but that doesn't maintain insertion order. So later on it was possible for the DimArray to be created with the dimensions in the wrong order, which would cause an exception.

I think it would be good to get this in a release soon-ish since it's quite a serious bug, e.g. if a square matrix is being loaded then the dimensions could get applied in the wrong order and other cases may just fail.