### PR TITLE
Specialize Base.sizeof() for AbstractDimArray

### DIFF
--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -629,3 +629,5 @@ Base.dataids(A::AbstractDimArray) = Base.dataids(parent(A))
 # We need to override copy_similar because our `similar` doesn't work with size changes
 # Fixed in Base in https://github.com/JuliaLang/julia/pull/53210
 LinearAlgebra.copy_similar(A::AbstractDimArray, ::Type{T}) where {T} = copyto!(similar(A, T), A)
+
+Base.sizeof(A::AbstractDimArray) = sizeof(parent(A))

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -946,3 +946,7 @@ end
         @test parent(mapreduce(identity, +, A; dims=(Y, Ti), init)) ≈ mapreduce(identity, +, parent(A); dims=(1, 2), init)
     end
 end
+
+@testset "sizeof()" begin
+    @test sizeof(rand(X(100))) == sizeof(rand(100))
+end


### PR DESCRIPTION
Previously `sizeof(::DimArray)` would report the size of the `DimArray` struct rather than the underlying array. Reporting the size of the array is consistent with `Array`.