### PR TITLE
Fix vcat for Datetime

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -421,21 +421,28 @@ function _check_cat_lookups(D, ::Regular, lookups...)
             @warn _cat_warn_string(D, "step sizes $(step(span(l))) and $s do not match")
             return false
         end
-        if hasmethod(isapprox, (typeof(lastval+s), typeof(first(l))))
-            if !(lastval + s ≈ first(l))
-                @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s ≈ $(first(l)) should hold")
-                return false
-            end
-        else
-            if lastval + s != first(l)
-                @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s == $(first(l)) should hold since isapprox is not defined")
-                return false
-            end
-        end
+        _check_cat_step_join(D, lastval, first(l), s) || return false
         lastval = last(l)
         return true
     end |> all
 end
+
+function _check_cat_step_join(D, lastval::Number, firstval::Number, steplen)
+    if !(lastval + steplen ≈ firstval)
+        @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $steplen ≈ $firstval should hold")
+        return false
+    end
+    return true
+end
+
+function _check_cat_step_join(D, lastval, firstval, steplen)
+    if lastval + steplen != firstval
+        @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $steplen == $firstval should hold since isapprox is not defined")
+        return false
+    end
+    return true
+end
+
 function _check_cat_lookups(D, ::Explicit, lookups...)
     map(lookups) do l
         span(l) isa Explicit || _mixed_span_warn(D, Explicit, span(l))

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -421,7 +421,7 @@ function _check_cat_lookups(D, ::Regular, lookups...)
             @warn _cat_warn_string(D, "step sizes $(step(span(l))) and $s do not match")
             return false
         end
-        if !(lastval + s ≈ first(l))
+        (lastval+s) == first(l) ||  if !(lastval + s ≈ first(l))
             @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s ≈ $(first(l)) should hold")
             return false
         end

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -421,9 +421,16 @@ function _check_cat_lookups(D, ::Regular, lookups...)
             @warn _cat_warn_string(D, "step sizes $(step(span(l))) and $s do not match")
             return false
         end
-        (lastval+s) == first(l) ||  if !(lastval + s ≈ first(l))
-            @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s ≈ $(first(l)) should hold")
-            return false
+        if hasmethod(isapprox, (typeof(lastval+s), typeof(first(l))))
+            if !(lastval + s ≈ first(l))
+                @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s ≈ $(first(l)) should hold")
+                return false
+            end
+        else
+            if lastval + s != first(l)
+                @warn _cat_warn_string(D, "`Regular` lookups do not join with the correct step size: $(lastval) + $s == $(first(l)) should hold since isapprox is not defined")
+                return false
+            end
         end
         lastval = last(l)
         return true

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -621,6 +621,17 @@ end
             @test_warn "lookups are mixed `ForwardOrdered` and `ReverseOrdered`" vcat(d1, reverse(d2))
             @test_warn "lookups are misaligned" vcat(d2, d1)
         end
+
+        @testset "vcat" begin
+            t1 = Ti(DateTime(2000):Day(1):DateTime(2001)-Day(1))
+            d1 = rand(t1)
+            t2 = Ti(DateTime(2001):Day(1):DateTime(2002))
+            d2 = rand(t2)
+            v = vcat(d1, d2)
+            @test length(v) == 732
+            @test v[1:366] == d1[:]
+            @test v[367:end] == d2[:]
+        end
     end
 
     @testset "Explicit" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -622,15 +622,18 @@ end
             @test_warn "lookups are misaligned" vcat(d2, d1)
         end
 
-        @testset "vcat" begin
+        @testset "vcat time axis" begin
             t1 = Ti(DateTime(2000):Day(1):DateTime(2001)-Day(1))
             d1 = rand(t1)
             t2 = Ti(DateTime(2001):Day(1):DateTime(2002))
             d2 = rand(t2)
+            t3 = Ti(DateTime(2001,3,1):Day(1):DateTime(2002))
+            d3 = rand(t3)
             v = vcat(d1, d2)
             @test length(v) == 732
             @test v[1:366] == d1[:]
             @test v[367:end] == d2[:]
+            @test_warn "lookups do not join with the correct step size" vcat(d1,d3)
         end
     end
 


### PR DESCRIPTION
This fixes #1060 by making an equality test before making an approx test. Because the equality works for datetimes. 

This adds the example from #1060 as a test case. 