### PR TITLE
Implement `checkbounds` with no args + with kwargs

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -43,8 +43,11 @@ function Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray; kw...)
     Base.checkbounds(Bool, A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
 end
 function Base.checkbounds(A::AbstractBasicDimArray; kw...)
-    isempty(kw) && return all(x -> x == 1, size(A))
-    Base.checkbounds(A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
+    if isempty(kw)
+        all(x -> x == 1, size(A)) || throw(BoundsError(A, ()))
+    else
+        Base.checkbounds(A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
+    end
 end
 
 """

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -39,11 +39,11 @@ Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray, d1::IDim, dims::IDim...
 Base.checkbounds(A::AbstractBasicDimArray, d1::IDim, dims::IDim...) =
     Base.checkbounds(A, dims2indices(A, (d1, dims...))...)
 function Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray; kw...)
-    isempty(kw) && return Base.checkbounds(Bool, CartesianIndices(A))
+    isempty(kw) && return all(x -> x == 1, size(A))
     Base.checkbounds(Bool, A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
 end
 function Base.checkbounds(A::AbstractBasicDimArray; kw...)
-    isempty(kw) && return Base.checkbounds(CartesianIndices(A))
+    isempty(kw) && return all(x -> x == 1, size(A))
     Base.checkbounds(A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
 end
 

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -39,16 +39,16 @@ Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray, d1::IDim, dims::IDim...
 Base.checkbounds(A::AbstractBasicDimArray, d1::IDim, dims::IDim...) =
     Base.checkbounds(A, dims2indices(A, (d1, dims...))...)
 function Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray; kw...)
-    isempty(kw) && return Base.checkbounds(Bool, parent(A))
+    isempty(kw) && return Base.checkbounds(Bool, CartesianIndices(A))
     Base.checkbounds(Bool, A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
 end
 function Base.checkbounds(A::AbstractBasicDimArray; kw...)
-    isempty(kw) && return Base.checkbounds(parent(A))
+    isempty(kw) && return Base.checkbounds(CartesianIndices(A))
     Base.checkbounds(A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
 end
 
 """
-    AbstractDimArray <: AbstractBasicArray
+    AbstractDimArray <: AbstractBasicDimArray
 
 Abstract supertype for all "dim" arrays.
 

--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -38,6 +38,14 @@ Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray, d1::IDim, dims::IDim...
     Base.checkbounds(Bool, A, dims2indices(A, (d1, dims...))...)
 Base.checkbounds(A::AbstractBasicDimArray, d1::IDim, dims::IDim...) =
     Base.checkbounds(A, dims2indices(A, (d1, dims...))...)
+function Base.checkbounds(::Type{Bool}, A::AbstractBasicDimArray; kw...)
+    isempty(kw) && return Base.checkbounds(Bool, parent(A))
+    Base.checkbounds(Bool, A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
+end
+function Base.checkbounds(A::AbstractBasicDimArray; kw...)
+    isempty(kw) && return Base.checkbounds(parent(A))
+    Base.checkbounds(A, _simplify_dim_indices(kw2dims(values(kw))...,)...)
+end
 
 """
     AbstractDimArray <: AbstractBasicArray

--- a/test/array.jl
+++ b/test/array.jl
@@ -27,6 +27,22 @@ da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
     checkbounds(da, X(2), Y(1))
     @test_throws BoundsError checkbounds(da, X(10), Y(20))
     @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
+
+    # kwargs
+    @test @inferred checkbounds(Bool, da2; row=1, column=1) == true
+    @test @inferred checkbounds(Bool, da2; row=10, column=1) == false
+    @test @inferred checkbounds(Bool, da2; row=10) == false
+    checkbounds(da2; row=1, column=1)
+    @test_throws BoundsError checkbounds(da2; row=10, column=20)
+    @test_throws BoundsError checkbounds(da2; row=1:10, column=1:20)
+    @test_throws BoundsError checkbounds(da2; row=10)
+
+    # zero arguments
+    single_elem = DimArray([42], (X,))
+    @test @inferred checkbounds(Bool, single_elem) == true
+    @test @inferred checkbounds(Bool, da) == false
+    checkbounds(single_elem)
+    @test_throws BoundsError checkbounds(da)
 end
 
 @testset "checkdims" begin

--- a/test/array.jl
+++ b/test/array.jl
@@ -22,27 +22,36 @@ val(dims(da, 1)) |> typeof
 da2 = DimArray(a2, dimz2; refdims=refdimz, name=:test2)
 
 @testset "checkbounds" begin
-    @test @inferred checkbounds(Bool, da, X(2), Y(1)) == true
-    @test @inferred checkbounds(Bool, da, X(10), Y(1)) == false
-    checkbounds(da, X(2), Y(1))
-    @test_throws BoundsError checkbounds(da, X(10), Y(20))
-    @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
+    # test on both AbstractDimArray and AbstractBasicDimArray
+    for abda in (da, DimIndices(da))
+        @test @inferred checkbounds(Bool, da, X(2), Y(1)) == true
+        @test @inferred checkbounds(Bool, da, X(10), Y(1)) == false
+        checkbounds(da, X(2), Y(1))
+        @test_throws BoundsError checkbounds(da, X(10), Y(20))
+        @test_throws BoundsError checkbounds(da, X(1:10), Y(2:20))
+    end
 
     # kwargs
-    @test @inferred checkbounds(Bool, da2; row=1, column=1) == true
-    @test @inferred checkbounds(Bool, da2; row=10, column=1) == false
-    @test @inferred checkbounds(Bool, da2; row=10) == false
-    checkbounds(da2; row=1, column=1)
-    @test_throws BoundsError checkbounds(da2; row=10, column=20)
-    @test_throws BoundsError checkbounds(da2; row=1:10, column=1:20)
-    @test_throws BoundsError checkbounds(da2; row=10)
+    for abda in (da2, DimIndices(da2))
+        @test @inferred checkbounds(Bool, abda; row=1, column=1) == true
+        @test @inferred checkbounds(Bool, abda; row=10, column=1) == false
+        @test @inferred checkbounds(Bool, abda; row=10) == false
+        checkbounds(abda; row=1, column=1)
+        @test_throws BoundsError checkbounds(abda; row=10, column=20)
+        @test_throws BoundsError checkbounds(abda; row=1:10, column=1:20)
+        @test_throws BoundsError checkbounds(abda; row=10)
+    end
 
     # zero arguments
     single_elem = DimArray([42], (X,))
-    @test @inferred checkbounds(Bool, single_elem) == true
-    @test @inferred checkbounds(Bool, da) == false
-    checkbounds(single_elem)
-    @test_throws BoundsError checkbounds(da)
+    for abda in (single_elem, DimIndices(single_elem))
+        @test @inferred checkbounds(Bool, abda) == true
+        checkbounds(abda)
+    end
+    for abda in (da, DimIndices(da))
+        @test @inferred checkbounds(Bool, da) == false
+        @test_throws BoundsError checkbounds(da)
+    end
 end
 
 @testset "checkdims" begin


### PR DESCRIPTION
Closes #1156. Prior to this, any call to `checkbounds` with either no arguments or with keyword arguments would error.

On a pragmatic note, I'm not sure whether you would like PR submitters to bump the patch number + add a changelog note. Over on the Turing.jl ecosystem, we do that with every PR, so I'm very happy to do it here; let me know!