### PR TITLE
Fix CHOLMOD.Dense 1D comparison in SparseArrays tests

### DIFF
--- a/test/sparsearrays.jl
+++ b/test/sparsearrays.jl
@@ -35,11 +35,12 @@ using DimensionalData: AbstractDimArray
         # @test dims(dst_generic) == dims2d
         
         # Test 1D DimArray with Float64
+        # Note: CHOLMOD.Dense always creates 2D arrays, so we need to compare with vec()
         src_1d_f64 = SparseArrays.CHOLMOD.Dense(rand(Float64, 5))
         dst1d_f64 = DimArray(zeros(Float64, 5), dims1d)
         result = copyto!(dst1d_f64, src_1d_f64)
         @test result === dst1d_f64
-        @test parent(dst1d_f64) == src_1d_f64
+        @test parent(dst1d_f64) == vec(src_1d_f64)
         @test dims(dst1d_f64) == dims1d
     end
     


### PR DESCRIPTION
## Battle of the bots
- Fixed failing test in PR #1066 where CHOLMOD.Dense 1D arrays were incorrectly compared
- CHOLMOD.Dense always creates 2D arrays (n×1 matrices) even for 1D input
- Updated test to use `vec()` to flatten the CHOLMOD.Dense array for proper comparison

## Test Results
All SparseArrays extension tests now pass successfully:
```
Test Summary:          | Pass  Total  Time
SparseArrays Extension |   24     24  0.7s
```

This fix resolves the "cholmod copyto\! is broken" issue mentioned in the original PR.

🤖 Generated with [Claude Code](https://claude.ai/code)