### PR TITLE
fix makie axis keywords

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -71,13 +71,17 @@ for (f1, f2) in _paired(:plot => :scatter, :scatter, :lines, :scatterlines, :sta
     """
     @eval begin
         @doc $docstring
-        function Makie.$f1(A::AbstractDimVector; axislegendkw=(;), axis=(;), attributes...)
+        function Makie.$f1(A::AbstractDimVector; 
+            axislegendkw=(;), axislegend=axislegendkw, axis=(;), attributes...
+        )
             args, merged_attributes = _pointbased1(A, attributes; axis)
             p = Makie.$f2(args...; merged_attributes...)
-            axislegend(p.axis; merge=false, unique=false, axislegendkw...)
+            Makie.axislegend(p.axis; merge=false, unique=false, axislegend...)
             return p
         end
-        function Makie.$f1!(ax, A::AbstractDimVector; axislegendkw=(;), attributes...)
+        function Makie.$f1!(ax, A::AbstractDimVector; 
+            axislegendkw=(;), attributes...
+        )
             args, merged_attributes = _pointbased1(A, attributes; set_axis_attributes=false)
             return Makie.$f2!(ax, args...; merged_attributes...)
         end
@@ -153,7 +157,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
                 haskey(axis, :scenekw) && (lscene_attrs[:scenekw] = axis[:scenekw])
                 haskey(axis, :show_axis) && (lscene_attrs[:show_axis] = axis[:show_axis])
                 # surface is an LScene so we cant pass some axis attributes
-                p = Makie.$f2(args...; axis=lscene_attrs, merged_attributes...)
+                p = Makie.$f2(args...; merged_attributes..., axis=lscene_attrs)
                 # And instead set axisnames manually
                 if p.axis isa Makie.LScene && !isnothing(p.axis.scene[Makie.OldAxis])
                     p.axis.scene[Makie.OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))
@@ -173,7 +177,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
             return p
         end
         function Makie.$f1!(ax, A::AbstractDimMatrix; 
-            x=nothing, y=nothing, colorbarkw=(;), colorbar=colorbarkw, attributes...
+            x=nothing, y=nothing, colorbarkw=(;), attributes...
         )
             replacements = _keywords2dimpairs(x, y)
             _, _, args, _ = _surface2(A, $f2, attributes, replacements)
@@ -181,7 +185,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
             return Makie.$f2!(ax, args...; attributes...)
         end
         function Makie.$f1!(axis, A::Observable{<:AbstractDimMatrix};
-            x=nothing, y=nothing, colorbarkw=(;), colorbar=colorbarkw, attributes...
+            x=nothing, y=nothing, colorbarkw=(;), attributes...
         )
             replacements = _keywords2dimpairs(x,y)
             args =  lift(x->_surface2(x, $f2, attributes, replacements)[3], A)
@@ -201,12 +205,6 @@ function _surface2(A, plotfunc, attributes, replacements; axis=(;))
     # We define conversions by trait for all of the explicitly overridden functions,
     # so we can just use the trait here.
     args = Makie.convert_arguments(PTrait, A2)
-
-    # if status === true
-    #     args = converted
-    # else
-    #     args = Makie.convert_arguments(P, converted...)
-    # end
 
     # Plot attribute generation
     dx, dy = DD.dims(A2)
@@ -285,7 +283,7 @@ Plot a 2-dimensional `AbstractDimArray` with `Makie.series`.
 $(_labeldim_detection_doc(series))
 """
 function Makie.series(A::AbstractDimMatrix; 
-    color=:lighttest, axislegendkw=(;), axis=(;), labeldim=nothing, attributes...,
+    color=:lighttest, axislegendkw=(;), axislegend=axislegendkw, axis=(;), labeldim=nothing, attributes...,
 )
     args, merged_attributes = _series(A, attributes, labeldim)
 
@@ -296,11 +294,11 @@ function Makie.series(A::AbstractDimMatrix;
     else
         Makie.series(args...; axis, color, merged_attributes...)
     end
-    axislegend(p.axis; merge=true, unique=false, axislegendkw...)
+    Makie.axislegend(p.axis; merge=true, unique=false, axislegend...)
     return p
 end
 function Makie.series!(axis, A::AbstractDimMatrix; 
-    axislegendkw=(;), axislegend=axislegendkw, labeldim=nothing, attributes...
+    axislegendkw=(;), labeldim=nothing, attributes...
 )
     args, _ = _series(A, attributes, labeldim)
     return Makie.series!(axis, args...; attributes...)

--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -12,7 +12,7 @@ _paired(args...) = map(x -> x isa Pair ? x : x => x, args)
 # Shared docstrings: keep things consistent.
 
 const AXISLEGENDKW_DOC = """
-- `axislegendkw`: attributes to pass to `axislegend`.
+- `axislegend`: attributes to pass to `axislegend`.
 """
 _keyword_heading_doc(f) = """
 # Keywords
@@ -46,7 +46,7 @@ $(_keyword_heading_doc(f))
 function _maybe_colorbar_doc(f) 
     if f in (:heatmap, :contourf)
         """
-        - `colorbarkw`: keywords to pass to `Makie.Colorbar`.
+        - `colorbar`: keywords to pass to `Makie.Colorbar`.
         """
     else
         ""
@@ -71,10 +71,9 @@ for (f1, f2) in _paired(:plot => :scatter, :scatter, :lines, :scatterlines, :sta
     """
     @eval begin
         @doc $docstring
-        function Makie.$f1(A::AbstractDimVector; axislegendkw=(;), axis = (;), figure = (;), attributes...)
-            args, merged_attributes = _pointbased1(A, attributes)
-            axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
-            p = Makie.$f2(args...; axis = axis_kw, figure = figure_kw, merged_attributes...)
+        function Makie.$f1(A::AbstractDimVector; axislegendkw=(;), axis=(;), attributes...)
+            args, merged_attributes = _pointbased1(A, attributes; axis)
+            p = Makie.$f2(args...; merged_attributes...)
             axislegend(p.axis; merge=false, unique=false, axislegendkw...)
             return p
         end
@@ -85,7 +84,7 @@ for (f1, f2) in _paired(:plot => :scatter, :scatter, :lines, :scatterlines, :sta
     end
 end
 
-function _pointbased1(A, attributes; set_axis_attributes=true)
+function _pointbased1(A, attributes; set_axis_attributes=true, axis=(;))
     # Array/Dimension manipulation
     A1 = _prepare_for_makie(A)
     lookup_attributes, newdims = _split_attributes(A1)
@@ -99,6 +98,7 @@ function _pointbased1(A, attributes; set_axis_attributes=true)
                 xlabel=string(label(dims(A, 1))), 
                 ylabel=DD.label(A),
                 title=DD.refdims_title(A),
+                axis...
             ),
         )
     else
@@ -131,15 +131,14 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
     @eval begin
         @doc $docstring
         function Makie.$f1(A::AbstractDimMatrix{T}; 
-            x=nothing, y=nothing, colorbarkw=(;), axis = (;), figure = (;), attributes...
+            # colorbarkw is deprecated for colorbar
+            x=nothing, y=nothing, colorbarkw=(;), colorbar=colorbarkw, axis=(;), attributes...
         ) where T
             replacements = _keywords2dimpairs(x, y)
-            A1, A2, args, merged_attributes = _surface2(A, $f2, attributes, replacements)
+            A1, A2, args, merged_attributes = _surface2(A, $f2, attributes, replacements; axis)
 
-            axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
-
-            axis_type = if haskey(axis_kw, :type)
-                to_value(axis_kw[:type])
+            axis_type = if haskey(axis, :type)
+                to_value(axis[:type])
             else
                 Makie.args_preferred_axis(Makie.Plot{$f2}, args...)
             end
@@ -151,30 +150,30 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
                 # or filter out shared attributes from axis_kw somehow.
                 lscene_attrs = Dict{Symbol, Any}()
                 lscene_attrs[:type] = axis_type
-                haskey(axis_kw, :scenekw) && (lscene_attrs[:scenekw] = axis_kw[:scenekw])
-                haskey(axis_kw, :show_axis) && (lscene_attrs[:show_axis] = axis_kw[:show_axis])
+                haskey(axis, :scenekw) && (lscene_attrs[:scenekw] = axis[:scenekw])
+                haskey(axis, :show_axis) && (lscene_attrs[:show_axis] = axis[:show_axis])
                 # surface is an LScene so we cant pass some axis attributes
-                p = Makie.$f2(args...; figure = figure_kw, axis = lscene_attrs, merged_attributes...)
+                p = Makie.$f2(args...; axis=lscene_attrs, merged_attributes...)
                 # And instead set axisnames manually
                 if p.axis isa Makie.LScene && !isnothing(p.axis.scene[Makie.OldAxis])
                     p.axis.scene[Makie.OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))
                 end
                 p
             else # axis_type isa Nothing, axis_type isa Makie.Axis or GeoAxis or similar
