### PR TITLE
Breaking: skipmissing on a dimstack

### DIFF
--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -65,7 +65,7 @@ DimensionalData.AbstractDimTable
 DimTable
 ```
 
-# Group by methods
+## Group by methods
 
 For transforming DimensionalData objects:
 
@@ -82,7 +82,7 @@ months
 hours
 ```
 
-# Utility methods
+## Utility methods
 
 For transforming DimensionalData objects:
 
@@ -98,7 +98,7 @@ unmergedims
 reorder
 ```
 
-# Global lookup strictness settings
+## Global lookup strictness settings
 
 Control how strict DimensionalData when comparing [`Lookup`](@ref)s
 before doing broadcasts and matrix multipications.
@@ -115,12 +115,13 @@ DimensionalData.strict_matmul
 DimensionalData.strict_matmul!
 ```
 
-Base methods
+## Base methods
 
 ```@docs
 Base.cat
 Base.copy!
 Base.eachslice
+Base.skipmissing
 ```
 
 Most base methods work as expected, using `Dimension` wherever a `dims`

--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -547,3 +547,30 @@ function DimStack(st::AbstractDimStack;
 end
 
 layerdims(s::DimStack{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,Nothing}, name::Symbol) = dims(s)
+
+### Skipmissing on DimStacks
+"""
+    skipmissing(itr::AbstractDimStack)
+
+Returns an iterable over the elements in a `AbstractDimStack` object, skipping any values if any of the layers are missing.
+"""
+Base.skipmissing
+
+# Specialized dispatch of iterate to skip values if any layer is missing.
+function Base.iterate(itr::Base.SkipMissing{<:AbstractDimStack}, state...)
+    y = iterate(itr.x, state...)
+    y === nothing && return nothing
+    item, state = y
+    while any(map(ismissing, item)) # instead of ismissing(item)
+        y = iterate(itr.x, state)
+        y === nothing && return nothing
+        item, state = y
+    end
+    item, state
+end
+
+Base.eltype(::Type{Base.SkipMissing{T}}) where {T<:AbstractDimStack{<:Any, NT}} where NT =
+    _nonmissing_nt(NT)
+
+@generated _nonmissing_nt(NT::Type{<:NamedTuple{K,V}}) where {K,V} =
+    NamedTuple{K, Tuple{map(Base.nonmissingtype, V.parameters)...}}

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -397,3 +397,19 @@ end
     @test ds[Z = 1:2] == ds
 
 end
+
+@testset "skipmissing" begin
+    skips = skipmissing(s)
+    skips2 = skipmissing(mixed)
+    @test eltype(skips) === @NamedTuple{one::Float64, two::Float32, three::Int}
+    @test eltype(skips2) === @NamedTuple{one::Float64, two::Float32, extradim::Float64}
+    @test collect(skips) == vec(s)
+    @test collect(skips2) == vec(mixed)
+
+    da5 = DimArray([missing, 1], x)
+    s2 = DimStack((one = da1, two = da5))
+    @test eltype(skipmissing(s2)) === @NamedTuple{one::Float64, two::Int}
+    cs2 = collect(skipmissing(s2))
+    @test all(getindex.(cs2, :two) .== 1)
+    @test getindex.(cs2, :one) == da1[X=2]
+end


### PR DESCRIPTION
As I proposed over in https://github.com/rafaqz/Rasters.jl/issues/765#issuecomment-3061292962, this changes the behaviour of `skipmissing(dimstack)`.

Right now this is not really ever useful, because a dimstack iterates namedtuples, which can never be missing. This PR changes that behaviour to iterating over values where none of the layres/namedtuple fields are missing