### PR TITLE
Implement Broadcast.instantiate function

### DIFF
--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -73,11 +73,11 @@ BroadcastStyle(a::Style{Tuple}, ::DimensionalStyle{B}) where {B} = DimensionalSt
         length(axes) == length(ds) || 
             throw(ArgumentError("Number of broadcasted dimensions $(length(axes)) larger than $(ds)"))
         axes = map(Dimensions.DimUnitRange, axes, ds)
-    else # bc already has axes which might have dimensions
+    else # bc already has axes which might have dimensions, e.g. when assigning to a DimArray
         axes = bc.axes
         Base.Broadcast.check_broadcast_axes(axes, bc.args...)
         ds = dims(axes)
-        isnothing(ds) || _comparedims_broadcast(A, bdims..., ds)
+        isnothing(ds) ? _comparedims_broadcast(A, bdims...) : _comparedims_broadcast(A, ds, bdims...)
     end
     return Broadcasted(bc.style, bc.f, bc.args, axes)
 end

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -88,6 +88,7 @@ function Broadcast.copy(bc::Broadcasted{DimensionalStyle{S}}) where S
     data = copy(_unwrap_broadcasted(bc))
     # unwrap AbstractDimArray data
     data = data isa AbstractDimArray ? parent(data) : data
+    data isa AbstractArray || return data
     return rebuild(A; data, dims = dims(bc.axes), refdims=refdims(A), name=Symbol(""))
 end
 

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -62,9 +62,9 @@ BroadcastStyle(::DimensionalStyle{A}, b::Style{Tuple}) where {A} = DimensionalSt
 @inline function Broadcast.instantiate(bc::Broadcasted{<:DimensionalStyle{S}}) where S
     A = _firstdimarray(bc)
     bdims = _broadcasted_dims(bc)
+    _comparedims_broadcast(A, bdims...)
     if bc.axes isa Nothing
         axes = Base.Broadcast.combine_axes(map(_unwrap_broadcasted, bc.args)...)
-        _comparedims_broadcast(A, bdims...)
         ds = Dimensions.promotedims(bdims...; skip_length_one=true)
         length(axes) == length(ds) || 
             throw(ArgumentError("Number of broadcasted dimensions $(length(axes)) larger than $(ds)"))
@@ -73,7 +73,7 @@ BroadcastStyle(::DimensionalStyle{A}, b::Style{Tuple}) where {A} = DimensionalSt
         axes = bc.axes
         Base.Broadcast.check_broadcast_axes(axes, bc.args...)
         ds = dims(axes)
-        isnothing(ds) ? _comparedims_broadcast(A, bdims...) : _comparedims_broadcast(A, ds, bdims...)
+        isnothing(ds) || _comparedims_broadcast(A, ds, bdims...)
     end
     return Broadcasted(bc.style, bc.f, bc.args, axes)
 end

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -86,12 +86,13 @@ end
 
 function Base.similar(bc::Broadcasted{DimensionalStyle{S}}, ::Type{T}) where {S,T}
     A = _firstdimarray(bc)
-    A2 = A isa BroadcastOptionsDimArray ? parent(A) : A
-    rebuild(A2; data = similar(_unwrap_broadcasted(bc), T), dims = dims(axes(bc)))
+    rebuild(A; data = similar(_unwrap_broadcasted(bc), T), dims = dims(axes(bc)))
 end
+
 @inline function Base.materialize!(::S, dest, bc::Broadcasted) where {S<:DimensionalStyle}
     return Base.copyto!(dest, Broadcast.instantiate(Broadcasted(S(), bc.f, bc.args, axes(dest))))
 end
+
 @inline Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:DimensionalStyle{S}}) where S = 
     Base.copyto!(dest, _unwrap_broadcasted(bc))
 

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -382,9 +382,9 @@ _unwrap_broadcasted(t::Tuple) = map(_unwrap_broadcasted, t)
 _unwrap_broadcasted(du::Dimensions.DimUnitRange) = parent(du)
 # Get the first dimensional array in the broadcast
 _firstdimarray(x::Broadcasted) = _firstdimarray(x.args)
-_firstdimarray(x::Tuple{<:AbstractDimArray,Vararg}) = x[1]
+_firstdimarray(x::Union{AbstractDimArray,DimGroupByArray}) = x
 _firstdimarray(ext::Base.Broadcast.Extruded) = _firstdimarray(ext.x)
-function _firstdimarray(x::Tuple{<:Broadcasted,Vararg})
+function _firstdimarray(x::Tuple)
     found = _firstdimarray(x[1])
     if found isa Nothing
         _firstdimarray(tail(x))
@@ -392,7 +392,7 @@ function _firstdimarray(x::Tuple{<:Broadcasted,Vararg})
         found
     end
 end
-_firstdimarray(x::Tuple) = _firstdimarray(tail(x))
+_firstdimarray(x) = nothing
 _firstdimarray(x::Tuple{}) = nothing
 
 # Make sure all arrays have the same dims, and return them

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -382,8 +382,6 @@ _unwrap_broadcasted(t::Tuple) = map(_unwrap_broadcasted, t)
 _unwrap_broadcasted(du::Dimensions.DimUnitRange) = parent(du)
 # Get the first dimensional array in the broadcast
 _firstdimarray(x::Broadcasted) = _firstdimarray(x.args)
-_firstdimarray(x::Union{AbstractDimArray,DimGroupByArray}) = x
-_firstdimarray(ext::Base.Broadcast.Extruded) = _firstdimarray(ext.x)
 function _firstdimarray(x::Tuple)
     found = _firstdimarray(x[1])
     if found isa Nothing
@@ -392,8 +390,10 @@ function _firstdimarray(x::Tuple)
         found
     end
 end