-                Makie.$f2(args...; axis = axis_kw, figure = figure_kw, merged_attributes...)
+                Makie.$f2(args...; axis, merged_attributes...)
             end
             # Add a Colorbar for heatmaps and contourf
             # TODO: why not surface too?
             if T <: Real && $(f1 in (:plot, :heatmap, :contourf))
                 Colorbar(p.figure[1, 2], p.plot;
-                    label=DD.label(A), colorbarkw...
+                    label=DD.label(A), colorbar...
                 )
             end
             p
             return p
         end
         function Makie.$f1!(ax, A::AbstractDimMatrix; 
-            x=nothing, y=nothing, colorbarkw=(;), attributes...
+            x=nothing, y=nothing, colorbarkw=(;), colorbar=colorbarkw, attributes...
         )
             replacements = _keywords2dimpairs(x, y)
             _, _, args, _ = _surface2(A, $f2, attributes, replacements)
@@ -182,7 +181,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
             return Makie.$f2!(ax, args...; attributes...)
         end
         function Makie.$f1!(axis, A::Observable{<:AbstractDimMatrix};
-            x=nothing, y=nothing, colorbarkw=(;), attributes...
+            x=nothing, y=nothing, colorbarkw=(;), colorbar=colorbarkw, attributes...
         )
             replacements = _keywords2dimpairs(x,y)
             args =  lift(x->_surface2(x, $f2, attributes, replacements)[3], A)
