### PR TITLE
Add empty tuple to DimensionIndsArrays

### DIFF
--- a/src/dimindices.jl
+++ b/src/dimindices.jl
@@ -438,7 +438,7 @@ function mergedims(A::DimExtensionArray, dim_pairs::Pair...)
 end
 
 const SelectorOrStandard = Union{SelectorOrInterval,StandardIndices}
-const DimensionIndsArrays = Union{AbstractArray{<:Dimension},AbstractArray{<:DimTuple}}
+const DimensionIndsArrays = Union{AbstractArray{<:Dimension},AbstractArray{<:DimTupleOrEmpty}}
 const DimensionalIndices = Union{DimTuple,DimIndices,DimSelectors,Dimension,DimensionIndsArrays}
 const _DimIndicesAmb = Union{AbstractArray{Union{}},DimIndices{<:Integer},DimSelectors{<:Integer}}
 

--- a/test/dimindices.jl
+++ b/test/dimindices.jl
@@ -61,6 +61,8 @@ A = zeros(X(4.0:7.0), Y(10.0:12.0))
         @test ndims(di0) == 0
         @test dims(di0) == ()
         @test size(di0) == ()
+        da0 = DimArray(fill(1), ())
+        @test da0[DimIndices(da0)] == da0
     end
     @testset "keywords error" begin
         @test_throws MethodError DimIndices(A; order=ForwardOrdered())


### PR DESCRIPTION
This is an attempt to fix #1097. I am not entirely sure, whether this is the correct position to add the empty tuple but at least it fixed the issue in #1097 but let's see what it broke. 