### PR TITLE
fix depwarns

### DIFF
--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -1,4 +1,4 @@
-using DimensionalData.Dimensions: dimcolor, dimsymbols, print_dims
+using DimensionalData.Dimensions: dimcolor, dimsymbol, print_dims
 
 # Base show
 function Base.summary(io::IO, A::AbstractBasicDimArray{T,N}) where {T,N}
@@ -279,9 +279,9 @@ showarrows() = ShowWith(1.0, :print_arrows, :nothing)
 
 function Base.show(io::IO, mime::MIME"text/plain", x::ShowWith; kw...)
     if x.mode == :print_arrows
-        printstyled(io, dimsymbols(1); color=dimcolor(1))
+        printstyled(io, dimsymbol(1); color=dimcolor(1))
         print(io, " ")
-        printstyled(io, dimsymbols(2); color=dimcolor(2))
+        printstyled(io, dimsymbol(2); color=dimcolor(2))
     else
         s = sprint(show, mime, x.val; context=io, kw...)
         printstyled(io, s; color=x.color)


### PR DESCRIPTION
i got this warning when testing another package that depended on DD:

```julia
┌ DimensionalData
│  ┌ Warning: `dimsymbols(x)` is deprecated, use `dimsymbol(x)` instead.
│  │   caller = show(io::IOContext{IOBuffer}, mime::MIME{Symbol("text/plain")}, x::DimensionalData.ShowWith; kw::Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}) at show.jl:282
│  └ @ DimensionalData ~/.julia/dev/DimensionalData/src/array/show.jl:282
│  ┌ Warning: `dimsymbols(x)` is deprecated, use `dimsymbol(x)` instead.
│  │   caller = show(io::IOContext{IOBuffer}, mime::MIME{Symbol("text/plain")}, x::DimensionalData.ShowWith; kw::Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}) at show.jl:284
│  └ @ DimensionalData ~/.julia/dev/DimensionalData/src/array/show.jl:284
```