### PR TITLE
Forward name keyword in groupby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changelog.generate(
   tables, so that values may themselves be `AbstractDimArray` ([#917])
 - `rebuildsliced` documented and added to the developer interface 
 - Broadcasts improved for all `AbstractBasicDimArray`, like `DimSelectors`.
+- `groupby` accepts name keyword to set the name of the DimGroupbyArray
+
 
 ### Fixed
 

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -343,15 +343,16 @@ julia> groupmeans = mean.(groupby(A, Ti=>month, Y=>isodd))
  12        0.501643     0.499298
 ```
 """
-DataAPI.groupby(A::DimArrayOrStack, x) = groupby(A, dims(x))
-DataAPI.groupby(A::DimArrayOrStack, dimfuncs::Dimension...) = groupby(A, dimfuncs)
+DataAPI.groupby(A::DimArrayOrStack, x; name=:groubpy) = groupby(A, dims(x); name)
+DataAPI.groupby(A::DimArrayOrStack, dimfuncs::Dimension...; name=:groupby) = groupby(A, dimfuncs; name)
 function DataAPI.groupby(
     A::DimArrayOrStack, p1::Pair{<:Any,<:Base.Callable}, ps::Pair{<:Any,<:Base.Callable}...;
+    name=:groupby
 )
     dims = map((p1, ps...)) do (d, v)
         rebuild(basedims(d), v)
     end
-    return groupby(A, dims)
+    return groupby(A, dims; name)
 end
 function DataAPI.groupby(A::DimArrayOrStack, dimfuncs::DimTuple; name=:groupby)
     length(otherdims(dimfuncs, dims(A))) > 0 &&

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -343,7 +343,7 @@ julia> groupmeans = mean.(groupby(A, Ti=>month, Y=>isodd))
  12        0.501643     0.499298
 ```
 """
-DataAPI.groupby(A::DimArrayOrStack, x; name=:groubpy) = groupby(A, dims(x); name)
+DataAPI.groupby(A::DimArrayOrStack, x; name=:groupby) = groupby(A, dims(x); name)
 DataAPI.groupby(A::DimArrayOrStack, dimfuncs::Dimension...; name=:groupby) = groupby(A, dimfuncs; name)
 function DataAPI.groupby(
     A::DimArrayOrStack, p1::Pair{<:Any,<:Base.Callable}, ps::Pair{<:Any,<:Base.Callable}...;

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -241,8 +241,8 @@ These can wrap around the end of the day.
 hours(step; start=0, labels=nothing) = CyclicBins(hour; cycle=24, step, start, labels)
 
 """
-    groupby(A::Union{AbstractDimArray,AbstractDimStack}, dims::Pair...)
-    groupby(A::Union{AbstractDimArray,AbstractDimStack}, dims::Dimension{<:Callable}...)
+    groupby(A::Union{AbstractDimArray,AbstractDimStack}, dims::Pair...; name=:groupby)
+    groupby(A::Union{AbstractDimArray,AbstractDimStack}, dims::Dimension{<:Callable}...; name=:groupby)
 
 Group `A` by grouping functions or [`Bins`](@ref) over multiple dimensions.
 
@@ -252,6 +252,10 @@ Group `A` by grouping functions or [`Bins`](@ref) over multiple dimensions.
 - `dims`: `Pair`s such as `groups = groupby(A, :dimname => groupingfunction)` or wrapped
   [`Dimension`](@ref)s like `groups = groupby(A, DimType(groupingfunction))`. Instead of
   a grouping function [`Bins`](@ref) can be used to specify group bins.
+
+## Keywords
+
+- `name`: name that is applied to the resulting [`DimGroupByArray`](@ref)
 
 ## Return value
 

--- a/test/groupby.jl
+++ b/test/groupby.jl
@@ -18,7 +18,7 @@ end
     da = rand(X(1:10), Y(1:10))
     grps = groupby(da, X=>isodd, name="isodd")
     @test name(grps) == "isodd"
-
+end
 @testset "manual groupby comparisons" begin
     # Group by month and even/odd Y axis values
     months = DateTime(2000):Month(1):DateTime(2000, 12, 31)

--- a/test/groupby.jl
+++ b/test/groupby.jl
@@ -14,6 +14,11 @@ st = DimStack((a=A, b=A, c=A[X=1]))
     @test first(grps) isa eltype(grps) # false
 end
 
+@testset "groupby name is set" begin
+    da = rand(X(1:10), Y(1:10))
+    grps = groupby(da, X=>isodd, name="isodd")
+    @test name(grps) == "isodd"
+
 @testset "manual groupby comparisons" begin
     # Group by month and even/odd Y axis values
     months = DateTime(2000):Month(1):DateTime(2000, 12, 31)


### PR DESCRIPTION
This should just forward the name keyword in the groupby function, so that it can be changed in the highest level.

