### PR TITLE
Overload DiskArrays.mockchunks

### DIFF
--- a/ext/DimensionalDataDiskArraysExt.jl
+++ b/ext/DimensionalDataDiskArraysExt.jl
@@ -92,7 +92,7 @@ end
 end
 
 @static if isdefined(DiskArrays, :mockchunks)
-    DiskArrays.mockchunks(x::Union{AbstractDimStack,AbstractDimArray}, chunks) = 
+    DiskArrays.mockchunks(x::AbstractDimArray, chunks) = 
         modify(A -> DiskArrays.mockchunks(A, chunks), x)
 end
 

--- a/ext/DimensionalDataDiskArraysExt.jl
+++ b/ext/DimensionalDataDiskArraysExt.jl
@@ -91,4 +91,9 @@ end
     end
 end
 
+@static if isdefined(DiskArrays, :mockchunks)
+    DiskArrays.mockchunks(x::Union{AbstractDimStack,AbstractDimArray}, chunks) = 
+        modify(A -> DiskArrays.mockchunks(A, chunks), x)
+end
+
 end

--- a/test/ecosystem.jl
+++ b/test/ecosystem.jl
@@ -110,6 +110,8 @@ end
     @testset "isdisk" begin
         @test DiskArrays.isdisk(da)
         @test !DiskArrays.isdisk(rand(X(5), Y(4)))
+        @test DiskArrays.isdisk(st)
+        @test !DiskArrays.isdisk(DimStack((a=rand(X(5), Y(4)), b=rand(X(5)))))
     end
     @testset "pad" begin
         p = DiskArrays.pad(da, (; X=(2, 3), Y=(40, 50)); fill=1.0)
@@ -127,5 +129,10 @@ end
     @testset "PermutedDimsArray and PermutedDiskArray" begin
         @test parent(PermutedDimsArray(modify(Array, da), (3, 1, 2))) isa PermutedDimsArray
         @test parent(PermutedDimsArray(da, (3, 1, 2))) isa DiskArrays.PermutedDiskArray
+    end
+
+    @testset "mockchunks" begin
+        damockchunked = DiskArrays.mockchunks(da, DiskArrays.GridChunks(da, (20,20)))
+        @test size(DiskArrays.eachchunk(damockchunked)) == (5,5)
     end
 end


### PR DESCRIPTION
This is the replacement of #940 . This overloads the DiskArrays.mockchunks function to work on AbstractDimArray by  forwarding this to the parent. 
This removes the method for DimStacks because this would need a bit more thought whether it actually make sense to change the chunking structure of all underlying arrays. Especially for datasets that have different number of dimensions. 

