### PR TITLE
Breaking: cat: preserve lookup values by demoting order to Unordered on misalignment

### DIFF
--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -560,6 +560,7 @@ struct Throw{M<:Union{AbstractString,Nothing}} <: AbstractMessage{M}
 end
 Throw() = Throw(nothing)
 _limit_sprint(x) = sprint(show, x; context = :limit => true)
+_limit_sprint_array(x) = sprint(Base.print_array, x; context = :limit => true)
 _dimsmismatchmsg(a, b) = "$(basetypeof(a)) and $(basetypeof(b)) dims on the same axis."
 _valmsg(a, b) = "Lookup values for $(basetypeof(a)) of $(_limit_sprint(parent(a))) and $(_limit_sprint(parent(b))) do not match."
 _dimsizemsg(a, b) = "Found both lengths $(length(a)) and $(length(b)) for $(basetypeof(a))."

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -455,13 +455,23 @@ end
 
 function _check_cat_lookups(D, ::Explicit, lookups...)
     for l in lookups
-        span(l) isa Explicit || (_mixed_span_warn(D, Explicit, span(l)); return :drop)
+        if span(l) isa Explicit
+            continue
+        else
+            _mixed_span_warn(D, Explicit, span(l))
+            return :drop
+        end
     end
     return :ok
 end
 function _check_cat_lookups(D, ::Irregular, lookups...)
     for l in lookups
-        span(l) isa Irregular || (_mixed_span_warn(D, Irregular, span(l)); return :drop)
+        if span(l) isa Irregular
+            continue
+        else
+            _mixed_span_warn(D, Irregular, span(l))
+            return :drop
+        end
     end
     return :ok
 end

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -301,10 +301,21 @@ function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
             else
                 # vcat the index for the catdim in each of Xin
                 joindims = map(A -> dims(A, catdim), Xin)
-                if !check_cat_lookups(joindims...) 
-                    return rebuild(catdim, NoLookup())
+                _status = check_cat_lookups(joindims...)
+                if _status === :ok
+                    _vcat_dims(joindims...)
+                elseif _status === :demote
+                    _vcat_dims_demote(joindims...)
+                elseif _status === :error
+                    D = basetypeof(first(joindims))
+                    intr = intersect(map(l -> Set(val(l)), lookup.(joindims))...)
+                    throw(DimensionMismatch(
+                        "Cannot concatenate along $D: lookups share values $intr. " *
+                        "Pass `dims=$D(newlookupvals)` with explicit lookup values."
+                    ))
+                else
+                    rebuild(catdim, NoLookup())
                 end
-                _vcat_dims(joindims...)
             end
         else
             # Concatenate new dims
@@ -351,7 +362,7 @@ function Base.hcat(As::Union{AbstractDimVector,AbstractDimMatrix}...)
         AnonDim(NoLookup())
     else
         joindims = map(last ∘ dims, As)
-        check_cat_lookups(joindims...) || return Base.hcat(map(parent, As)...)
+        check_cat_lookups(joindims...) === :ok || return Base.hcat(map(parent, As)...)
         _vcat_dims(joindims...)
     end
     noncatdim = dims(A1, 1)
@@ -369,7 +380,7 @@ end
 function Base.vcat(As::Union{AbstractDimVector,AbstractDimMatrix}...)
     A1 = first(As)
     firstdims = map(first ∘ dims, As)
-    check_cat_lookups(firstdims...) || return Base.vcat(map(parent, As)...)
+    check_cat_lookups(firstdims...) === :ok || return Base.vcat(map(parent, As)...)
     newdims = if A1 isa AbstractDimVector
         catdim = _vcat_dims(firstdims...)
         (catdim,)
@@ -391,38 +402,39 @@ end
 function Base.vcat(d1::Dimension, ds::Dimension...)
     dims = (d1, ds...)
     comparedims(dims...; length=false)
