### PR TITLE
doc: fix FFT doc equations

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -31,6 +31,7 @@ const navTemp = {
         { text: 'DiskArrays', link: '/diskarrays' },
         { text: 'Xarray', link: '/xarray' },
         { text: 'Extending DimensionalData', link: '/extending_dd' },
+        { text: 'FFT', link: '/fft' },
       ],
     },
   ],

--- a/docs/src/fft.md
+++ b/docs/src/fft.md
@@ -1,0 +1,21 @@
+# Fast Fourier Transform (FFT)
+`DimensionalData.jl` implements the Fast Fourier Transform (FFT) for `DimensionalArray` objects, allowing users to perform frequency domain analysis while preserving dimensional metadata.
+
+It uses lookups to scale the forward and inverse transforms to remain physically meaningful. As such, it implements the following conventions. If we denote a signal as a function of time ``a(x)`` sampled at discrete intervals ``dx``, the discrete Fourier transform (DFT) is defined as:
+```math
+\operatorname{DFT}(A)[k] =
+\sum_{n=1}^{\operatorname{length}(A)} \exp\left(i2π x[n]f[k] \right) A[n] dx.
+```
+The inverse discrete Fourier transform (IDFT) is defined as:
+```math
+\operatorname{IDFT}(A)[n] =
+\sum_{k=1}^{\operatorname{length}(A)} \exp\left(-i2π x[n]f[k] \right) A[k] df.
+```
+
+These conventions ensure that the transforms are unitary, meaning that applying the DFT followed by the IDFT returns the original signal without any additional scaling factors. The scaling factors applied to the forward and inverse transforms are different from the "standard" discrete Fourier transform definitions, which typically does not scale the forward transform, and includes a normalization factor of `1/N` in the inverse transform.
+
+## API
+
+The following functions are provided for performing FFTs on `DimensionalArray` objects:
+
+TODO

--- a/ext/DimensionalDataAbstractFFTsExt.jl
+++ b/ext/DimensionalDataAbstractFFTsExt.jl
@@ -269,7 +269,7 @@ for i in (:fft, :ifft, :rfft)
 
         ```math
         \\operatorname{DFT}(A)[k] =
-        \\sum_{n=1}^{\\operatorname{length}(A)} \\exp\\left($(signal)\\pi x[n]f[k] \\right) A[n] dx.
+        \\sum_{n=1}^{\\operatorname{length}(A)} \\exp\\left($(signal)2\\pi x[n]f[k] \\right) A[n] dx.
         ```
         where `x` is the lookup dimension of the input data, `f` is the lookup dimension of the output data, and `dx` is the step of the lookup dimension of the input data.
 
@@ -292,7 +292,7 @@ end
 
         ```math
         \\operatorname{DFT}(A)[k] =
-        \\sum_{n=1}^{\\operatorname{length}(A)} \\exp\\left(i\\pi x[n]f[k] \\right) A[n] dx.
+        \\sum_{n=1}^{\\operatorname{length}(A)} \\exp\\left(i2\\pi x[n]f[k] \\right) A[n] dx.
         ```
         where `x` is the lookup dimension of the input data, `f` is the lookup dimension of the output data, and `dx` is the step of the lookup dimension of the input data.
 


### PR DESCRIPTION
I think the docstrings are missing `2` before pi.

I also started some docs explaining how `DimensionalData` does FFT, since it's not the "standard" way (I spent many hours trying to understand why my cross-correlation calculations, which need to be normalized to `[-1,1]` were "wrong"). 

I don't know how to link package extension docstrings to Documenter[^1], but happy to update this or a future PR if I get some pointers how to do it.

[^1]: Relevant issue https://github.com/JuliaDocs/Documenter.jl/issues/2124