### PR TITLE
:zap: (Change to _noname(::AbstractString) to support Substring)

### DIFF
--- a/src/array/array.jl
+++ b/src/array/array.jl
@@ -323,7 +323,7 @@ _arraytype(::Type{Bool}) = BitArray
 
 # Keep the same type in `similar`
 _noname(A::AbstractBasicDimArray) = _noname(name(A))
-_noname(s::String) = ""
+_noname(s::AbstractString) = ""
 _noname(::NoName) = NoName()
 _noname(::Symbol) = Symbol("")
 _noname(name::Name) = name # Keep the name so the type doesn't change

--- a/test/array.jl
+++ b/test/array.jl
@@ -641,3 +641,9 @@ end
     @test isequal(da, dshift) == false
     @test (da == dshift) == false
 end
+
+@testset "Substring name broadcast" begin
+  name_str = SubString("test_anme", 1, 4 )  # "test"
+  da = DimArray(rand(5), (X(1:5),); name=name_str)
+  @test_nowarn isfinite.(da)
+end


### PR DESCRIPTION
* Summary: Change _noname(::String) to _noname(::AbstractString) to support SubString.

* Reason: Currently, broadcasting operations (e.g., isfinite.(...)) fail with a MethodError if the array name is a SubString. Using AbstractString follows Julia's best practices and resolves this issue.

* Reproduce
```julia
using DimensionalData
da = DimArray(rand(5), (X(1:5),); name=SubString("test", 1, 2))
isfinite.(da) # This fails without the fix
```
