### PR TITLE
Enable individual indexing for merged lookups

### DIFF
--- a/src/Dimensions/coord.jl
+++ b/src/Dimensions/coord.jl
@@ -1,4 +1,4 @@
-struct CoordLookup{T,A<:AbstractVector{T},D,Me} <: Lookup{T,1}
+struct CoordLookup{T,A<:AbstractVector{T},D,Me} <: MultiDimensionalLookup{T}
     data::A
     dims::D
     metadata::Me

--- a/src/Dimensions/dimension.jl
+++ b/src/Dimensions/dimension.jl
@@ -309,6 +309,32 @@ function Extents.extent(ds::DimTuple, args...)
     return Extents.Extent{name(extent_dims)}(extent_bounds)
 end
 
+function _experimental_extent(ds::DimTuple)
+    regulardims = dims(ds, x -> !(lookup(x) isa MultiDimensionalLookup))    
+    regular_bounds = bounds.(regulardims)
+    regular_bounds_nt = NamedTuple{map(name, regulardims)}(regular_bounds)
+    
+    multidims = otherdims(ds, regulardims)
+    multidim_raw_bounds = bounds.(multidims) # we trust that bounds will give us a tuple of bounds one for each enclosed dimension
+    multidim_dims = combinedims(map(dims, multidims)...; length = false)
+    multidim_bounds = map(multidim_dims) do outdim
+        foldl(zip(multidims, multidim_raw_bounds); init = (nothing, nothing)) do (minval, maxval), (dim, bounds)
+            if hasdim(dim, outdim)
+                if isnothing(minval) && isnothing(maxval)
+                    bounds[dimnum(dim, outdim)]
+                else
+                    this_dim_bounds = bounds[dimnum(dim, outdim)]
+                    (min(minval, this_dim_bounds[1]), max(maxval, this_dim_bounds[2]))
+                end
+            else
+                (minval, maxval)
+            end
+        end
+    end
+    multidim_bounds_nt = NamedTuple{map(name, multidim_dims)}(multidim_bounds)
+    return merge(regular_bounds_nt, multidim_bounds_nt)
+end
+
 dims(extent::Extents.Extent{K}) where K = map(rebuild, name2dim(K), values(extent))
 dims(extent::Extents.Extent, ds) = dims(dims(extent), ds)
 

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -63,9 +63,6 @@ Convert a `Dimension` or `Selector` `I` to indices of `Int`, `AbstractArray` or 
     return map(dims, one_to_one_idxs) do dim, idx
         # Note that this loop iterates over `dims` so each multidim can only be encountered once
         if hasdim(multidims, dim)
-            if !(idx isa Colon)
-                error("I should be a Colon but I am not: dimension $(name(dim))\nGot\n$idx")
-            end
             dims2indices(dim, Dimensions.dims(I, Dimensions.dims(dim)))
         else
             idx

--- a/src/Dimensions/indexing.jl
+++ b/src/Dimensions/indexing.jl
@@ -45,10 +45,32 @@ Convert a `Dimension` or `Selector` `I` to indices of `Int`, `AbstractArray` or 
 @inline dims2indices(dims::DimTuple, ::Tuple{}) = ()
 # Otherwise attempt to convert dims to indices
 @inline function dims2indices(dims::DimTuple, I::DimTuple)
-    extradims = otherdims(I, dims)
-    length(extradims) > 0 && _extradimswarn(extradims)
+    extradims = otherdims(I, dims) # extra dims in the query, I
+    # Extract "multi dimensional" lookups like MergedLookup or Rasters' GeometryLookup
+    multidims = Dimensions.dims(otherdims(dims, I), x -> lookup(x) isa AbstractMergedLookup && !isempty(Dimensions.dims(x, I)))
     Isorted = Dimensions.sortdims(I, dims)
-    return split_alignments(dims2indices, unalligned_dims2indices, dims, Isorted) 
+    # Warn if any dims from I were not picked up by multidims
+    actuallyextradims = otherdims(extradims, x -> any(y -> hasdim(y, x), multidims)) # one way setdiff(extradims, multidims) essentially
+    length(actuallyextradims) > 0 && _extradimswarn(actuallyextradims)
+    # Run the query for the known one-to-one dimensions
+    one_to_one_idxs = split_alignments(dims2indices, unalligned_dims2indices, dims, Isorted) 
+    
+    # This is basically doing an Accessors.@set on the full_dim_structure
+    # one_to_one_idxs is capable of indexing the whole dataset, but 
+    # it doesn't know about the merged lookups.  This keeps all one-to-one
+    # things the same but injects the solutions to the merged lookups where
+    # available and appropriate.
+    return map(dims, one_to_one_idxs) do dim, idx
+        if dim in multidims
+            if !(idx isa Colon)
+                error("I should be a Colon but I am a $idx: dimension $(name(dim))")
+            end
+            # TODO: Unaligned dims are NOT supported in merged lookups!!!!!!!!!
+            dims2indices(dim, Dimensions.dims(I, Dimensions.dims(dim)))
+        else
+            idx
+        end
+    end
 end
 @inline dims2indices(dims::Tuple{}, ::Tuple{}) = ()
 