@@ -192,7 +191,7 @@ for (f1, f2) in _paired(:plot => :heatmap, :heatmap, :image, :contour, :contourf
     end
 end
 
-function _surface2(A, plotfunc, attributes, replacements)
+function _surface2(A, plotfunc, attributes, replacements; axis=(;))
     # Array/Dimension manipulation
     A1 = _prepare_for_makie(A, replacements)
     lookup_attributes, newdims = _split_attributes(A1)
@@ -209,8 +208,6 @@ function _surface2(A, plotfunc, attributes, replacements)
     #     args = Makie.convert_arguments(P, converted...)
     # end
 
-
-
     # Plot attribute generation
     dx, dy = DD.dims(A2)
     user_attributes = Makie.Attributes(; attributes...)
@@ -219,6 +216,7 @@ function _surface2(A, plotfunc, attributes, replacements)
             xlabel=DD.label(dx),
             ylabel=DD.label(dy),
             title=DD.refdims_title(A),
+            axis...
         ),
     )
     merged_attributes = merge(user_attributes, plot_attributes, lookup_attributes)
@@ -241,17 +239,20 @@ for (f1, f2) in _paired(:plot => :volume, :volume, :volumeslices)
     """
     @eval begin
         @doc $docstring
-        function Makie.$f1(A::AbstractDimArray{<:Any,3}; x=nothing, y=nothing, z=nothing, axis = (;), figure = (;), attributes...)
+        function Makie.$f1(A::AbstractDimArray{<:Any,3}; 
+            x=nothing, y=nothing, z=nothing, axis=(;), attributes...
+        )
             replacements = _keywords2dimpairs(x, y, z)
-            A1, A2, args, merged_attributes = _volume3(A, $f2, attributes, replacements)
-            axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
-            p = Makie.$f2(args...; axis = axis_kw, figure = figure_kw, merged_attributes...)
+            A1, A2, args, merged_attributes = _volume3(A, $f2, attributes, replacements; axis)
+            p = Makie.$f2(args...; merged_attributes...)
             if p.axis isa LScene
                 p.axis.scene[OldAxis][:names, :axisnames] = map(DD.label, DD.dims(A2))
             end
             return p
         end
-        function Makie.$f1!(ax, A::AbstractDimArray{<:Any,3}; x=nothing, y=nothing, z=nothing, attributes...)
+        function Makie.$f1!(ax, A::AbstractDimArray{<:Any,3}; 
+            x=nothing, y=nothing, z=nothing, attributes...
+        )
             replacements = _keywords2dimpairs(x, y, z)
             _, _, args, _ = _volume3(A, $f2, attributes, replacements)
             return Makie.$f2!(ax, args...; attributes...)
@@ -259,7 +260,7 @@ for (f1, f2) in _paired(:plot => :volume, :volume, :volumeslices)
     end
 end
 
-function _volume3(A, plotfunc, attributes, replacements)
+function _volume3(A, plotfunc, attributes, replacements; axis=(;))
     # Array/Dimension manipulation
     A1 = _prepare_for_makie(A, replacements)
     _, newdims = _split_attributes(A1)
@@ -268,9 +269,7 @@ function _volume3(A, plotfunc, attributes, replacements)
 
     # Plot attribute generation
     user_attributes = Makie.Attributes(; attributes...)
-    plot_attributes = Makie.Attributes(; 
-        # axis=(; cant actually set much here for LScene)
-    )
+    plot_attributes = Makie.Attributes(; axis)
     merged_attributes = merge(user_attributes, plot_attributes)
 
     return A1, A2, args, merged_attributes
@@ -286,28 +285,28 @@ Plot a 2-dimensional `AbstractDimArray` with `Makie.series`.
 $(_labeldim_detection_doc(series))
 """
 function Makie.series(A::AbstractDimMatrix; 
-    color=:lighttest, axislegendkw=(;), axis = (;), figure = (;), labeldim=nothing, attributes...,
+    color=:lighttest, axislegendkw=(;), axis=(;), labeldim=nothing, attributes...,
 )
     args, merged_attributes = _series(A, attributes, labeldim)
 
