### PR TITLE
fix indexing with sliced DimSelectors

### DIFF
--- a/src/array/indexing.jl
+++ b/src/array/indexing.jl
@@ -198,7 +198,8 @@ Base.@assume_effects :foldable @inline _simplify_dim_indices(::Tuple{}) = ()
 Base.@assume_effects :foldable @inline _simplify_dim_indices(d::DimIndices, ds...) =
     (dims(d)..., _simplify_dim_indices(ds)...)
 Base.@assume_effects :foldable @inline function _simplify_dim_indices(d::DimSelectors, ds...)
-    seldims = map(dims(d), d.selectors) do d, s
+    sorteddims = dims((dims(d)..., _refdims_firsts(d)...), orderdims(d))
+    seldims = map(sorteddims, d.selectors) do d, s
         # But the dimension values inside selectors
         rebuild(d, rebuild(s; val=val(d)))
     end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -287,6 +287,12 @@ end
         da2[DimSelectors(da)] += da
         @test da == da1
         @test da == da2
+        
+        ## Passing selectors to DimSelectors works
+        da3 = set(da, Y(lookup(da, Y) .+ 0.1))
+        ds = DimSelectors(da; selectors = (At, Near))
+        da3[ds]
+        @test da3[ds[X(1)]] == da3[(X(1))]
     end
     
     @testset "selectors work" begin


### PR DESCRIPTION
closes https://github.com/rafaqz/DimensionalData.jl/issues/1189

Now respects `selectors` passed to `DimSelectors`, even after slicing