### PR TITLE
use rebuild for similar of dimarray with new axes

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -262,7 +262,6 @@ function _similar(A::AbstractDimArray, T::Type, shape::Tuple;
     shape isa Tuple{Vararg{Dimensions.DimUnitRange}} || return data
     rebuild(A; data, dims, refdims, name, metadata, kw...)
 end
-
 function _similar(A::AbstractArray, T::Type, shape::Tuple; kw...)
     data = similar(parent(A), T, map(_parent_range, shape))
     shape isa Tuple{Vararg{Dimensions.DimUnitRange}} || return data

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -254,6 +254,14 @@ for s1 in (:(Dimensions.DimUnitRange), :MaybeDimUnitRange)
         end
     end
 end
+function _similar(A::AbstractDimArray, T::Type, shape::Tuple; 
+    dims=dims(shape), refdims=(), name=_noname(A), metadata=metadata(A), kw...
+)
+    data = similar(parent(A), T, map(_parent_range, shape))
+    shape isa Tuple{Vararg{Dimensions.DimUnitRange}} || return data
+    rebuild(A; data, dims, refdims, name, metadata, kw...)
+end
+
 function _similar(A::AbstractArray, T::Type, shape::Tuple; kw...)
     data = similar(parent(A), T, map(_parent_range, shape))
     shape isa Tuple{Vararg{Dimensions.DimUnitRange}} || return data

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -254,6 +254,7 @@ for s1 in (:(Dimensions.DimUnitRange), :MaybeDimUnitRange)
         end
     end
 end
+
 function _similar(A::AbstractDimArray, T::Type, shape::Tuple; 
     dims=dims(shape), refdims=(), name=_noname(A), metadata=metadata(A), kw...
 )

--- a/test/array.jl
+++ b/test/array.jl
@@ -225,21 +225,21 @@ end
         @test size(da_all) == size(da)
         @test dims(da_all) === dims(da)
         @test refdims(da_all) == ()
-        @test metadata(da_all) == NoMetadata()
+        @test metadata(da_all) == metadata(da)
 
         da_first = similar(da, Missing, (axes(da, 1),))   
         @test eltype(da_first) === Missing
         @test size(da_first) == (size(da, 1),)
         @test dims(da_first) === (dims(da, 1),)
         @test refdims(da_first) == ()
-        @test metadata(da_first) == NoMetadata()
+        @test metadata(da_first) == metadata(da)
 
         da_last = similar(da, Nothing, (axes(da, 2),))
         @test eltype(da_last) === Nothing
         @test size(da_last) == (size(da, 2),)
         @test dims(da_last) === (dims(da, 2),)
         @test refdims(da_last) == ()
-        @test metadata(da_last) == NoMetadata()
+        @test metadata(da_last) == metadata(da)
     end
 
     @testset "similar with DimArray and new axes" begin
@@ -249,7 +249,7 @@ end
         @test size(da_sim) == (2,)
         @test dims(da_sim) == (dims(ax),)
         @test refdims(da_sim) == ()
-        @test metadata(da_sim) == NoMetadata()
+        @test metadata(da_sim) == metadata(da)
     end
 
     @testset "similar with AbstractArray and DimUnitRange" begin


### PR DESCRIPTION
closes https://github.com/rafaqz/DimensionalData.jl/issues/1077#issuecomment-3190958095

With new axes it never makes sense to keep refdims - since the axes might have new dimensions. For the metadata I've now opted to keep this since this is what happens for `similar(da, Int)` - but then we could also choose to always drop metadata. I'm not sure