-    axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
-
     n = size(last(args), 1)
     p = if n > 7
-            color = resample_cmap(color, n) 
-            Makie.series(args...; axis = axis_kw, figure = figure_kw, color, merged_attributes...)
-        else
-            Makie.series(args...; axis = axis_kw, figure = figure_kw, color, merged_attributes...)
-        end
+        color = resample_cmap(color, n) 
+        Makie.series(args...; axis, color, merged_attributes...)
+    else
+        Makie.series(args...; axis, color, merged_attributes...)
+    end
     axislegend(p.axis; merge=true, unique=false, axislegendkw...)
     return p
 end
-function Makie.series!(axis, A::AbstractDimMatrix; axislegendkw=(;), labeldim=nothing, attributes...)
+function Makie.series!(axis, A::AbstractDimMatrix; 
+    axislegendkw=(;), axislegend=axislegendkw, labeldim=nothing, attributes...
+)
     args, _ = _series(A, attributes, labeldim)
     return Makie.series!(axis, args...; attributes...)
 end
 
-function _series(A, attributes, labeldim)
+function _series(A, attributes, labeldim; axis=(;))
     # Array/Dimension manipulation
     categoricaldim = _categorical_or_dependent(A, labeldim)
     isnothing(categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups"))
@@ -324,6 +323,7 @@ function _series(A, attributes, labeldim)
             xlabel=DD.label(otherdim),
             ylabel=DD.label(A),
             title=DD.refdims_title(A),
+            axis...
         ),
     )
     merged_attributes = merge(user_attributes, lookup_attributes, plot_attributes)
