### PR TITLE
Backport: move DimensionalPlot back to the main package

### DIFF
--- a/ext/DimensionalDataRecipesBaseExt.jl
+++ b/ext/DimensionalDataRecipesBaseExt.jl
@@ -1,7 +1,7 @@
 module DimensionalDataRecipesBaseExt
 
 using DimensionalData
-using DimensionalData: Dimension, Lookup, NoLookup, Categorical, ForwardOrdered,
+using DimensionalData: Dimension, Lookup, NoLookup, Categorical, ForwardOrdered, DimensionalPlot,
     refdims_title, label, forward_order_plot_dims, reverse_order_plot_dims
 using RecipesBase: RecipesBase, @recipe
 
@@ -11,8 +11,6 @@ struct WireframeLike <: DimPlotMode seriestype::Symbol end
 struct SeriesLike <: DimPlotMode seriestype::Symbol end
 struct HistogramLike <: DimPlotMode seriestype::Symbol end
 struct ViolinLike <: DimPlotMode seriestype::Symbol end
-
-struct DimensionalPlot end
 
 @recipe function f(A::AbstractDimArray)
     DimensionalPlot(), A

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -34,3 +34,5 @@ end
 const PLOT_DIMENSION_ORDER = (TimeDim, XDim, IndependentDim, IndependentDim, YDim, ZDim, DependentDim, DependentDim, Dimension, Dimension, Dimension)
 forward_order_plot_dims(x) = dims(dims(x), PLOT_DIMENSION_ORDER)
 reverse_order_plot_dims(x) = reverse(forward_order_plot_dims(reverse(dims(x))))
+
+struct DimensionalPlot end


### PR DESCRIPTION
Turns out we need this in 0.29