### PR TITLE
Delete unnecessary `similar()` method

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -173,8 +173,6 @@ end
 # An alternative would be to fill missing dims with `Anon`, and keep existing
 # dims but strip the Lookup? It just seems a little complicated when the methods
 # below using DimTuple work better anyway.
-Base.similar(A::AbstractDimArray, i::Integer, I::Vararg{Integer}; kw...) =
-    similar(A, eltype(A), (i, I...); kw...)
 Base.similar(A::AbstractDimArray, I::Tuple{Int,Vararg{Int}}; kw...) = 
     similar(A, eltype(A), I; kw...)
 Base.similar(A::AbstractDimArray, ::Type{T}, i::Integer, I::Vararg{Integer}; kw...) where T =


### PR DESCRIPTION
This is already implemented in Base: https://github.com/JuliaLang/julia/blob/e1dda38c5151d5c31af584151f86c41779eaa6ad/base/abstractarray.jl#L825

Fixes these invalidations:
```julia
 inserting similar(T::Type{<:AbstractArray}, shape::Tuple{Union{Integer, Base.OneTo, DimensionalData.Dimensions.DimUnitRange}, Union{Integer, Base.OneTo, DimensionalData.Dimensions.DimUnitRange}, Union{Integer, Base.OneTo, DimensionalData.
Dimensions.DimUnitRange}, DimensionalData.Dimensions.DimUnitRange, Vararg{Union{Integer, Base.OneTo, DimensionalData.Dimensions.DimUnitRange}}}; kw...) @ DimensionalData ~/git/DimensionalData.jl/src/array/array.jl:238 invalidated:         
   mt_backedges: 1: signature Tuple{typeof(similar), Type{Array{@NamedTuple{region::UnitRange{Int64}, label::Symbol, value}, _A}} where _A, Any} triggered MethodInstance for Base._array_for_inner(::Type{@NamedTuple{region::UnitRange{Int64}
, label::Symbol, value}}, ::Base.HasShape, ::Any) (1 children)                                                                                                                                                                                 
                 2: signature Tuple{typeof(similar), Type{Array{String, _A}} where _A, Any} triggered MethodInstance for Base._array_for_inner(::Type{String}, ::Base.HasShape{N}, ::Any) where N (1 children)                                 
                 3: signature Tuple{typeof(similar), Type{Array{T, _A}} where {T, _A}, Any} triggered MethodInstance for Base._array_for_inner(::DataType, ::Base.HasShape{N}, ::Any) where N (1 children)                                     
                 4: signature Tuple{typeof(similar), Type{Array{Expr, _A}} where _A, Any} triggered MethodInstance for Base._array_for_inner(::Type{Expr}, ::Base.HasShape{N}, ::Any) where N (2 children)                                     
                 5: signature Tuple{typeof(similar), Type{Array{Int64, _A}} where _A, Any} triggered MethodInstance for Base._array_for_inner(::Type{Int64}, ::Base.HasShape, ::Any) (3 children)                                              
                 6: signature Tuple{typeof(similar), Type{Array{T, _A}} where {T, _A}, Any} triggered MethodInstance for Base._array_for_inner(::Type{T}, ::Base.HasShape{N}, ::Any) where {T, N} (6 children)                                 
                 7: signature Tuple{typeof(similar), Type{Array{Any, _A}} where _A, Any} triggered MethodInstance for Base._array_for_inner(::Type{Any}, ::Base.HasShape, ::Any) (9 children)                                                  
                 8: signature Tuple{typeof(similar), Type{BitArray}, Any} triggered MethodInstance for similar(::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N}}, ::Type{Bool}, ::Any) where N (51 children)
```

Part of #1046.