--- a/src/Dimensions/merged.jl
+++ b/src/Dimensions/merged.jl
@@ -1,3 +1,5 @@
+abstract type AbstractMergedLookup{T} <: Lookup{T,1} end
+
 """
     MergedLookup <: Lookup
 
@@ -18,7 +20,7 @@ A [`Lookup`](@ref) that holds multiple combined dimensions.
 - `metadata`: a `Dict` or `Metadata` object to attach dimension metadata.
 
 """
-struct MergedLookup{T,A<:AbstractVector{T},D,Me} <: Lookup{T,1}
+struct MergedLookup{T,A<:AbstractVector{T},D,Me} <: AbstractMergedLookup{T}
     data::A
     dims::D
     metadata::Me

--- a/src/Dimensions/merged.jl
+++ b/src/Dimensions/merged.jl
@@ -1,4 +1,4 @@
-abstract type AbstractMergedLookup{T} <: Lookup{T,1} end
+abstract type MultiDimensionalLookup{T} <: Lookup{T,1} end
 
 """
     MergedLookup <: Lookup
@@ -20,7 +20,7 @@ A [`Lookup`](@ref) that holds multiple combined dimensions.
 - `metadata`: a `Dict` or `Metadata` object to attach dimension metadata.
 
 """
-struct MergedLookup{T,A<:AbstractVector{T},D,Me} <: AbstractMergedLookup{T}
+struct MergedLookup{T,A<:AbstractVector{T},D,Me} <: MultiDimensionalLookup{T}
     data::A
     dims::D
     metadata::Me

