### PR TITLE
Add support for zero-copy conversions from an xarray to a DimArray

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,3 +1,4 @@
 [deps]
 xarray = ""
 numpy = ""
+openssl = "<=julia"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.29.16"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -16,6 +15,7 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -70,10 +70,11 @@ InvertedIndices = "1"
 IteratorInterfaceExtensions = "1"
 JLArrays = "0.1"
 LinearAlgebra = "1"
-OffsetArrays = "1"
-OrderedCollections = "1"
 Makie = "0.20, 0.21, 0.22"
 NearestNeighbors = "0.4"
+OffsetArrays = "1"
+OpenSSL = "1.4.3"
+OrderedCollections = "1"
 Plots = "1"
 PrecompileTools = "1"
 PythonCall = "0.9"
@@ -110,6 +111,7 @@ ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+OpenSSL = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -120,33 +122,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = [
-    "AlgebraOfGraphics",
-    "Aqua",
-    "ArrayInterface",
-    "BenchmarkTools",
-    "CairoMakie",
-    "CategoricalArrays",
-    "ColorTypes",
-    "Combinatorics",
-    "CoordinateTransformations",
-    "DataFrames",
-    "DiskArrays",
-    "Distributions",
-    "Documenter",
-    "GPUArrays",
-    "ImageFiltering",
-    "ImageTransformations",
-    "JLArrays",
-    "NearestNeighbors",
-    "OffsetArrays",
-    "Plots",
-    "PythonCall",
-    "Random",
-    "SafeTestsets",
-    "StatsBase",
-    "StatsPlots",
-    "Test",
-    "Unitful"
-]
-
+test = ["AlgebraOfGraphics", "Aqua", "ArrayInterface", "BenchmarkTools", "CairoMakie", "CategoricalArrays", "ColorTypes", "Combinatorics", "CoordinateTransformations", "DataFrames", "DiskArrays", "Distributions", "Documenter", "GPUArrays", "ImageFiltering", "ImageTransformations", "JLArrays", "NearestNeighbors", "OffsetArrays", "OpenSSL", "Plots", "PythonCall", "Random", "SafeTestsets", "StatsBase", "StatsPlots", "Test", "Unitful"]

--- a/docs/src/xarray.md
+++ b/docs/src/xarray.md
@@ -14,13 +14,29 @@ converting these Xarray types to their DimensionalData equivalent:
 ```julia
 import PythonCall: pyconvert
 
+# By default this will share the underlying array
 my_dimarray = pyconvert(DimArray, my_dataarray)
 
 my_dimstack = pyconvert(DimStack, my_dataset)
 ```
 
-Note that:
-- The current implementation will make a copy of the underlying arrays.
+Here are some things to keep in mind when converting:
+- `pyconvert(DimArray, x)` is zero-copy by default, i.e. it will share the
+  underlying array with Python and register itself with Pythons GC to ensure
+  that the memory isn't garbage-collected prematurely. If you want to make a
+  copy you can call it like `pyconvert(DimArray, x; copy=true)`.
+- When doing a zero-copy conversion from `x` to `x_jl`, `parent(x_jl)` will be a
+  [PyArray](https://juliapy.github.io/PythonCall.jl/stable/pythoncall-reference/#PythonCall.Wrap.PyArray). In
+  most situations there should be no overhead from this but note that a
+  `PyArray` is not a `DenseArray` so some operations that dispatch on
+  `DenseArray` may not be performant, e.g. BLAS calls. See these issues for more
+  information:
+  - https://github.com/JuliaPy/PythonCall.jl/issues/319
+  - https://github.com/JuliaPy/PythonCall.jl/issues/182
+
+  When `copy=true`, `parent(x_jl)` will always be a standard `Array`. However,
+  we do not consider the type of parent array covered by semver so this may
+  change in the future.
 - Python stores arrays in row-major order whereas Julia stores them in
   column-major order, hence the dimensions on a converted `DimArray` will be in
   reverse order from the original `DataArray`. This is done to ensure that the

--- a/ext/DimensionalDataPythonCall.jl
+++ b/ext/DimensionalDataPythonCall.jl
@@ -61,4 +61,15 @@ function PythonCall.pyconvert(::Type{DimStack}, x::Py, d=nothing; copy=false)
     return DimStack(NamedTuple(arrays); metadata)
 end
 
+# Precompile main calls to pyconvert(::DimArray) with copy=true and copy=false
+precompile(Tuple{typeof(PythonCall.Core.pyconvert), Type{DimensionalData.DimArray{T, N, D, R, A, Na, Me} where Me where Na where A<:AbstractArray{T, N} where R<:Tuple where D<:Tuple where N where T}, PythonCall.Core.Py})
+precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:copy,), Tuple{Bool}}, typeof(PythonCall.Core.pyconvert), Type{DimensionalData.DimArray{T, N, D, R, A, Na, Me} where Me where Na where A<:AbstractArray{T, N} where R<:Tuple where D<:Tuple where N where T}, PythonCall.Core.Py})
+
+# Precompile lower-level conversion calls for common types and dimensions
+for T in (Int32, Int64, UInt32, UInt64, Float32, Float64)
+    for N in (1, 2, 3, 4, 5)
+        precompile(Tuple{typeof(PythonCall.Core.pyconvert), Type{Array{T, N}}, PythonCall.Core.Py})
+    end
+end
+
 end