-    check_cat_lookups(dims...) || return Base.vcat(map(parent, dims)...)
+    check_cat_lookups(dims...) === :ok || return Base.vcat(map(parent, dims)...)
     return _vcat_dims(d1, ds...)
 end
 
 check_cat_lookups(dims::Dimension...) =
-    _check_cat_lookups(basetypeof(first(dims)), lookup(dims)...)
+    _check_cat_lookups(basetypeof(first(dims)), lookup(dims)...)::Symbol
 
 # Lookups may need adjustment for `cat`
 _check_cat_lookups(D, lookups::Lookup...) = _check_cat_lookup_order(D, lookups...)
-_check_cat_lookups(D, l1::NoLookup, lookups::NoLookup...) = true
+_check_cat_lookups(D, l1::NoLookup, lookups::NoLookup...) = :ok
 function _check_cat_lookups(D, l1::AbstractSampled, lookups::AbstractSampled...)
-    length(lookups) > 0 || return true
-    _check_cat_lookup_order(D, l1, lookups...) || return false
+    length(lookups) > 0 || return :ok
+    ostatus = _check_cat_lookup_order(D, l1, lookups...)
+    ostatus === :ok || return ostatus
     _check_cat_lookups(D, span(l1), l1, lookups...)
 end
 function _check_cat_lookups(D, ::Regular, lookups...)
-    length(lookups) > 1 || return true
+    length(lookups) > 1 || return :ok
     lastval = last(first(lookups))
     s = step(first(lookups))
-    map(Base.tail(lookups)) do l
+    for l in Base.tail(lookups)
         if !(span(l) isa Regular)
             _mixed_span_warn(D, Regular, span(l))
-            return false
+            return :drop
         end
         if !(step(span(l)) == s)
             @warn _cat_warn_string(D, "step sizes $(step(span(l))) and $s do not match")
-            return false
+            return :drop
         end
-        _check_cat_step_join(D, lastval, first(l), s) || return false
+        _check_cat_step_join(D, lastval, first(l), s) || return :drop
         lastval = last(l)
-        return true
-    end |> all
+    end
+    return :ok
 end
 
 function _check_cat_step_join(D, lastval::Number, firstval::Number, steplen)
@@ -442,58 +454,70 @@ function _check_cat_step_join(D, lastval, firstval, steplen)
 end
 
 function _check_cat_lookups(D, ::Explicit, lookups...)
-    map(lookups) do l
-        span(l) isa Explicit || _mixed_span_warn(D, Explicit, span(l))
-    end |> all
+    for l in lookups
+        span(l) isa Explicit || (_mixed_span_warn(D, Explicit, span(l)); return :drop)
+    end
+    return :ok
 end
 function _check_cat_lookups(D, ::Irregular, lookups...)
-    map(lookups) do l
-        span(l) isa Irregular || _mixed_span_warn(D, Irregular, span(l))
-    end |> all
+    for l in lookups
+        span(l) isa Irregular || (_mixed_span_warn(D, Irregular, span(l)); return :drop)
+    end
+    return :ok
 end
 
 function _check_cat_lookup_order(D, lookups::Lookup...)
-    length(lookups) > 1 || return true
+    length(lookups) > 1 || return :ok
     l1 = first(lookups)
     length(l1) == 0 && return _check_cat_lookup_order(D, Base.tail(lookups)...)
-    L = basetypeof(l1)
     x = last(l1)
     if isordered(l1)
-        map(Base.tail(lookups)) do lookup
-            length(lookup) > 0 || return true
+        for (i, lookup) in enumerate(Base.tail(lookups))
+            length(lookup) == 0 && continue
             if isforward(lookup)
                 if isreverse(l1)
                     _cat_mixed_ordered_warn(D)
-                    return false
-                elseif length(lookup) == 0 || first(lookup) > x
+                    return :demote
+                elseif first(lookup) > x
                     x = last(lookup)
-                    return true
                 else
                     x = last(lookup)
