### PR TITLE
Preserve dimensions when broadcasting dimstack

### DIFF
--- a/src/stack/stack.jl
+++ b/src/stack/stack.jl
@@ -627,3 +627,5 @@ Base.eltype(::Type{Base.SkipMissing{T}}) where {T<:AbstractDimStack{<:Any, NT}} 
 
 @generated _nonmissing_nt(NT::Type{<:NamedTuple{K,V}}) where {K,V} =
     NamedTuple{K, Tuple{map(Base.nonmissingtype, V.parameters)...}}
+
+Base.Broadcast.broadcastable(st::AbstractDimStack) = [st[D] for D in DimIndices(st)]


### PR DESCRIPTION
After we implemented collect for dimstacks, broadcasting dimstacks is now possible but returns an array.

This one line change makes it so broadcasting operations will return DimArrays with dimensions preserved:

E.g.
```
using DimensionalData
a = rand(X(1:10), Y(1:10))
b = rand(X(1:10))
ds = DimStack((; a, b))
myfun(x::NamedTuple) = x.a + x.b
myfun.(ds)
```

We could improve on this by making the generator lazy as a AbstractDimArrayGenerator. Then we could even specialize some dispatch so that broadcasting over RasterStacks would return Rasters.

Closes https://github.com/rafaqz/DimensionalData.jl/issues/412