--- a/ext/DimensionalDataPythonCall.jl
+++ b/ext/DimensionalDataPythonCall.jl
@@ -1,41 +1,12 @@
 module DimensionalDataPythonCall
 
 using DimensionalData
+import DimensionalData as DD
 import PythonCall
-import PythonCall: Py, pyis, pyconvert, pytype, pybuiltins
-import DimensionalData.Lookups: NoLookup
+import PythonCall: Py, PyArray, pyis, pyconvert, pytype, pybuiltins, pylen
 
-function dtype2type(dtype::String)
-    if dtype == "float16"
-        Float16
-    elseif dtype == "float32"
-        Float32
-    elseif dtype == "float64"
-        Float64
-    elseif dtype == "int8"
-        Int8
-    elseif dtype == "int16"
-        Int16
-    elseif dtype == "int32"
-        Int32
-    elseif dtype == "int64"
-        Int64
-    elseif dtype == "uint8"
-        UInt8
-    elseif dtype == "uint16"
-        UInt16
-    elseif dtype == "uint32"
-        UInt32
-    elseif dtype == "uint64"
-        UInt64
-    elseif dtype == "bool"
-        Bool
-    else
-        error("Unsupported dtype: '$dtype'")
-    end
-end
 
-function PythonCall.pyconvert(::Type{DimArray}, x::Py, d=nothing)
+function PythonCall.pyconvert(::Type{DimArray}, x::Py, d=nothing; copy=false)
     x_pytype = string(pytype(x).__name__)
     if x_pytype != "DataArray"
         if isnothing(d)
@@ -46,36 +17,30 @@ function PythonCall.pyconvert(::Type{DimArray}, x::Py, d=nothing)
     end
 
     # Transpose here so that the fast axis remains the same in the Julia array
-    data_npy = x.data.T
-    data_type = dtype2type(string(data_npy.dtype.name))
-    data_ndim = pyconvert(Int, data_npy.ndim)
-    data = pyconvert(Array{data_type, data_ndim}, data_npy)
+    data_py = PyArray(x.data.T; copy=false)
+    data = copy ? pyconvert(Array, data_py) : data_py
 
     dim_names = Symbol.(collect(x.dims))
     coord_names = Symbol.(collect(x.coords.keys()))
-    lookups_vec = Pair{Symbol, Any}[]
+    new_dims = Dim[]
     for dim in reverse(dim_names) # Iterate in reverse order because of row/col major
         if dim in coord_names
-            coord = getproperty(x, dim).data
-            coord_type = dtype2type(string(coord.dtype.name))
-            coord_ndim = pyconvert(Int, coord.ndim)
-
-            push!(lookups_vec, dim => pyconvert(Array{coord_type, coord_ndim}, coord))
+            coord_py = PyArray(getproperty(x, dim).data; copy=false)
+            coord = copy ? pyconvert(Array, coord_py) : coord_py
+            push!(new_dims, Dim{dim}(coord))
         else
-            push!(lookups_vec, dim => NoLookup())
+            push!(new_dims, Dim{dim}())
         end
     end
 
-    lookups = NamedTuple(lookups_vec)
+    metadata = pylen(x.attrs) == 0 ? DD.NoMetadata() : pyconvert(Dict, x.attrs)
 