-                    _cat_lookup_overlap_warn(D, first(lookup), x)
-                    return false
+                    has_overlap = any(j -> !isempty(intersect(val(lookups[j]), val(lookup))), 1:i)
+                    if has_overlap
+                        _cat_lookup_overlap_warn(D, first(lookup), x)
+                        return :error
+                    else
+                        _cat_lookup_overlap_warn(D, first(lookup), x)
+                        return :demote
+                    end
                 end
             else
                 if isforward(l1)
                     _cat_mixed_ordered_warn(D)
-                    return false
-                elseif length(lookup) == 0 || first(lookup) < x
+                    return :demote
+                elseif first(lookup) < x
                     x = last(lookup)
-                    return true
                 else
                     x = last(lookup)
-                    _cat_lookup_overlap_warn(D, first(lookup), x)
-                    return false
+                    has_overlap = any(j -> !isempty(intersect(val(lookups[j]), val(lookup))), 1:i)
+                    if has_overlap
+                        _cat_lookup_overlap_warn(D, first(lookup), x)
+                        return :error
+                    else
+                        _cat_lookup_overlap_warn(D, first(lookup), x)
+                        return :demote
+                    end
                 end
             end
-        end |> all
+        end
+        return :ok
     else
         intr = intersect(lookups...)
         if length(intr) == 0
-            return true
+            return :ok
         else
             _cat_lookup_intersect_warn(D, intr)
-            return false
+            return :error
         end
     end
 end
@@ -501,6 +525,25 @@ end
 function _vcat_dims(d1::Dimension, ds::Dimension...)
     dims = (d1, ds...)
     newlookup = _vcat_lookups(lookup(dims)...)
+    return rebuild(d1, newlookup)
+end
+
+function _vcat_dims_demote(d1::Dimension, ds::Dimension...)
+    dims = (d1, ds...)
+    ls = lookup(dims)
+    newindex = _vcat_index(ls...)
+    newlookup = if first(ls) isa AbstractSampled
+        bnds = map(l -> extrema(val(l)), ls)
+        newbounds = (minimum(map(first, bnds)), maximum(map(last, bnds)))
+        sp = if sampling(first(ls)) isa Intervals
+            Irregular(newbounds)
+        else
+            Irregular(nothing, nothing)
+        end
+        rebuild(first(ls); data=newindex, order=Unordered(), span=sp)
+    else
+        rebuild(first(ls); data=newindex, order=Unordered())
+    end
     return rebuild(d1, newlookup)
 end
 
@@ -555,7 +598,7 @@ end
 
 @noinline _cat_mixed_ordered_warn(D) = @warn _cat_warn_string(D, "`Ordered` lookups are mixed `ForwardOrdered` and `ReverseOrdered`")
 @noinline _cat_lookup_overlap_warn(D, x1, x2) = @warn _cat_warn_string(D, "`Ordered` lookups are misaligned at $x2 and $x1")
-@noinline _cat_lookup_intersect_warn(D, intr) = @warn _cat_warn_string(D, "`Unorderd` lookups share values: $intr")
+@noinline _cat_lookup_intersect_warn(D, intr) = @warn _cat_warn_string(D, "`Unordered` lookups share values: $intr")
 
 @noinline _mixed_span_error(D, S, span) = throw(DimensionMismatch(_span_string(D, S, span)))
 @noinline function _mixed_span_warn(D, S, span)

--- a/src/array/methods.jl
+++ b/src/array/methods.jl
@@ -304,13 +304,14 @@ function _cat(catdims::Tuple, A1::AbstractDimArray, As::AbstractDimArray...)
                 _status = check_cat_lookups(joindims...)
                 if _status === :ok
                     _vcat_dims(joindims...)
-                elseif _status === :demote
-                    _vcat_dims_demote(joindims...)
-                elseif _status === :error
+                elseif _status === :unordered
+                    _vcat_dims_unordered(joindims...)
+                elseif _status === :intersecting
                     D = basetypeof(first(joindims))
                     intr = intersect(map(l -> Set(val(l)), lookup.(joindims))...)
