### PR TITLE
Extension of AbstractFFTs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -64,6 +64,7 @@ DiskArrays = "0.3, 0.4"
 Distributions = "0.25"
 Documenter = "1"
 Extents = "0.1"
+FFTW = "1"
 GPUArrays = "10"
 ImageFiltering = "0.7"
 ImageTransformations = "0.10"
@@ -108,6 +109,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
@@ -125,4 +127,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["AlgebraOfGraphics", "Aqua", "ArrayInterface", "BenchmarkTools", "CairoMakie", "CategoricalArrays", "ColorTypes", "Combinatorics", "CoordinateTransformations", "DataFrames", "DiskArrays", "Distributions", "Documenter", "GPUArrays", "ImageFiltering", "ImageTransformations", "JLArrays", "NearestNeighbors", "OffsetArrays", "OpenSSL", "Plots", "PythonCall", "Random", "SafeTestsets", "StatsBase", "StatsPlots", "Test", "Unitful"]
+test = ["AlgebraOfGraphics", "Aqua", "ArrayInterface", "BenchmarkTools", "CairoMakie", "CategoricalArrays", "ColorTypes", "Combinatorics", "CoordinateTransformations", "DataFrames", "DiskArrays", "Distributions", "Documenter", "FFTW", "GPUArrays", "ImageFiltering", "ImageTransformations", "JLArrays", "NearestNeighbors", "OffsetArrays", "OpenSSL", "Plots", "PythonCall", "Random", "SafeTestsets", "StatsBase", "StatsPlots", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
@@ -34,6 +35,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [extensions]
+DimensionalDataAbstractFFTsExt = "AbstractFFTs"
 DimensionalDataAlgebraOfGraphicsExt = "AlgebraOfGraphics"
 DimensionalDataCategoricalArraysExt = "CategoricalArrays"
 DimensionalDataDiskArraysExt = "DiskArrays"
@@ -43,6 +45,7 @@ DimensionalDataPythonCall = "PythonCall"
 DimensionalDataStatsBase = "StatsBase"
 
 [compat]
+AbstractFFTs = "1"
 Adapt = "2, 3.0, 4"
 AlgebraOfGraphics = "0.8, 0.9, 0.10, 0.11"
 Aqua = "0.8"

--- a/ext/DimensionalDataAbstractFFTsExt.jl
+++ b/ext/DimensionalDataAbstractFFTsExt.jl
@@ -9,55 +9,90 @@ import LinearAlgebra: *
 
 const Inverse = 1
 const Forward = -1
+const RealFFT = -1
+const ComplexFFT = 1
 
-struct DDPlan{T, P<:AbstractFFTs.Plan, I,A} <: AbstractFFTs.Plan{T}
+struct DDPlan{T, I, F, P<:AbstractFFTs.Plan,A} <: AbstractFFTs.Plan{T}
     p::P
     temp::A
-    function DDPlan{I}(p::P, temp::A) where {I, P<:AbstractFFTs.Plan{T},A} where T
-        new{T, P, I, A}(p, temp)
+    function DDPlan{I,F}(p::P, temp::A) where {I, F, P<:AbstractFFTs.Plan{T},A} where T
+        new{T, I, F, P, A}(p, temp)
     end
 end
 
 AbstractFFTs.fftdims(plan::DDPlan) = AbstractFFTs.fftdims(plan.p)
+AbstractFFTs.output_size(plan::DDPlan) = AbstractFFTs.output_size(plan.p)
 Base.size(plan::DDPlan) = size(plan.p)
 
-is_inverse_transform(plan::DDPlan{<:Any, <:Any, Inverse}) = true
-is_inverse_transform(plan::DDPlan{<:Any, <:Any, Forward}) = false
+is_inverse_transform(plan::DDPlan{<:Any, Inverse}) = true
+is_inverse_transform(plan::DDPlan{<:Any, Forward}) = false
 
 function _step(lookup)
     if !DD.Lookups.isregular(lookup)
-        throw(ArgumentError("The spacing of the lookup along the fft dimension must be regular."))
+        throw(ArgumentError("The spacing of the lookup along the dimensions to which FFT will be applied must be regular."))
     end
     lookup[2] - lookup[1]
 end
 
-function _step(lookup::DD.Lookups.Sampled{<:Real, <:AbstractFFTs.Frequencies})
-    lookup[2]
+_step(lookup::DD.Dimensions.Dimension{<:AbstractFFTs.Frequencies}) = lookup[2]
+_step(lookup::DimensionalData.Dimensions.Dimension{<:DimensionalData.Dimensions.Lookups.Sampled{<:Any, <:Frequencies{<:Any}}}) = lookup[2]
+
+function _fftfreq(dd_lookup)
+    DD.basetypeof(dd_lookup)(fftfreq(length(dd_lookup), 1 / _step(dd_lookup)))
 end
 
-function _fftfreq_dd(::Type{P}, dd_lookup, is_fft_dim, is_first_fft_dim) where P
-    if is_fft_dim
-        if dd_lookup isa DD.Lookups.Sampled{<:Real, <:AbstractFFTs.Frequencies}
-            len = length(dd_lookup)
-            dx = 1 / _step(dd_lookup) / len
-            return range(-len / 2 * dx, step = dx, length = len)
-        else
-            return fftfreq(length(dd_lookup), 1 / _step(dd_lookup))
-        end
+function _ifftfreq(dd_lookup)
+    len = length(dd_lookup)
+    dx = 1 / _step(dd_lookup) / len
+    if isodd(len)
+        DD.basetypeof(dd_lookup)(range(-(len - 1) / 2 * dx, step = dx, length = len))
     else
-        return dd_lookup
+        DD.basetypeof(dd_lookup)(range(-len / 2 * dx, step = dx, length = len))
     end
 end
 
-function _fftfreq_dd(::Type{<:AbstractFFTs.Plan{<:Real}}, dd_lookup, is_fft_dim, is_first_fft_dim)
+function _rfftfreq(dd_lookup)
+    DD.basetypeof(dd_lookup)(rfftfreq(length(dd_lookup), 1 / _step(dd_lookup)))
+end
+
+function _irfftfreq(dd_lookup, len::Integer)
+    dx = 1 / _step(dd_lookup) / len
+    if isodd(len)
+        DD.basetypeof(dd_lookup)(range(-(len - 1) / 2 * dx, step = dx, length = len))
+    else
+        DD.basetypeof(dd_lookup)(range(-len / 2 * dx, step = dx, length = len))
+    end
+end
+
+function get_fft_frequencies_dim(::Type{<:DDPlan{<:Any, Forward, R}}, dd_lookup, is_fft_dim, is_first_fft_dim, len) where R
     if is_fft_dim
         if is_first_fft_dim
-            return rfftfreq(length(dd_lookup), 1 / _step(dd_lookup))
+            if R == RealFFT 
+                _rfftfreq(dd_lookup)
+            else
+                _fftfreq(dd_lookup)
+            end
         else
-            return fftfreq(length(dd_lookup), 1 / _step(dd_lookup))
+            _fftfreq(dd_lookup)
         end
     else
-        return dd_lookup
+        dd_lookup
+    end
+end
+
+function get_fft_frequencies_dim(::Type{<:DDPlan{<:Any, Inverse, R}}, dd_lookup, is_fft_dim, is_first_fft_dim, len) where R
+    if is_fft_dim
+        if is_first_fft_dim
+            if R == RealFFT 
+                _irfftfreq(dd_lookup, len)
+            else
+                _ifftfreq(dd_lookup)
+            end
+        else
+            _ifftfreq(dd_lookup)
+        end
+    else
+        dd_lookup
     end
 end
 
@@ -65,15 +100,14 @@ function get_freqs(plan::P, dd::DD.AbstractDimArray{<:Any, N}) where {P<:Abstrac
     fft_dims = AbstractFFTs.fftdims(plan)
     is_fft_dims = ntuple(i -> i in fft_dims, N)
     is_first_fft_dim = ntuple(i -> i == first(fft_dims), N)
-    freqs = ntuple(i -> _fftfreq_dd(P, lookup(dd, i), is_fft_dims[i], is_first_fft_dim[i]), N)
-    lookups = ntuple(i -> DD.basetypeof(dims(dd, i))(freqs[i]), N)
-    lookups
+    out_size = AbstractFFTs.output_size(plan)
+    ntuple(i -> get_fft_frequencies_dim(P, dims(dd, i), is_fft_dims[i], is_first_fft_dim[i], out_size[i]), N)
 end
 
 function get_scale_factor(plan::P, dd::DD.AbstractDimArray{<:Any, N}) where {P<:AbstractFFTs.Plan, N}
     fft_dims = AbstractFFTs.fftdims(plan)
     is_fft_dims = ntuple(i -> i in fft_dims, N)
-    steps_dd = ntuple(i -> is_fft_dims[i] ? _step(lookup(dd, i)) : 1, N)
+    steps_dd = ntuple(i -> is_fft_dims[i] ? _step(dims(dd, i)) : 1, N)
     prod(steps_dd)
 end
 
@@ -99,14 +133,12 @@ function LinearAlgebra.mul!(dd_out::DD.AbstractDimArray{<:Any, N}, plan::DDPlan,
         throw(ArgumentError("The lookups of the output and input DimensionalData must match."))
     end
     input_to_plan = if is_inverse_transform(plan)
-        @show "asda"
         copyto!(parent(plan.temp), parent(dd_in))
         correct_phase_reference!(plan.temp, plan, lookups_out, 1)
         plan.temp
     else
         dd_in
     end
-    @show plan.p
     LinearAlgebra.mul!(parent(dd_out), plan.p, parent(input_to_plan))
     if !is_inverse_transform(plan)
         correct_phase_reference!(dd_out, plan, lookup(dd_in), -1)
@@ -122,28 +154,37 @@ end
 
 for i in (:fft, :ifft, :rfft)
     eval(quote
-        function AbstractFFTs.$i(dd::AbstractDimArray{<:Any, N}, dims = 1:N; kwargs...) where N
+        function AbstractFFTs.$i(dd::AbstractDimArray{<:Any, N}, dims = ntuple(identity, N); kwargs...) where N
             plan = $(Symbol(:plan_, i))(dd, dims; kwargs...)
             plan * dd
         end
     end)
 end
 
-function AbstractFFTs.plan_fft(dd::AbstractDimArray{T, N}, dims = 1:N; kwargs...) where {T,N}
-    p = AbstractFFTs.plan_fft(parent(dd), dims; kwargs...)
-    s = get_scale_factor(p, dd)
-    DDPlan{Forward}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
-end
-function AbstractFFTs.plan_rfft(dd::AbstractDimArray{T, N}, dims = 1:N; kwargs...) where {N,T}
-    p = AbstractFFTs.plan_rfft(parent(dd), dims; kwargs...)
-    s = get_scale_factor(p, dd)
-    DDPlan{Forward}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
+function AbstractFFTs.irfft(dd::AbstractDimArray{<:Any, N}, len::Integer, dims = ntuple(identity, N); kwargs...) where N
+    plan = plan_irfft(dd, len, dims; kwargs...)
+    plan * dd
 end
 
-function AbstractFFTs.plan_ifft(dd::AbstractDimArray{<:Any, N}, dims = 1:N; kwargs...) where N
+
+function AbstractFFTs.plan_fft(dd::AbstractDimArray{T, N}, dd_dims = ntuple(identity, N); kwargs...) where {T,N}
+    dims = DD.dimnum(dd, dd_dims)
+    p = AbstractFFTs.plan_fft(parent(dd), dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Forward, ComplexFFT}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
+end
+function AbstractFFTs.plan_rfft(dd::AbstractDimArray{T, N}, dd_dims = ntuple(identity, N); kwargs...) where {N,T}
+    dims = DD.dimnum(dd, dd_dims)
+    p = AbstractFFTs.plan_rfft(parent(dd), dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Forward, RealFFT}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
+end
+
+function AbstractFFTs.plan_ifft(dd::AbstractDimArray{<:Any, N}, dd_dims = ntuple(identity, N); kwargs...) where N
+    dims = DD.dimnum(dd, dd_dims)
     p = AbstractFFTs.plan_ifft(parent(dd), dims; kwargs...)
     s = get_scale_factor(p, dd)
-    DDPlan{Inverse}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
+    DDPlan{Inverse, ComplexFFT}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
 end
 
 function AbstractFFTs.plan_inv(plan::DDPlan)
@@ -154,10 +195,11 @@ function LinearAlgebra.inv(plan::DDPlan)
     throw(ErrorException("The plan_inv function is not implemented yet for DDPlan. Use plan_ifft or plan_irfft instead."))
 end
 
-function AbstractFFTs.plan_irfft(dd::AbstractDimArray{<:Any, N}, len, dims = 1:N; kwargs...) where N
+function AbstractFFTs.plan_irfft(dd::AbstractDimArray{<:Any, N}, len::Integer, dd_dims = ntuple(identity, N); kwargs...) where N
+    dims = DD.dimnum(dd, dd_dims)
     p = AbstractFFTs.plan_irfft(parent(dd), len, dims; kwargs...)
     s = get_scale_factor(p, dd)
-    DDPlan{Inverse}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
+    DDPlan{Inverse, RealFFT}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
 end
 
 
@@ -173,7 +215,8 @@ for f in (:fftshift, :ifftshift)
                 return lookup
             end
         end
-        function AbstractFFTs.$f(dd::AbstractDimArray{<:Any, N}, dims = 1:N) where N
+        function AbstractFFTs.$f(dd::AbstractDimArray{<:Any, N}, dd_dims = ntuple(identity, N)) where N
+            dims = DD.dimnum(dd, dd_dims)
             is_fft_dims = ntuple(i -> i in dims, N)
             dims_dd = DD.dims(dd)
             DimArray($f(parent(dd), dims), ntuple(i -> $(Symbol(:apply_, f))(dims_dd[i], is_fft_dims[i]), N))

--- a/ext/DimensionalDataAbstractFFTsExt.jl
+++ b/ext/DimensionalDataAbstractFFTsExt.jl
@@ -145,7 +145,6 @@ function LinearAlgebra.mul!(dd_out::DD.AbstractDimArray{Tout, N}, plan::DDPlan{<
         dd_in
     end
 
-    
     T_in_val = Tin <: NotQuantity ? eltype(input_to_plan) : typeof(input_to_plan[1].val)
     T_out_val = Tout <: NotQuantity ? eltype(dd_out) : typeof(dd_out[1].val)
 
@@ -154,12 +153,9 @@ function LinearAlgebra.mul!(dd_out::DD.AbstractDimArray{Tout, N}, plan::DDPlan{<
         correct_phase_reference!(dd_out, plan, lookup(dd_in), -1)
     end
     
-    correct_unit = if !(Tout <: NotQuantity)
-        real(oneunit(Tin) * oneunit(Tp) / oneunit(Tout))
-    else
-        oneunit(Tout)
-    end
-    dd_out .*= correct_unit
+    # Corrects for the unit of the output. For example, if the input is g*s and the output is kg*s.
+    correct_unit = real(oneunit(Tin) * oneunit(Tp) / oneunit(Tout))
+    dd_out .*= correct_unit # Also used as a check to ensure that the output has the correct units.
 
     dd_out
 end

--- a/ext/DimensionalDataAbstractFFTsExt.jl
+++ b/ext/DimensionalDataAbstractFFTsExt.jl
@@ -1,0 +1,184 @@
+module DimensionalDataAbstractFFTsExt
+
+using DimensionalData
+using AbstractFFTs, LinearAlgebra
+
+const DD = DimensionalData
+
+import LinearAlgebra: *
+
+const Inverse = 1
+const Forward = -1
+
+struct DDPlan{T, P<:AbstractFFTs.Plan, I,A} <: AbstractFFTs.Plan{T}
+    p::P
+    temp::A
+    function DDPlan{I}(p::P, temp::A) where {I, P<:AbstractFFTs.Plan{T},A} where T
+        new{T, P, I, A}(p, temp)
+    end
+end
+
+AbstractFFTs.fftdims(plan::DDPlan) = AbstractFFTs.fftdims(plan.p)
+Base.size(plan::DDPlan) = size(plan.p)
+
+is_inverse_transform(plan::DDPlan{<:Any, <:Any, Inverse}) = true
+is_inverse_transform(plan::DDPlan{<:Any, <:Any, Forward}) = false
+
+function _step(lookup)
+    if !DD.Lookups.isregular(lookup)
+        throw(ArgumentError("The spacing of the lookup along the fft dimension must be regular."))
+    end
+    lookup[2] - lookup[1]
+end
+
+function _step(lookup::DD.Lookups.Sampled{<:Real, <:AbstractFFTs.Frequencies})
+    lookup[2]
+end
+
+function _fftfreq_dd(::Type{P}, dd_lookup, is_fft_dim, is_first_fft_dim) where P
+    if is_fft_dim
+        if dd_lookup isa DD.Lookups.Sampled{<:Real, <:AbstractFFTs.Frequencies}
+            len = length(dd_lookup)
+            dx = 1 / _step(dd_lookup) / len
+            return range(-len / 2 * dx, step = dx, length = len)
+        else
+            return fftfreq(length(dd_lookup), 1 / _step(dd_lookup))
+        end
+    else
+        return dd_lookup
+    end
+end
+
+function _fftfreq_dd(::Type{<:AbstractFFTs.Plan{<:Real}}, dd_lookup, is_fft_dim, is_first_fft_dim)
+    if is_fft_dim
+        if is_first_fft_dim
+            return rfftfreq(length(dd_lookup), 1 / _step(dd_lookup))
+        else
+            return fftfreq(length(dd_lookup), 1 / _step(dd_lookup))
+        end
+    else
+        return dd_lookup
+    end
+end
+
+function get_freqs(plan::P, dd::DD.AbstractDimArray{<:Any, N}) where {P<:AbstractFFTs.Plan, N}
+    fft_dims = AbstractFFTs.fftdims(plan)
+    is_fft_dims = ntuple(i -> i in fft_dims, N)
+    is_first_fft_dim = ntuple(i -> i == first(fft_dims), N)
+    freqs = ntuple(i -> _fftfreq_dd(P, lookup(dd, i), is_fft_dims[i], is_first_fft_dim[i]), N)
+    lookups = ntuple(i -> DD.basetypeof(dims(dd, i))(freqs[i]), N)
+    lookups
+end
+
+function get_scale_factor(plan::P, dd::DD.AbstractDimArray{<:Any, N}) where {P<:AbstractFFTs.Plan, N}
+    fft_dims = AbstractFFTs.fftdims(plan)
+    is_fft_dims = ntuple(i -> i in fft_dims, N)
+    steps_dd = ntuple(i -> is_fft_dims[i] ? _step(lookup(dd, i)) : 1, N)
+    prod(steps_dd)
+end
+
+function (*)(plan::DDPlan, dd::DD.AbstractDimArray)
+    lookups = get_freqs(plan, dd)
+    input_to_plan = if is_inverse_transform(plan)
+        copyto!(parent(plan.temp), parent(dd))
+        correct_phase_reference!(plan.temp, plan, lookups, 1)
+        plan.temp
+    else
+        dd
+    end
+    fft_dd = plan.p * parent(input_to_plan)
+    dd_out = DimArray(fft_dd, lookups)
+    if !is_inverse_transform(plan)
+        correct_phase_reference!(dd_out, plan, lookup(dd), -1)
+    end
+    dd_out
+end
+function LinearAlgebra.mul!(dd_out::DD.AbstractDimArray{<:Any, N}, plan::DDPlan, dd_in::DD.AbstractDimArray{<:Any, N}) where N
+    lookups_out = get_freqs(plan, dd_in)
+    if !all(i -> dims(dd_out, i) == lookups_out[i], 1:N)
+        throw(ArgumentError("The lookups of the output and input DimensionalData must match."))
+    end
+    input_to_plan = if is_inverse_transform(plan)
+        @show "asda"
+        copyto!(parent(plan.temp), parent(dd_in))
+        correct_phase_reference!(plan.temp, plan, lookups_out, 1)
+        plan.temp
+    else
+        dd_in
+    end
+    @show plan.p
+    LinearAlgebra.mul!(parent(dd_out), plan.p, parent(input_to_plan))
+    if !is_inverse_transform(plan)
+        correct_phase_reference!(dd_out, plan, lookup(dd_in), -1)
+    end
+    dd_out
+end
+
+function correct_phase_reference!(dd::DD.AbstractDimArray{<:Any, N}, plan::DDPlan, lookup_refs, phase_scaling) where N
+    for i in fftdims(plan)
+        dd .*= exp.((im * 2π * phase_scaling * first(lookup_refs[i])) .* lookup(dd, i))
+    end
+end
+
+for i in (:fft, :ifft, :rfft)
+    eval(quote
+        function AbstractFFTs.$i(dd::AbstractDimArray{<:Any, N}, dims = 1:N; kwargs...) where N
+            plan = $(Symbol(:plan_, i))(dd, dims; kwargs...)
+            plan * dd
+        end
+    end)
+end
+
+function AbstractFFTs.plan_fft(dd::AbstractDimArray{T, N}, dims = 1:N; kwargs...) where {T,N}
+    p = AbstractFFTs.plan_fft(parent(dd), dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Forward}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
+end
+function AbstractFFTs.plan_rfft(dd::AbstractDimArray{T, N}, dims = 1:N; kwargs...) where {N,T}
+    p = AbstractFFTs.plan_rfft(parent(dd), dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Forward}(AbstractFFTs.ScaledPlan(p, s), similar(dd, complex(T)))
+end
+
+function AbstractFFTs.plan_ifft(dd::AbstractDimArray{<:Any, N}, dims = 1:N; kwargs...) where N
+    p = AbstractFFTs.plan_ifft(parent(dd), dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Inverse}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
+end
+
+function AbstractFFTs.plan_inv(plan::DDPlan)
+    throw(ErrorException("The plan_inv function is not implemented yet for DDPlan. Use plan_ifft or plan_irfft instead."))
+end
+
+function LinearAlgebra.inv(plan::DDPlan)
+    throw(ErrorException("The plan_inv function is not implemented yet for DDPlan. Use plan_ifft or plan_irfft instead."))
+end
+
+function AbstractFFTs.plan_irfft(dd::AbstractDimArray{<:Any, N}, len, dims = 1:N; kwargs...) where N
+    p = AbstractFFTs.plan_irfft(parent(dd), len, dims; kwargs...)
+    s = get_scale_factor(p, dd)
+    DDPlan{Inverse}(AbstractFFTs.ScaledPlan(p.p, s), similar(dd))
+end
+
+
+for f in (:fftshift, :ifftshift)
+    eval(quote
+        function AbstractFFTs.$f(dim::DD.Dimensions.Dimension)
+            DD.basetypeof(dim)(AbstractFFTs.$f(parent(lookup(dim))))
+        end
+        function $(Symbol(:apply_, f))(lookup, is_fft_dim)
+            if is_fft_dim
+                return AbstractFFTs.$f(lookup)
+            else
+                return lookup
+            end
+        end
+        function AbstractFFTs.$f(dd::AbstractDimArray{<:Any, N}, dims = 1:N) where N
+            is_fft_dims = ntuple(i -> i in dims, N)
+            dims_dd = DD.dims(dd)
+            DimArray($f(parent(dd), dims), ntuple(i -> $(Symbol(:apply_, f))(dims_dd[i], is_fft_dims[i]), N))
+        end
+    end)
+end
+end
+

--- a/test/abstractffts.jl
+++ b/test/abstractffts.jl
@@ -1,0 +1,31 @@
+using DimensionalData, AbstractFFTs, FFTW, Test, LinearAlgebra
+
+gauss(x, a, x0) = exp(-a * (x - x0)^2)
+fourier_gauss(k, a, x0) = √(π / a) * exp(-π^2 * k^2 / a + 2π * im * x0 * k) # Fourier transform of a Gaussian
+
+x = range(-5, 5, length = 1000)
+y = gauss.(X(x), 5, 0)
+
+fft_y = fft(y)
+ref_values = fourier_gauss.(dims(fft_y, 1), 5, 0)
+
+@test all(isapprox.(fft_y, fourier_gauss.(dims(fft_y, 1), 5, 0), atol = 1E-9))
+shift_fft_y = fftshift(fft_y)
+@test all(isapprox.(shift_fft_y, fourier_gauss.(dims(shift_fft_y, 1), 5, 0), atol = 1E-9))
+shift_shift_fft_y = fftshift(shift_fft_y)
+@test all(isapprox.(shift_shift_fft_y, fft_y, atol = 1E-5))
+
+ifft_y = ifft(fft_y)
+@test all(isapprox.(ifft_y, gauss.(lookup(ifft_y, 1), 5, 0), atol = 1E-9))
+@test all(isapprox.(lookup(ifft(fft_y), 1) |> parent |> step, step(x), atol = 1E-9))
+
+# Double test to ensure that the plan uses correctly the temporary arrays used to avoid allocations
+p = plan_fft(y)
+@test all(isapprox.(mul!(fft_y, p, complex.(y)), ref_values, atol = 1E-9))
+@test all(isapprox.(mul!(fft_y, p, complex.(y)), ref_values, atol = 1E-9))
+pinv = plan_ifft(fft_y)
+@test all(isapprox.(mul!(ifft_y, pinv, fft_y), gauss.(lookup(ifft_y, 1), 5, 0), atol = 1E-9))
+@test all(isapprox.(mul!(ifft_y, pinv, fft_y), gauss.(lookup(ifft_y, 1), 5, 0), atol = 1E-9))
+
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ import OpenSSL
     Aqua.test_deps_compat(DimensionalData)
 end
 
+@time @safetestset "FFT" begin include("abstractffts.jl") end
 @time @safetestset "interface" begin include("interface.jl") end
 @time @safetestset "metadata" begin include("metadata.jl") end
 @time @safetestset "name" begin include("name.jl") end
@@ -41,6 +42,7 @@ end
 @time @safetestset "ecosystem" begin include("ecosystem.jl") end
 @time @safetestset "categorical" begin include("categorical.jl") end
 @time @safetestset "xarray" begin include("xarray.jl") end
+
 
 if Sys.islinux()
     # Unfortunately this can hang on other platforms.


### PR DESCRIPTION
Hi,

I have created a draft for the AbstractFFTs extension discussed on #1040.

I did some work to make it work with Unitful but not sure if my solution was the best. The issue I faced was that I need a way of getting the data type information from Quantity{T, D, U} without the Unitful extension. 

My work around was to use a combination of `if` statements with `oneunit`. For example:
https://github.com/rafaqz/DimensionalData.jl/blob/3e6c2d7cd8d85b5fc0fbc2a4299c9ad10b2feb90/ext/DimensionalDataAbstractFFTsExt.jl#L126
https://github.com/rafaqz/DimensionalData.jl/blob/3e6c2d7cd8d85b5fc0fbc2a4299c9ad10b2feb90/ext/DimensionalDataAbstractFFTsExt.jl#L128

Do you know a better way of achieving the same?

Thanks 