--- a/src/Dimensions/merged.jl
+++ b/src/Dimensions/merged.jl
@@ -1,7 +1,7 @@
 abstract type MultiDimensionalLookup{T} <: Lookup{T,1} end
 
 """
-    MergedLookup <: Lookup
+    MergedLookup <: MultiDimensionalLookup <: Lookup
 
     MergedLookup(data, dims; [metadata])
 
@@ -10,12 +10,48 @@ A [`Lookup`](@ref) that holds multiple combined dimensions.
 `MergedLookup` can be indexed with [`Selector`](@ref)s like `At`, 
 `Between`, and `Where` although `Near` has undefined meaning.
 
-# Arguments
+## Examples
+The easiest way to create a `MergedLookup` is to use the `mergedims` function:
+
+```julia
+da = rand(X(1:3), Y(1:3), Ti(1:3))
+merged = mergedims(da, (X, Y) => :space)
+
+julia> merged = mergedims(da, (X, Y) => :space)
+┌ 3×9 DimArray{Float64, 2} ┐
+├──────────────────────────┴─────────────────────────────────────────────────────────────────────────────── dims ┐
+  ↓ Ti    Sampled{Int64} 1:3 ForwardOrdered Regular Points,
+  → space MergedLookup{Tuple{Int64, Int64}} [(1, 1), (2, 1), …, (2, 3), (3, 3)] ↓ X, → Y
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ↓ →   (1, 1)    (2, 1)   (3, 1)    (1, 2)    (2, 2)    (3, 2)    (1, 3)     (2, 3)     (3, 3)
+ ⋮                                           ⋮                                         
+ 3    0.832755  0.89284  0.184938  0.434221  0.552545  0.612124  0.0630973  0.0365063  0.103989
+```
+
+Then, you can index into the merged dimensions in two ways: by referring specifically to the merged dimension,
+```julia
+merged[space=1:2]
+merged[space=(X(At(1)), Y(At(2))), Ti(At(2))]
+```
+
+or by using the `Coord` type, which is able to infer the merged lookup from the dimension names:
+```julia
+merged[space=(X(At(1)), Y(At(2))), Ti(At(2))]
+```
+
+or by directly passing selectors for the merged dimensions:
+```julia
+merged[X(At(1)), Y(At(2)), Ti(At(2))] == merged[space=(X(At(1)), Y(At(2))), Ti(At(2))]
+```
+
+This allows quite a bit of very powerful behaviour!
+
+## Arguments
 
 - `data`: A `Vector` of `Tuple`.
 - `dims`: A `Tuple` of [`Dimension`](@ref) indicating the dimensions in the tuples in `data`.
 
-# Keywords
+## Keywords
 
 - `metadata`: a `Dict` or `Metadata` object to attach dimension metadata.
 

--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -77,6 +77,7 @@ function show_after(io::IO, mime, A::AbstractBasicDimArray)
     blockwidth = get(io, :blockwidth, 0)
     print_block_close(io, blockwidth)
     ndims(A) > 0 && println(io)
+    any(==(0), size(A)) && return
     print_array(io, mime, A)
 end
 

--- a/test/merged.jl
+++ b/test/merged.jl
@@ -14,6 +14,14 @@ da2 = DimArray((0.1:0.1:0.4) * (1:1:3)', (dim, Ti(1u"s":1u"s":3u"s")); metadata=
     @test da2[Coord(4), Ti(3)] ≈ 1.2
 end
 
+@testset "subdim indexing" begin
+    @test da[X(At(1))] == da[Coord(X(At(1)))]
+    @test da[X(At(1)), Y(At(1))] == da[Coord(X(At(1)), Y(At(1)))]
+    @test da[X(At(1)), Y(At(1)), Z(At(1))] == da[Coord(X(At(1)), Y(At(1)), Z(At(1)))]
+    @test da[Y(At(1)), Z(At(1))] == da[Coord(Y(At(1)), Z(At(1)))]
+    @test da[Z(At(4))] == da[Coord(Z(At(4)))]
+end
+
 @testset "merged selector indexing" begin
     @test da[Coord(:, :, :)] == [0.1, 0.2, 0.3, 0.4]
     @test da[Coord(Between(1, 5), :, At(4.0))] == [0.3, 0.4]
@@ -25,6 +33,7 @@ end
 
 @testset "merged dimension indexing" begin
     @test da[Coord(Z(At(1.0)), Y(Between(1, 3)))] == [0.1]
+    @test da[Coord(Z(At(1.0)), Y(Between(1, 3)))] == da[Z(At(1.0)), Y(Between(1, 3))]
 end
 
 @test index(da[Coord(:, Between(1, 2), :)], Coord) == [(1.0,1.0,1.0), (1.0,2.0,2.0)]
@@ -42,7 +51,9 @@ end
 
 @testset "merged indexing with intervals" begin
     @test da[Coord(Z(At(1.0)), Y(1..3))] == [0.1]
+    @test da[Z(At(1.0)), Y(1..3)] == [0.1]
     @test da2[Ti(At(1u"s")), Coord(X(At(1.0)), Y(At(3.0)), Z(At(4.0)))] == 0.4
+    @test da2[Ti(At(1u"s")), X(At(1.0)), Y(1..3)] == [0.1, 0.2, 0.3]
 end
 
 @testset "custom merged names" begin
@@ -51,6 +62,7 @@ end
     da = DimArray(A, (Dim{:var}(1:2), merged))
     @test da[var=2, mymerged=(Dim{:draw}(At(8)), Dim{:chain}(At(4)))] == 76
     @test da[var=1, mymerged=(draw=At(8), chain=At(1))] == 8 
+    @test da[var=1, draw=At(8), chain=At(1)] == 8 
 end
 
 @testset "show merged" begin
@@ -89,4 +101,11 @@ end
         @test all(a .== unmerged)
         @test all(a .== perm_unmerged)
     end
+end
+
+@testset "indexing with totally random dim on merged lookup still errors" begin
+    da = ones(X(1:10), Y(1:10), Dim{:random}(1:10))
+    merged = mergedims(da, (X, Y) => :space)
+    @test_throws ArgumentError da[Z(1)]
+
 end

--- a/test/merged.jl
+++ b/test/merged.jl
@@ -53,7 +53,7 @@ end
     @test da[Coord(Z(At(1.0)), Y(1..3))] == [0.1]
     @test da[Z(At(1.0)), Y(1..3)] == [0.1]
     @test da2[Ti(At(1u"s")), Coord(X(At(1.0)), Y(At(3.0)), Z(At(4.0)))] == 0.4
-    @test da2[Ti(At(1u"s")), X(At(1.0)), Y(1..3)] == [0.1, 0.2, 0.3]
+    @test da2[Ti(At(1u"s")), X(At(1.0)), Y(1..3)] == [0.1, 0.2, 0.4]
 end
 
 @testset "custom merged names" begin
@@ -106,6 +106,5 @@ end
 @testset "indexing with totally random dim on merged lookup still errors" begin
     da = ones(X(1:10), Y(1:10), Dim{:random}(1:10))
     merged = mergedims(da, (X, Y) => :space)
-    @test_throws ArgumentError da[Z(1)]
-
+    @test_warn "Z" merged[Z(1)]
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -190,6 +190,11 @@ end
     sv = sprint(show, MIME("text/plain"), D)
     @test occursin('a', sv) && occursin('b', sv)
     @test occursin("(1, 1)", sv) && occursin("(1, 2)", sv)
+
+    # Test trailing zero dimension
+    @test_nowarn sprint(show, MIME("text/plain"), ones(X(1), Y(1), Z(0)))
+    @test_nowarn sprint(show, MIME("text/plain"), ones(X(1), Y(0), Z(1)))
+    @test_nowarn sprint(show, MIME("text/plain"), ones(X(0), Y(0), Z(0)))
 end
 
 @testset "stack" begin


### PR DESCRIPTION
```julia
ds = rand(X(1:10), Y(1:10), Ti(1:10))
m = mergedims(ds, (X, Y) => :space)

m[X(At(1))]
```
previously threw an error, with this PR it just works

What this does is that it introduces a new AbstractMergedLookup supertype that requires that the lookup have dims.  this way we can find all lookups that might be secretly multidimensional (currently just merged lookup and geometry lookup) and pass all matching dims into them directly.  That gets us back a vector index like thing that we can replace the placeholder Colon with that we receive from the split_dims.

This enables geometry lookups in Rasters to work like this as well, and also selecting by extents, crop, etc.

This isn't actually breaking in any way so can be merged for a non breaking release, I think.

Needs tests and benchmarks to check that this does not impact the getindex time, ie it should just compile away