+                    intr_repr = Dimensions._limit_sprint_array(reshape(collect(intr), :, 1))
                     throw(DimensionMismatch(
-                        "Cannot concatenate along $D: lookups share values $intr. " *
+                        "Cannot concatenate along $D: lookups share values: \nShared:\n$intr_repr \n\n" *
                         "Pass `dims=$D(newlookupvals)` with explicit lookup values."
                     ))
                 else
@@ -425,13 +426,13 @@ function _check_cat_lookups(D, ::Regular, lookups...)
     for l in Base.tail(lookups)
         if !(span(l) isa Regular)
             _mixed_span_warn(D, Regular, span(l))
-            return :drop
+            return :mismatch
         end
         if !(step(span(l)) == s)
             @warn _cat_warn_string(D, "step sizes $(step(span(l))) and $s do not match")
-            return :drop
+            return :mismatch
         end
-        _check_cat_step_join(D, lastval, first(l), s) || return :drop
+        _check_cat_step_join(D, lastval, first(l), s) || return :mismatch
         lastval = last(l)
     end
     return :ok
@@ -459,7 +460,7 @@ function _check_cat_lookups(D, ::Explicit, lookups...)
             continue
         else
             _mixed_span_warn(D, Explicit, span(l))
-            return :drop
+            return :mismatch
         end
     end
     return :ok
@@ -470,7 +471,7 @@ function _check_cat_lookups(D, ::Irregular, lookups...)
             continue
         else
             _mixed_span_warn(D, Irregular, span(l))
-            return :drop
+            return :mismatch
         end
     end
     return :ok
@@ -487,7 +488,7 @@ function _check_cat_lookup_order(D, lookups::Lookup...)
             if isforward(lookup)
                 if isreverse(l1)
                     _cat_mixed_ordered_warn(D)
-                    return :demote
+                    return :unordered
                 elseif first(lookup) > x
                     x = last(lookup)
                 else
@@ -495,16 +496,16 @@ function _check_cat_lookup_order(D, lookups::Lookup...)
                     has_overlap = any(j -> !isempty(intersect(val(lookups[j]), val(lookup))), 1:i)
                     if has_overlap
                         _cat_lookup_overlap_warn(D, first(lookup), x)
-                        return :error
+                        return :intersecting
                     else
                         _cat_lookup_overlap_warn(D, first(lookup), x)
-                        return :demote
+                        return :unordered
                     end
                 end
             else
                 if isforward(l1)
                     _cat_mixed_ordered_warn(D)
-                    return :demote
+                    return :unordered
                 elseif first(lookup) < x
                     x = last(lookup)
                 else
@@ -512,10 +513,10 @@ function _check_cat_lookup_order(D, lookups::Lookup...)
                     has_overlap = any(j -> !isempty(intersect(val(lookups[j]), val(lookup))), 1:i)
                     if has_overlap
                         _cat_lookup_overlap_warn(D, first(lookup), x)
-                        return :error
+                        return :intersecting
                     else
                         _cat_lookup_overlap_warn(D, first(lookup), x)
-                        return :demote
+                        return :unordered
                     end
                 end
             end
@@ -526,8 +527,7 @@ function _check_cat_lookup_order(D, lookups::Lookup...)
         if length(intr) == 0
             return :ok
         else
-            _cat_lookup_intersect_warn(D, intr)
-            return :error
+            return :intersecting
         end
     end
 end
@@ -538,7 +538,7 @@ function _vcat_dims(d1::Dimension, ds::Dimension...)
     return rebuild(d1, newlookup)
 end
 
-function _vcat_dims_demote(d1::Dimension, ds::Dimension...)
+function _vcat_dims_unordered(d1::Dimension, ds::Dimension...)
     dims = (d1, ds...)
     ls = lookup(dims)
     newindex = _vcat_index(ls...)
@@ -608,7 +608,6 @@ end
 
 @noinline _cat_mixed_ordered_warn(D) = @warn _cat_warn_string(D, "`Ordered` lookups are mixed `ForwardOrdered` and `ReverseOrdered`")
 @noinline _cat_lookup_overlap_warn(D, x1, x2) = @warn _cat_warn_string(D, "`Ordered` lookups are misaligned at $x2 and $x1")