@@ -345,10 +345,11 @@ for f in (:violin, :boxplot, :rainclouds)
     """
     @eval begin
         @doc $docstring
-        function Makie.$f(A::AbstractDimMatrix; labeldim=nothing, axis = (;), figure = (;), attributes...)
-            args, merged_attributes = _boxplotlike(A, attributes, labeldim)
-            axis_kw, figure_kw = _handle_axis_figure_attrs(merged_attributes, axis, figure)
-            return Makie.$f(args...; axis = axis_kw, figure = figure_kw, merged_attributes...)
+        function Makie.$f(A::AbstractDimMatrix; 
+            labeldim=nothing, axis=(;), attributes...
+        )
+            args, merged_attributes = _boxplotlike(A, attributes, labeldim; axis)
+            return Makie.$f(args...; merged_attributes...)
         end
         function Makie.$f!(ax, A::AbstractDimMatrix; labeldim=nothing, attributes...)
             args, _ = _boxplotlike(A, attributes, labeldim)
@@ -357,7 +358,7 @@ for f in (:violin, :boxplot, :rainclouds)
     end
 end
 
-function _boxplotlike(A, attributes, labeldim)
+function _boxplotlike(A, attributes, labeldim; axis=(;))
     # Array/Dimension manipulation
     categoricaldim = _categorical_or_dependent(A, labeldim)
     categoricallookup = lookup(categoricaldim)
@@ -376,6 +377,7 @@ function _boxplotlike(A, attributes, labeldim)
             xtickformat=I -> map(string, categoricallookup[map(Int, I)]),
             ylabel=DD.label(A),
             title=DD.refdims_title(A),
+            axis...
         ),
     )
     merged_attributes = merge(user_attributes, plot_attributes)
@@ -457,9 +459,9 @@ end
 function Makie.convert_arguments(t::Makie.VolumeLike, A::AbstractDimArray{<:Any,3})
     A1 = _prepare_for_makie(A)
     xl, yl, zl = lookup(A1)
-    _check_regular_or_categorical_sampling(xl; axis = :x, conversiontrait = t)
-    _check_regular_or_categorical_sampling(yl; axis = :y, conversiontrait = t)
-    _check_regular_or_categorical_sampling(zl; axis = :z, conversiontrait = t)
+    _check_regular_or_categorical_sampling(xl; axis=:x, conversiontrait=t)
+    _check_regular_or_categorical_sampling(yl; axis=:y, conversiontrait=t)
+    _check_regular_or_categorical_sampling(zl; axis=:z, conversiontrait=t)
     xs, ys, zs = map(_lookup_to_interval, (xl, yl, zl))
     return xs, ys, zs, last(Makie.convert_arguments(t, parent(A1)))
 end
@@ -572,17 +574,6 @@ end
 function _split_attributes(dim::Dimension)
     attributes, dims = _split_attributes((dim,))
     return attributes, dims[1]
-end
-
-function _handle_axis_figure_attrs(merged_attributes, axis, figure)
-    akw = haskey(merged_attributes, :axis) ? pop!(merged_attributes, :axis)[] : Attributes()
-    fkw = haskey(merged_attributes, :figure) ? pop!(merged_attributes, :figure)[] : Attributes()
-    axis_kw = merge(akw, Attributes(axis)).attributes |> Dict{Symbol, Any} # to get a dict
-    if haskey(axis_kw, :type)
-        axis_kw[:type] = axis_kw[:type][]
-    end
-    figure_kw = merge(fkw, Attributes(figure)).attributes |> Dict{Symbol, Any} # to get a dict
-    return axis_kw, figure_kw
 end
 
 function _prepare_for_makie(A, replacements=())

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -166,7 +166,7 @@ end
 end
 
 
-@testset "Makie" begin
+# @testset "Makie" begin
 
     using CairoMakie: CairoMakie as M
     using ColorTypes
@@ -291,8 +291,6 @@ end
 
     fig, ax, _ = M.surface(A2)
     M.surface!(ax, A2)
-    fig, ax, _ = M.surface(A2u)
-    M.surface!(ax, A2u)
     fig, ax, _ = M.surface(A2ui)
     M.surface!(ax, A2ui)
     # Broken with missing
@@ -339,7 +337,7 @@ end
     M.series!(ax, A2ab; labeldim=:a)
 
     fig, ax, _ = M.series(A2ab; labeldim=:b)
-    # M.series!(ax, A2ab;labeldim=:b)
+    # M.series!(ax, A2ab; labeldim=:b)
 
     # 3d, all these work with GLMakie
     A3 = rand(X(7), Z(10), Y(5))
@@ -374,28 +372,27 @@ end
     # x/y/z can be specified
     A3abc = DimArray(rand(10, 10, 7), (:a, :b, :c); name=:stuff)
     fig, ax, _ = M.volume(A3abc; x=:c)
-    # fig, ax, _ = M.volumeslices(A3abc; x=:c)
-    # fig, ax, _ = M.volumeslices(A3abc; z=:a)
-    # M.volumeslices!(ax, A3abc;z=:a)
+    fig, ax, _ = M.volumeslices(A3abc; x=:c)
+    fig, ax, _ = M.volumeslices(A3abc; z=:a)
+    M.volumeslices!(ax, A3abc; z=:a)
 
-    @testset "LScene support" begin
-        f, a, p = M.heatmap(A2ab; axis = (; type = M.LScene, show_axis = false))
-        @test a isa M.LScene
-        @test isnothing(a.scene[M.OldAxis])
-    end
+    "LScene support"
+    f, a, p = M.heatmap(A2ab; axis=(; type=M.LScene, show_axis=false))
+    @test a isa M.LScene
+    @test isnothing(a.scene[M.OldAxis])
 
-    @testset "Colorbar support" begin
-        fig, ax, _ = M.plot(A2ab)
-        colorbars = filter(x -> x isa M.Colorbar, fig.content)
-        @test length(colorbars) == 1
-        @test colorbars[1].label[] == "stuff"
+    "Colorbar support"
+    fig, ax, _ = M.plot(A2ab; colorbar=(; width=50))
+    colorbars = filter(x -> x isa M.Colorbar, fig.content)
+    @test length(colorbars) == 1
+    @test colorbars[1].label[] == "stuff"
+    @test colorbars[1].width[] == 50
 
-        A2ab_unnamed = DimArray(A2ab.data, dims(A2ab))
-        fig, ax, _ = M.plot(A2ab_unnamed)
-        colorbars = filter(x -> x isa M.Colorbar, fig.content)
-        @test length(colorbars) == 1
-        @test colorbars[1].label[] == ""
-    end
+    A2ab_unnamed = DimArray(A2ab.data, dims(A2ab))
+    fig, ax, _ = M.plot(A2ab_unnamed)
+    colorbars = filter(x -> x isa M.Colorbar, fig.content)
+    @test length(colorbars) == 1
+    @test colorbars[1].label[] == ""
 end
 
 @testset "AlgebraOfGraphics" begin

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -166,7 +166,7 @@ end
 end
 
 
-# @testset "Makie" begin
+@testset "Makie" begin
 
     using CairoMakie: CairoMakie as M
     using ColorTypes


### PR DESCRIPTION
Remove a bunch of complexity and makes `axis=(; title="foo")` and similar work.

Closes #929

(at the same time I renamed colorbarkw to colorbar to match the other keywords like axis. the previous colorbarkw will still work but is no longer documented)