### PR TITLE
Remove deprecations

### DIFF
--- a/src/DimensionalData.jl
+++ b/src/DimensionalData.jl
@@ -71,8 +71,7 @@ export AbstractDimTable, DimTable
 
 export AbstractDimTree, DimTree, prune
 
-export DimIndices, DimSelectors, DimPoints, #= deprecated =# DimKeys
-
+export DimIndices, DimSelectors, DimPoints
 # getter methods
 export dims, refdims, metadata, name, lookup, bounds, val, layers
 

--- a/src/Lookups/utils.jl
+++ b/src/Lookups/utils.jl
@@ -111,8 +111,6 @@ end
 _order(A) = first(A) <= last(A) ? ForwardOrdered() : ReverseOrdered()
 _order(A::AbstractArray{<:IntervalSets.Interval}) = first(A).left <= last(A).left ? ForwardOrdered() : ReverseOrdered()
 
-@deprecate maybeshiftlocus maybeshiftlocus
-@deprecate shiftlocus shiftlocus
 
 # Remove objects of type T from a 
 Base.@assume_effects :foldable _remove(::Type{T}, x, xs...) where T = (x, _remove(T, xs...)...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -181,8 +181,6 @@ function _broadcast_dims_inner!(f, dest, As, od)
     return dest
 end
 
-@deprecate dimwise broadcast_dims
-@deprecate dimwise! broadcast_dims!
 
 # Get a tuple of unique keys for DimArrays. If they have the same
 # name we call them layerI.


### PR DESCRIPTION
These deprecations are already longer than a full minor version in the code. Therefore we should remove them. 

Closes #1006 .
The deprecations I found in #1006 have already been removed in the breaking branch. 