-    metadata = pyconvert(Dict, x.attrs)
+    array_name = pyis(x.name, pybuiltins.None) ? DD.NoName() : string(x.name)
 
-    array_name = pyis(x.name, pybuiltins.None) ? nothing : string(x.name)
-
-    return DimArray(data, lookups; name=array_name, metadata)
+    return DimArray(data, Tuple(new_dims); name=array_name, metadata)
 end
 
-function PythonCall.pyconvert(::Type{DimStack}, x::Py, d=nothing)
+function PythonCall.pyconvert(::Type{DimStack}, x::Py, d=nothing; copy=false)
     x_pytype = string(pytype(x).__name__)
     if x_pytype != "Dataset"
         if isnothing(d)
@@ -88,7 +53,7 @@ function PythonCall.pyconvert(::Type{DimStack}, x::Py, d=nothing)
     variable_names = Symbol.(collect(x.data_vars.keys()))
     arrays = Dict{Symbol, DimArray}()
     for name in variable_names
-        arrays[name] = pyconvert(DimArray, getproperty(x, name))
+        arrays[name] = pyconvert(DimArray, getproperty(x, name); copy)
     end
 
     metadata = pyconvert(Dict, x.attrs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using DimensionalData, Test, Aqua, SafeTestsets
 
+# Dirty hack to ensure that PythonCall.jl doesn't attempt to load an
+# incompatible version of OpenSSL: load OpenSSL first.
+import OpenSSL
+
 @time @testset "Aqua" begin
     Aqua.test_ambiguities([DimensionalData, Base, Core])
     Aqua.test_unbound_args(DimensionalData)
@@ -37,6 +41,7 @@ end
 @time @safetestset "ecosystem" begin include("ecosystem.jl") end
 @time @safetestset "categorical" begin include("categorical.jl") end
 @time @safetestset "xarray" begin include("xarray.jl") end
+
 if Sys.islinux()
     # Unfortunately this can hang on other platforms.
     # Maybe ram use of all the plots on the small CI machine? idk

--- a/test/xarray.jl
+++ b/test/xarray.jl
@@ -1,6 +1,12 @@
 ENV["JULIA_CONDAPKG_ENV"] = "@dimensionaldata-tests"
 ENV["JULIA_CONDAPKG_BACKEND"] = "MicroMamba"
 
+# If you've already run the tests once to create the test Python environment,
+# you can comment out the lines above and uncomment the lines below. That will
+# re-use the environment without re-resolving it, which is a bit faster.
+# ENV["JULIA_PYTHONCALL_EXE"] = joinpath(Base.DEPOT_PATH[1], "conda_environments", "dimensionaldata-tests", "bin", "python")
+# ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
+
 using DimensionalData, Test, PythonCall
 import DimensionalData.Dimensions: NoLookup, NoMetadata
 
@@ -36,11 +42,21 @@ x2 = xr.DataArray(data2,
                               "pos" => 0.48,
                               "foo" => [1, 2, 3])
 
+    # Test the zero-copy support
+    y[1, 1] = 42f0
+    @test parent(y) isa PyArray
+    @test pyconvert(Float32, x[0, 0].item()) == 42f0
+
+    # Test copying
+    y_copy = pyconvert(DimArray, x; copy=true)
+    @test y == y_copy
+    @test parent(y_copy) isa Array
+
     @test_throws ArgumentError pyconvert(DimArray, xr)
     @test pyconvert(DimArray, xr, 42) == 42
 
     # Sanity test for higher-dimensional arrays
-    x3 = xr.DataArray(rand(2, 5, 5, 3),
+    x3 = xr.DataArray(np.random.rand(2, 5, 5, 3).astype(np.float32),
                       dims=("w", "x", "y", "z"),
                       coords=Dict("w" => [1, 2], "z" => [1, 2, 3]))
     y = pyconvert(DimArray, x3)


### PR DESCRIPTION
In the process I also refactored the code to rely on PythonCall more, which simplified it quite a lot. One thorny issue is that this could be considered a breaking change since the parent array type changed from `Array` to `PyArray`, which is not a `DenseArray` (mentioned in the new docs). But I feel that the parent array type is a pretty internal thing to change, and since in the worst case it won't break any existing code but just make it slower, maybe we can still put it in a patch release?