-@noinline _cat_lookup_intersect_warn(D, intr) = @warn _cat_warn_string(D, "`Unordered` lookups share values: $intr")
 
 @noinline _mixed_span_error(D, S, span) = throw(DimensionMismatch(_span_string(D, S, span)))
 @noinline function _mixed_span_warn(D, S, span)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -677,10 +677,28 @@ end
     end
 
     @testset "use lookup from dims" begin
-        @test_warn "lookups are misaligned" cat(da, db; dims=2)
+        @test_throws DimensionMismatch cat(da, db; dims=2)
         @test dims(cat(da, db; dims=X()), X) === X(NoLookup(Base.OneTo(4)))
         @test dims(cat(da, db; dims=X(NoLookup())), X) === X(NoLookup(Base.OneTo(4)))
         @test dims(cat(da, db; dims=X(1.0:4.0)), X) === X(Sampled(1.0:4.0, ForwardOrdered(), Regular(1.0), Points(), NoMetadata()))
+    end
+
+    @testset "misaligned ordered lookups are demoted to Unordered" begin
+        # Non-overlapping but out-of-order → demote to Unordered
+        dd_1 = DimArray(1:3, Ti([Date(2011), Date(2013), Date(2015)]))
+        dd_2 = DimArray(1:3, Ti([Date(2010), Date(2012), Date(2014)]))
+        @test_warn "misaligned" begin
+            result = cat(dd_1, dd_2; dims=Ti)
+            @test order(lookup(result, Ti)) isa Unordered
+            @test val(dims(result, Ti)) == [Date(2011), Date(2013), Date(2015), Date(2010), Date(2012), Date(2014)]
+            @test parent(result) == [1, 2, 3, 1, 2, 3]
+        end
+    end
+
+    @testset "overlap throws DimensionMismatch via cat" begin
+        dd_a = DimArray(1:3, X([1, 2, 3]))
+        dd_b = DimArray(4:6, X([3, 4, 5]))  # shares value 3
+        @test_throws DimensionMismatch cat(dd_a, dd_b; dims=X)
     end
 
     @testset "cat empty dimarrays" begin


### PR DESCRIPTION
Hello,

Currently, `cat` (or `Base.cat`) of two `AbstractDimArray`s (or `AbstractDimStack`s) along a dimension whose lookups are `ForwardOrdered` but not strictly contiguous silently **drops the lookup values**, replacing them with `NoLookup()`. For example:

```julia
dd_1 = DimArray(1:3, Ti([Date(2011), Date(2013), Date(2015)]))
dd_2 = DimArray(1:3, Ti([Date(2010), Date(2012), Date(2014)]))
cat(dd_1, dd_2; dims=Ti)     # ─╯ warns "misaligned" and returns Ti(NoLookup(...))
```

Once the coordinates are gone, there is no way to sort/recover them `sortby` (or `Base.sort`) also drops lookups (differently, but just as fatally). This makes it impossible to concatenate disjoint time-series chunks and then sort the result.

Closes #1207

## Approach

Replace the `check_cat_lookups(...)::Bool` return with a **Symbol tri-state**:

| Symbol | Meaning | Action in `_cat` |
|---|---|---|
| `:ok` | contiguous ordered, or any `NoLookup` | proceed normally (`_vcat_dims`) |
| `:demote` | misaligned/mixed-order but **no exact value overlap** | values preserved via new `_vcat_dims_demote`, order → `Unordered()`, span → `Irregular` |
| `:error` | exact value overlap (`intersect(lookups...)` non-empty) | `throw(DimensionMismatch(...))` |
| `:drop` | span/step mismatch | `rebuild(catdim, NoLookup())` (unchanged) |

