### PR TITLE
Test plot! functions without axis argument

### DIFF
--- a/test/makie.jl
+++ b/test/makie.jl
@@ -519,44 +519,57 @@ end
     @test org + wid >= 10
     fig, ax, _ = scatter(A1)
     scatter!(ax, A1)
+    scatter!(A1)
     fig, ax, _ = scatter(A1m)
     scatter!(ax, A1m)
+    scatter!(A1m)
     fig, ax, _ = lines(A1)
     lines!(ax, A1)
+    lines!(A1)
     fig, ax, _ = lines(A1u)
     # lines!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = lines(A1m)
     lines!(ax, A1m)
+    lines!(A1m)
     fig, ax, _ = scatterlines(A1)
     scatterlines!(ax, A1)
+    scatterlines!(A1)
     fig, ax, _ = scatterlines(A1u)
     # scatterlines!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = scatterlines(A1m)
     scatterlines!(ax, A1m)
+    scatterlines!(A1m)
     fig, ax, _ = stairs(A1)
     stairs!(ax, A1)
+    stairs!(A1)
     fig, ax, _ = stairs(A1u)
     # stairs!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = stairs(A1m)
     stairs!(ax, A1m)
+    stairs!(A1m)
     fig, ax, _ = stem(A1)
     stem!(ax, A1)
+    stem!(A1)
     fig, ax, _ = stem(A1u)
     # stem!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = stem(A1m)
     stem!(ax, A1m)
+    stem!(A1m)
     fig, ax, _ = barplot(A1)
     barplot!(ax, A1)
+    barplot!(A1)
     fig, ax, _ = barplot(A1u)
     # barplot!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = barplot(A1m)
     barplot!(ax, A1m)
+    barplot!(A1m)
     fig, ax, _ = waterfall(A1)
     waterfall!(ax, A1)
     fig, ax, _ = waterfall(A1u)
     # waterfall!(ax, A1u) # Does not work due to Makie limitation related with missing
     fig, ax, _ = waterfall(A1m)
     waterfall!(ax, A1m)
+    waterfall!(A1m)
 
     # 2d
     A2 = rand(X(10:10:100), Y(['a', 'b', 'c']))
@@ -569,8 +582,10 @@ end
 
     fig, ax, _ = plot(A2)
     plot!(ax, A2)
+    plot!(A2)
     fig, ax, _ = plot(A2m)
     plot!(ax, A2m)
+    plot!(A2m)
     # fig, ax, _ = plot(A2u) # Does not work due to Makie limitation
     # e.g. heatmap((1:10)m, (1:10)m, rand(10,10))
 
@@ -579,20 +594,28 @@ end
     # plot!(ax, A2ui)
     fig, ax, _ = plot(A2rgb)
     plot!(ax, A2rgb)
+    plot!(A2rgb)
     fig, ax, _ = heatmap(A2)
     heatmap!(ax, A2)
+    heatmap!(A2)
     fig, ax, _ = heatmap(A2m)
     heatmap!(ax, A2m)
+    heatmap!(A2m)
     fig, ax, _ = heatmap(A2rgb)
     heatmap!(ax, A2rgb)
+    heatmap!(A2rgb)
     fig, ax, _ = image(A2)
     image!(ax, A2)
+    image!(A2)
     fig, ax, _ = image(A2m)
     image!(ax, A2m)
+    image!(A2m)
     fig, ax, _ = image(A2rgb)
     image!(ax, A2rgb)
+    image!(A2rgb)
     fig, ax, _ = violin(A2r)
     violin!(ax, A2r)
+    violin!(A2r)
     @test_throws ArgumentError violin(A2m)
     @test_throws ArgumentError violin!(ax, A2m)
 
@@ -631,27 +654,36 @@ end
     A2ab = DimArray(rand(6, 10), (:a, :b); name=:stuff)
     fig, ax, _ = plot(A2ab)
     plot!(ax, A2ab)
+    plot!(A2ab)
     fig, ax, _ = contourf(A2ab; xdim=:a)
     contourf!(ax, A2ab, xdim=:a)
+    contourf!(A2ab, xdim=:a)
     fig, ax, _ = heatmap(A2ab; ydim=:b)
     heatmap!(ax, A2ab; ydim=:b)
+    heatmap!(A2ab, ydim=:b)
     fig, ax, _ = series(A2ab)
     series!(ax, A2ab)
+    series!(A2ab)
     fig, ax, _ = boxplot(A2ab)
     boxplot!(ax, A2ab)
+    boxplot!(A2ab)
     fig, ax, _ = violin(A2ab)
     violin!(ax, A2ab)
+    violin!(A2ab)
     # fig, ax, _ = rainclouds(A2ab) # Does not work due to Makie limitation
     # rainclouds!(ax, A2ab) # Does not work due to Makie limitation
     fig, ax, _ = surface(A2ab)
     surface!(ax, A2ab)
+    surface!(A2ab)
     fig, ax, _ = series(A2ab)
     series!(ax, A2ab)
+    series!(A2ab)
     fig, ax, _ = series(A2ab; labeldim=:a)
     series!(ax, A2ab; labeldim=:a)
+    series!(A2ab; labeldim=:a)
 
     fig, ax, _ = series(A2ab; labeldim=:b)
-    # series!(ax, A2ab; labeldim=:b)
+    # series!(ax, A2ab; labeldim=:b) This fails because the number of colors is not enough
 
     # 3d, all these work with GLMakie
     A3 = rand(X(7), Z(10), Y(5))
@@ -661,19 +693,21 @@ end
     A3rgb = rand(RGB, X(7), Z(10), Y(5))
     fig, ax, _ = volume(A3)
     volume!(ax, A3)
+    volume!(A3)
     fig, ax, _ = volume(A3m)
     volume!(ax, A3m)
-
+    volume!(A3m)
     # Units are broken in Makie ?
     # fig, ax, _ = volume(A3u)
     # volume!(ax, A3u)
 
     fig, ax, _ = volumeslices(A3)
     volumeslices!(ax, A3)
+    volumeslices!(A3)
     # Need to manually specify colorrange
     fig, ax, _ = volumeslices(A3m; colorrange=(1, 7))
     volumeslices!(ax, A3m; colorrange=(1, 7))
-
+    volumeslices!(A3m, colorrange=(1,7))
     # Unitful volumeslices broken in Makie ?
     # fig, ax, _ = volumeslices(A3u)
     # volumeslices!(ax, A3u)
@@ -689,6 +723,7 @@ end
     fig, ax, _ = volumeslices(A3abc; xdim=:c)
     fig, ax, _ = volumeslices(A3abc; zdim=:a)
     volumeslices!(ax, A3abc; zdim=:a)
+    volumeslices!(A3abc;zdim=:a)
 
     "LScene support"
     f, a, p = heatmap(A2ab; axis=(; type=LScene, show_axis=false))


### PR DESCRIPTION
This adds tests for the plot!(dimarray) functionality for all plotting types for which the function with an axis argument works. 

This superseeds #957. 