-_firstdimarray(x) = nothing
 _firstdimarray(x::Tuple{}) = nothing
+_firstdimarray(ext::Base.Broadcast.Extruded) = _firstdimarray(ext.x)
+_firstdimarray(x::AbstractDimArray) = x
+_firstdimarray(x) = nothing
 
 # Make sure all arrays have the same dims, and return them
 _broadcasted_dims(bc::Broadcasted) = _broadcasted_dims(bc.args...)

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -57,13 +57,10 @@ function BroadcastStyle(::Type{<:AbstractDimArray{T,N,D,A}}) where {T,N,D,A}
 end
 
 BroadcastStyle(::DimensionalStyle, ::Base.Broadcast.Unknown) = Unknown()
-BroadcastStyle(::Base.Broadcast.Unknown, ::DimensionalStyle) = Unknown()
 BroadcastStyle(::DimensionalStyle{A}, ::DimensionalStyle{B}) where {A, B} = DimensionalStyle(A(), B())
 BroadcastStyle(::DimensionalStyle{A}, b::AbstractArrayStyle{N}) where {A,N} = DimensionalStyle(A(), b)
 BroadcastStyle(::DimensionalStyle{A}, b::DefaultArrayStyle{N}) where {A,N} = DimensionalStyle(A(), b) # ambiguity
-BroadcastStyle(a::AbstractArrayStyle, ::DimensionalStyle{B}) where {B} = DimensionalStyle(a, B())
 BroadcastStyle(::DimensionalStyle{A}, b::Style{Tuple}) where {A} = DimensionalStyle(A(), b)
-BroadcastStyle(a::Style{Tuple}, ::DimensionalStyle{B}) where {B} = DimensionalStyle(a, B())
 
 # override base instantiate to check dimensions as well as axes
 @inline function Broadcast.instantiate(bc::Broadcasted{<:DimensionalStyle{S}}) where S

--- a/src/array/broadcast.jl
+++ b/src/array/broadcast.jl
@@ -80,7 +80,7 @@ end
 
 function Base.similar(bc::Broadcasted{<:DimensionalStyle{S}}, ::Type{T}) where {S,T}
     A = _firstdimarray(bc)
-    rebuild(A; data = similar(_unwrap_broadcasted(bc), T), dims = dims(axes(bc)))
+    rebuild(A; data = similar(_unwrap_broadcasted(bc), T), dims = dims(axes(bc)), name = NoName())
 end
 
 @inline function Base.materialize!(::S, dest, bc::Broadcasted) where {S<:DimensionalStyle}

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -227,8 +227,7 @@ end
 
     @test_throws DimensionMismatch z .= ab .+ ba
     @test_throws DimensionMismatch z .= ab .+ ac
-    # Maybe this should work...
-    # @test_throws DimensionMismatch a_ .= ab .+ ac
+    a_ .= ab .+ ac
     @test_throws DimensionMismatch ab .= a_ .+ ac
     @test_throws DimensionMismatch ac .= ab .+ ba
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -245,7 +245,7 @@ end
 
     @test_throws DimensionMismatch z .= ab .+ ba
     @test_throws DimensionMismatch z .= ab .+ ac
-    @test_throws DimensionMismatch a_ .= ab .+ ac
+    a_ .= ab .+ ac
     @test_throws DimensionMismatch ab .= a_ .+ ac
     @test_throws DimensionMismatch ac .= ab .+ ba
 
@@ -263,9 +263,9 @@ end
 end
 
 @testset "JLArray assign using named indexing and dotview" begin
-    A = DimArray(JLArray(zeros(3,2)), (X, Y))
-    A[X=1:2] .= JLArray([1, 2])
-    A[X=3] .= 7
+    A = DimArray(JLArray(zeros(3,2)), (X, Y));
+    A[X=1:2] .= JLArray([1, 2]);
+    A[X=3] .= 7;
     @test Array(A) == [1.0 1.0; 2.0 2.0; 7.0 7.0]
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -227,7 +227,8 @@ end
 
     @test_throws DimensionMismatch z .= ab .+ ba
     @test_throws DimensionMismatch z .= ab .+ ac
-    a_ .= ab .+ ac
+    # Maybe this should work...
+    # @test_throws DimensionMismatch a_ .= ab .+ ac
     @test_throws DimensionMismatch ab .= a_ .+ ac
     @test_throws DimensionMismatch ac .= ab .+ ba
 
@@ -245,7 +246,7 @@ end
 
     @test_throws DimensionMismatch z .= ab .+ ba
     @test_throws DimensionMismatch z .= ab .+ ac
-    a_ .= ab .+ ac
+    @test_throws DimensionMismatch a_ .= ab .+ ac
     @test_throws DimensionMismatch ab .= a_ .+ ac
     @test_throws DimensionMismatch ac .= ab .+ ba
 
@@ -263,9 +264,9 @@ end
 end
 
 @testset "JLArray assign using named indexing and dotview" begin
-    A = DimArray(JLArray(zeros(3,2)), (X, Y));
-    A[X=1:2] .= JLArray([1, 2]);
-    A[X=3] .= 7;
+    A = DimArray(JLArray(zeros(3,2)), (X, Y))
+    A[X=1:2] .= JLArray([1, 2])
+    A[X=3] .= 7
     @test Array(A) == [1.0 1.0; 2.0 2.0; 7.0 7.0]
 end
 


### PR DESCRIPTION
Define `Broadcast.instantiate` to more closely mirror the structure of base broadcasting. `instantiate` checks that dimensions align etc., so we don't need as many other methods (this gets rid of the `materialize!` dispatch completely)

Let's see if tests pass