The new `_vcat_dims_demote` helper reuses the existing `_vcat_index` machinery (the same `maybeshiftlocus` + `reduce(vcat, …)` from the success path) to concatenate the raw lookup values, then rebuilds the dimension with `order=Unordered()` and an `Irregular` span. This keeps the coordinates intact so downstream operations like `sortperm` + indexing (or a future `sortby`) can recover a `ForwardOrdered` result.

For the fallbacks `hcat`/`vcat`/`vcat(::Dimension,…)` the Symbol return is handled but **behaviour is unchanged**: they still warn and fall back to `Base.hcat(map(parent,…))` / `Base.vcat(map(parent,…))`. 

## Example after the fix

```julia
julia> cat(dd_1, dd_2; dims=Ti)
┌ Warning: `Ordered` lookups are misaligned at 2014-01-01 and 2010-01-01
│ on dimension Ti.
└ @ DimensionalData .../methods.jl:557
┌ 6-element DimArray{Int64, 1} ┐
├──────────────────────────────┴───────────────────────────────────── dims ┐
  ↓ Ti Sampled{Date} [Date("2011-01-01"), …, Date("2014-01-01")]
      Unordered Irregular Points
└──────────────────────────────────────────────────────────────────────────┘
 2011-01-01  1
 2013-01-01  2
 2015-01-01  3
 2010-01-01  1
 2012-01-01  2
 2014-01-01  3
```

The values are preserved. A subsequent `sortby` (or `ds[Ti=sortperm(lookup(ds,Ti))]`)
recovers `ForwardOrdered`.

## What changed

**`src/array/methods.jl`**
- `check_cat_lookups` → returns `::Symbol` instead of `::Bool`
- `_check_cat_lookup_order` → returns `:ok`/`:demote`/`:error`; tracks an
  accumulated `Set` to detect exact value overlap
- `_check_cat_lookups` → two-level chain: order check passes through to span
  check only on `:ok`; `:demote` short-circuits (span validation is meaningless
  when demoted)
- `_check_cat_lookups(D, ::Regular, …)` / `::Explicit` / `::Irregular` → return
  `:ok`/`:drop` (converted from `true`/`false`)
- New `_vcat_dims_demote(d1, ds…)` — concatenates values and rebuilds with
  `order=Unordered()`, `span=Irregular(combined bounds)` for `Intervals` /
  `Irregular(nothing,nothing)` for `Points`
- `_cat` call site: branches on `:ok` / `:demote` / `:error` / `else` (`:drop`)
- `hcat`, `vcat`, `vcat(::Dimension)` call sites: only `:ok` succeeds; anything
  else falls back (unchanged behaviour)
- Fixed `Unorderd` typo → `Unordered` in `_cat_lookup_intersect_warn`

**`test/methods.jl`**
- Flipped `@test_warn "misaligned" cat(da, db; dims=2)` → `@test_throws`
  (identical Y lookups = exact overlap, now correctly errors)
- New `"misaligned ordered lookups are demoted to Unordered"` testset
  (reproduces #1207, asserts `Unordered` + values preserved)
- New `"overlap throws DimensionMismatch via cat"` testset

## Open questions

1. **`hcat`/`vcat` inconsistency**: should they also demote on misalignment
   rather than falling back to a plain Array? Currently out of scope — only
   `_cat` was changed. Maybe a separate PR?
2. **`sortby` companion**: a helper like
   `sortby(x, dim) = set(x[rebuild(dims(x,dim), sortperm(lookup(x,dim)))], dim => ForwardOrdered())`
   is a natural partner to this fix. Should it be added in a follow-up PR
   or included here?
3. **Overlap behaviour**: currently overlap (exact shared values) throws
   `DimensionMismatch` in `_cat`. For `hcat`/`vcat` it still warns and
   falls back. Should this be made consistent in a follow-up?

## Related:
- #1014 touches the same code but it's orthogonal to this one, both can be merged together mechanically.

## Disclosure
PR was an initial hand implementation of https://github.com/rafaqz/DimensionalData.jl/issues/1207#issuecomment-4980788614, then checked and refined with an agent.