### PR TITLE
Restrict CI to Python 3.13

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -2,3 +2,5 @@
 xarray = ""
 numpy = ""
 openssl = "<=julia"
+# Python 3.14 segfaults something awful
+python = "3.13.*"


### PR DESCRIPTION
Preemptive fix since I ran into this on another project. I assume it's because of the free-threading changes.