### PR TITLE
remove extra `display` in makie plots

### DIFF
--- a/ext/DimensionalDataMakie.jl
+++ b/ext/DimensionalDataMakie.jl
@@ -73,14 +73,13 @@ PlotTypes_3D = (Volume, VolumeSlices)
 
 for p in (PlotTypes_1D..., PlotTypes_2D..., PlotTypes_3D..., Series, PlotTypes_Cat_1D...)
     f = Makie.plotkey(p)
-    eval(quote
+    @eval begin
         function Makie.$f(A::MayObs{<:AbstractDimArray}; figure = (;), attributes...)
             fig = Figure(; figure...)
             ax, plt = $f(fig[1,1], A; attributes...)
-            display(fig)
             return Makie.FigureAxisPlot(fig, ax, plt)
         end
-    end)
+    end
 end
 
 function error_if_has_content(grid::G) where G

--- a/test/makie.jl
+++ b/test/makie.jl
@@ -421,7 +421,8 @@ end
     @test volumeslices(dd_3d_char) isa Makie.FigureAxisPlot
 
     # Due to limitations on Makie
-    @test volumeslices(dd_3d_mis) broken = true 
+    # Event the broken test is broken in Makie due to errors while throwing the error
+    # @test volumeslices(dd_3d_mis) broken = true 
     @test volumeslices(dd_3d_uni) broken = true
     @test volumeslices(dd_3d_rgb) broken = true
     @test volume(dd_3d_uni) broken = true


### PR DESCRIPTION
Closes #1053. Also reformatted the eval block