### PR TITLE
adds selectors rrule

### DIFF
--- a/ext/DimensionalDataChainRulesCoreExt.jl
+++ b/ext/DimensionalDataChainRulesCoreExt.jl
@@ -37,16 +37,17 @@ end
 #! rrule for keyword getindex with selectors
 function ChainRulesCore.rrule(::typeof(getindex), A::DD.AbstractDimArray; kwargs...)
     dimsA = dims(A)
-    indices = ntuple(i -> begin
+    selectors = ntuple(i -> begin
         dim = dimsA[i]
         key = name(dim)
         if haskey(kwargs, key)
-            # Convert selector/Colon to actual indices along dimension
-            DD.Lookups.selectindices(dim, kwargs[key])
+            kwargs[key]  # the Selector passed by the user
         else
             Colon()
         end
     end, length(dimsA))
+
+    indices = DD.Dimensions.dims2indices(dimsA, selectors)
 
     B = getindex(A, indices...)
 

--- a/ext/DimensionalDataChainRulesCoreExt.jl
+++ b/ext/DimensionalDataChainRulesCoreExt.jl
@@ -1,25 +1,66 @@
 module DimensionalDataChainRulesCoreExt
 
 using DimensionalData
+import DimensionalData as DD
 using ChainRulesCore
 
-function ChainRulesCore.ProjectTo(x::DimensionalData.AbstractDimArray)
-    return ProjectTo{DimensionalData.DimArray}(; data=ProjectTo(parent(x)), dims=dims(x))
+function ChainRulesCore.ProjectTo(x::DD.AbstractDimArray)
+    return ProjectTo{DD.DimArray}(
+        data = ProjectTo(parent(x)),
+        dims = dims(x),
+        name = name(x),
+        refdims = refdims(x),
+        metadata = metadata(x)
+    )
 end
 
-(project::ProjectTo{DimensionalData.DimArray})(dx::DimensionalData.AbstractDimArray) =
-    DimArray(project.data(parent(dx)), project.dims)
-(project::ProjectTo{DimensionalData.DimArray})(dx::AbstractArray) =
-    DimArray(project.data(dx), project.dims)
-(project::ProjectTo{DimensionalData.DimArray})(dx::AbstractZero) = dx
+(project::ProjectTo{DD.DimArray})(dx::DD.AbstractDimArray) =
+    DD.DimArray(project.data(parent(dx)), project.dims; name=project.name, refdims=project.refdims, metadata=project.metadata)
 
-_DimArray_pullback(ȳ, project) = (NoTangent(), project(ȳ))
-_DimArray_pullback(ȳ::Tangent, project) = _DimArray_pullback(ȳ.data, project)
-_DimArray_pullback(ȳ::AbstractThunk, project) = _DimArray_pullback(unthunk(ȳ), project)
+(project::ProjectTo{DD.DimArray})(dx::AbstractArray) =
+    DD.DimArray(project.data(dx), project.dims; name=project.name, refdims=project.refdims, metadata=project.metadata)
 
-function ChainRulesCore.rrule(::typeof(parent), x::DimensionalData.AbstractDimArray)
-    pb(y) = _DimArray_pullback(y, ProjectTo(x))
-    return parent(x), pb
+(project::ProjectTo{DD.DimArray})(dx::AbstractZero) = dx
+
+DimArray_pullback(ȳ, project) = (NoTangent(), project(ȳ))
+DimArray_pullback(ȳ::Tangent, project) = DimArray_pullback(ȳ.data, project)
+DimArray_pullback(ȳ::AbstractThunk, project) = DimArray_pullback(unthunk(ȳ), project)
+
+function ChainRulesCore.rrule(::typeof(parent), x::DD.AbstractDimArray)
+    project = ProjectTo(x)
+    function parent_pullback(ȳ)
+        return DimArray_pullback(ȳ, project)
+    end
+    return parent(x), parent_pullback
+end
+
+#! rrule for keyword getindex with selectors
+function ChainRulesCore.rrule(::typeof(getindex), A::DD.AbstractDimArray; kwargs...)
+    dimsA = dims(A)
+    indices = ntuple(i -> begin
+        dim = dimsA[i]
+        key = name(dim)
+        if haskey(kwargs, key)
+            # Convert selector/Colon to actual indices along dimension
+            DD.Lookups.selectindices(dim, kwargs[key])
+        else
+            Colon()
+        end
+    end, length(dimsA))
+
+    B = getindex(A, indices...)
+
+    function pb(ȳ)
+        grad = zero(A)
+        if ȳ isa Number && length(grad[indices...]) == 1
+            grad[indices...] = ȳ
+        else
+            grad[indices...] .= ȳ
+        end
+        return (NoTangent(), grad)
+    end
+
+    return B, pb
 end
 
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -50,5 +50,28 @@ using ChainRulesCore
         _, Āz = pb(NoTangent())
         @test Āz === NoTangent()
     end
+    @testset "getindex rrule with selectors" begin
+        A = DimArray(rand(3, 4), (Y([:a, :b, :c]), X(1:4)))
+        
+        # Test At selector
+        y, pb = rrule(getindex, A; Y=At(:b))
+        @test size(y) == (4,)  # Only X dimension remains
+        
+        ȳ = ones(4)
+        _, grad = pb(ȳ)
+        @test size(grad) == size(A)
+        @test all(grad[1, :] .== 0)
+        @test all(grad[2, :] .== 1)  # Y=:b 
+        @test all(grad[3, :] .== 0)
+        
+        # Test multiple selectors
+        y2, pb2 = rrule(getindex, A; Y=At(:b), X=At(2))
+        @test y2 isa Number
+        
+        ȳ2 = 1.0
+        _, grad2 = pb2(ȳ2)
+        @test grad2[2, 2] == 1  # Y=:b, X=2
+        @test sum(grad2) == 1   # Only one element should be 1
+    end
 
 end


### PR DESCRIPTION
previous PR https://github.com/rafaqz/DimensionalData.jl/pull/1089 did not contained a rule for selectors, which is needed to slice data in certain dimensions ( targets ). This fixes that.

With this PR now this also works:

```Julia
using Zygote, ChainRulesCore, DimensionalData
ar = rand(3,3)
A = DimArray(ar, (Y([:a,:b,:c]), X(1:3)));
grad = Zygote.gradient(x -> sum(x[Y=At(:b)]), A)
```

this should help us close https://github.com/EarthyScience/EasyHybrid.jl/issues/139