### PR TITLE
Fix missing Colorbar in Makie heatmap

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -165,7 +165,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
             end
             # Add a Colorbar for heatmaps and contourf
             # TODO: why not surface too?
-            if T isa Real && $(f1 in (:plot, :heatmap, :contourf)) 
+            if T <: Real && $(f1 in (:plot, :heatmap, :contourf))
                 Colorbar(p.figure[1, 2], p.plot;
                     label=DD.label(A), colorbarkw...
                 )

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -168,6 +168,7 @@ end
 
 @testset "Makie" begin
 
+    using Makie
     using CairoMakie: CairoMakie as M
     using ColorTypes
 
@@ -382,6 +383,19 @@ end
         f, a, p = M.heatmap(A2ab; axis = (; type = M.LScene, show_axis = false))
         @test a isa M.LScene
         @test isnothing(a.scene[M.OldAxis])
+    end
+
+    @testset "Colorbar support" begin
+        fig, ax, _ = M.plot(A2ab)
+        colorbars = filter(x -> x isa Colorbar, contents(fig.layout))
+        @test length(colorbars) == 1
+        @test colorbars[1].label[] == "stuff"
+
+        A2ab_unnamed = DimArray(A2ab.data, dims(A2ab))
+        fig, ax, _ = M.plot(A2ab_unnamed)
+        colorbars = filter(x -> x isa Colorbar, contents(fig.layout))
+        @test length(colorbars) == 1
+        @test colorbars[1].label[] == ""
     end
 end
 

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -168,7 +168,6 @@ end
 
 @testset "Makie" begin
 
-    using Makie
     using CairoMakie: CairoMakie as M
     using ColorTypes
 
@@ -387,13 +386,13 @@ end
 
     @testset "Colorbar support" begin
         fig, ax, _ = M.plot(A2ab)
-        colorbars = filter(x -> x isa Colorbar, contents(fig.layout))
+        colorbars = filter(x -> x isa Colorbar, fig.content)
         @test length(colorbars) == 1
         @test colorbars[1].label[] == "stuff"
 
         A2ab_unnamed = DimArray(A2ab.data, dims(A2ab))
         fig, ax, _ = M.plot(A2ab_unnamed)
-        colorbars = filter(x -> x isa Colorbar, contents(fig.layout))
+        colorbars = filter(x -> x isa Colorbar, fig.content)
         @test length(colorbars) == 1
         @test colorbars[1].label[] == ""
     end


### PR DESCRIPTION
This PR aims to add an otherwise always missing `Colorbar` to a Makie plot of an `DimMatrix`.
Shall we add a `Project.toml` to the test dir and add Makie for testing? See also #957.

```julia
using CairoMakie
using DimensionalData

xs = X(1:10)
ys = Y(1:20)
data = rand(xs, ys)
a = DimArray(data, (xs, ys); name="air_temperature")
p = plot(a)
    
cb = filter(x -> x isa Colorbar,p.figure.content)[1]
cb.label[] == "air_temperature"
```
![image](https://github.com/user-attachments/assets/97270e9e-855f-403d-96b3-35fae56fc34c)
