### PR TITLE
Do not rely on age-dependent name lookup to find the base type

### DIFF
--- a/src/Lookups/utils.jl
+++ b/src/Lookups/utils.jl
@@ -75,7 +75,7 @@ where `Dim{:x}` is different from `Dim{:y}`.
     if T isa Union
         T
     else
-        getfield(parentmodule(T), nameof(T))
+        Base.unwrap_unionall(T).name.wrapper
     end
 end
 


### PR DESCRIPTION
The information is in the type and does not require a name lookup to find

Fix #937