### PR TITLE
Make `reducedims()` type-stable for dim type queries

### DIFF
--- a/src/Dimensions/merged.jl
+++ b/src/Dimensions/merged.jl
@@ -101,9 +101,6 @@ end
 
 # Dimension methods
 
-@inline _reducedims(lookup::MergedLookup, dim::Dimension) =
-    rebuild(dim, [map(x -> zero(x), dim.val[1])])
-
 function _format(dim::Dimension{<:MergedLookup}, axis::AbstractRange)
     checkaxis(dim, axis)
     return dim

--- a/src/Dimensions/primitives.jl
+++ b/src/Dimensions/primitives.jl
@@ -491,18 +491,19 @@ but the number of dimensions has not changed.
 cell step, sampling type and order.
 """
 function reducedims end
-@inline reducedims(x, dimstoreduce) = _reducedims(x, name2dim(dimstoreduce))
+@inline reducedims(x, dimstoreduce) = _dim_query(_reducedims, AlwaysTuple(), x, dimstoreduce)
+# The query machinery can't take a single `Dimension` as the object to query
+@inline reducedims(dim::Dimension, dimstoreduce) = first(reducedims((dim,), dimstoreduce))
+@inline reducedims(dim::Dimension) = rebuild(dim, reducelookup(lookup(dim)))
 
-@inline _reducedims(x, dimstoreduce) = _reducedims(x, (dimstoreduce,))
-@inline _reducedims(x, dimstoreduce::Tuple) = _reducedims(dims(x), dimstoreduce)
-@inline _reducedims(dims::DimTuple, dimstoreduce::Tuple) =
-    map(_reducedims, dims, sortdims(dimstoreduce, dims))
-# Map numbers to corresponding dims. Not always type-stable
-@inline _reducedims(dims::DimTuple, dimstoreduce::Tuple{Vararg{Int}}) =
-    map(_reducedims, dims, sortdims(map(i -> dims[i], dimstoreduce), dims))
+@inline _reducedims(f, dims::Tuple, dimstoreduce::Tuple) =
+    map(_reducedims1, dims, _sortdims(f, dimstoreduce, dims))
+# Map integers to corresponding dims. Not always type-stable
+@inline _reducedims(f, dims::Tuple, dimstoreduce::Tuple{Integer,Vararg{Integer}}) =
+    _reducedims(f, dims, map(i -> basedims(dims[i]), dimstoreduce))
 # Reduce matching dims but ignore nothing vals - they are the dims not being reduced
-@inline _reducedims(dim::Dimension, ::Nothing) = dim
-@inline _reducedims(dim::Dimension, ::DimOrDimType) = rebuild(dim, reducelookup(lookup(dim)))
+@inline _reducedims1(dim::Dimension, ::Nothing) = dim
+@inline _reducedims1(dim::Dimension, _) = rebuild(dim, reducelookup(lookup(dim)))
 
 const DimTupleOrEmpty = Union{DimTuple,Tuple{}}
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -143,8 +143,7 @@ end
     @testset "inference" begin
         x = DimArray(randn(2, 3, 4), (X, Y, Z));
         foo(x) = maximum(x; dims=(X, Y))
-        # TODO: this test recently broke
-        # @inferred foo(x)
+        @inferred foo(x)
     end
 end
 
@@ -255,8 +254,7 @@ end
     @testset "inference" begin
         x = DimArray(randn(2, 3, 4), (X, Y, Z));
         foo(x) = maximum(x; dims=(1, 2))
-        # TODO: this test recently broke
-        # @inferred foo(x)
+        @inferred foo(x)
     end
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,7 +1,7 @@
 using DimensionalData, Dates, Test , BenchmarkTools
 using DimensionalData.Lookups, DimensionalData.Dimensions
 
-using .Dimensions: _dim_query, _wraparg, _reducedims, AlwaysTuple, MaybeFirst, comparedims, promotedims
+using .Dimensions: _dim_query, _wraparg, AlwaysTuple, MaybeFirst, comparedims, promotedims
 
 @dim Tst
 
@@ -497,37 +497,37 @@ end
 end
 
 @testset "reducedims" begin
-    @test _reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Points(), NoMetadata())),
+    @test reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Points(), NoMetadata())),
                  Y(Sampled(1:5, ForwardOrdered(), Regular(1), Points(), NoMetadata()))), (X, Y)) ==
                      (X(Sampled(3.5:2:3.5, ForwardOrdered(), Regular(2.0), Points(), NoMetadata())),
                       Y(Sampled(3.0:5.0:3.0, ForwardOrdered(), Regular(5.0), Points(), NoMetadata())))
-    @test _reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Intervals(Start()), NoMetadata())),
+    @test reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Intervals(Start()), NoMetadata())),
                        Y(Sampled(1:5, ForwardOrdered(), Regular(1), Intervals(End()), NoMetadata()))), (X, Y)) ==
         (X(Sampled(3:2:3, ForwardOrdered(), Regular(2), Intervals(Start()), NoMetadata())),
          Y(Sampled(5:5:5, ForwardOrdered(), Regular(5), Intervals(End()), NoMetadata())))
 
-   @test _reducedims((X(Sampled(3:4, ForwardOrdered(), Irregular(2.5, 4.5), Intervals(Center()), NoMetadata())),
+   @test reducedims((X(Sampled(3:4, ForwardOrdered(), Irregular(2.5, 4.5), Intervals(Center()), NoMetadata())),
                       Y(Sampled(1:5, ForwardOrdered(), Irregular(0.5, 5.5), Intervals(Center()), NoMetadata()))), (X, Y))[1] ==
        (X(Sampled([3.5], ForwardOrdered(), Irregular(2.5, 4.5), Intervals(Center()), NoMetadata())),
         Y(Sampled([3.0], ForwardOrdered(), Irregular(0.5, 5.5), Intervals(Center()), NoMetadata())))[1]
-   @test _reducedims((X(Sampled(3:4, ForwardOrdered(), Irregular(3, 5), Intervals(Start()), NoMetadata())),
+   @test reducedims((X(Sampled(3:4, ForwardOrdered(), Irregular(3, 5), Intervals(Start()), NoMetadata())),
                       Y(Sampled(1:5, ForwardOrdered(), Irregular(0, 5), Intervals(End()), NoMetadata()))), (X, Y))[1] ==
       (X(Sampled([3], ForwardOrdered(), Irregular(3, 5), Intervals(Start()), NoMetadata())),
        Y(Sampled([5], ForwardOrdered(), Irregular(0, 5), Intervals(End()), NoMetadata())))[1]
 
     args = ForwardOrdered(), Irregular(), Points(), NoMetadata()
-    @test _reducedims((X(Sampled(3:4, args...)), Y(Sampled(1:5, args...))), (X, Y)) ==
+    @test reducedims((X(Sampled(3:4, args...)), Y(Sampled(1:5, args...))), (X, Y)) ==
         (X(Sampled([3.5], args...)), Y(Sampled([3.0], args...)))
-    @test _reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Points(), NoMetadata())),
+    @test reducedims((X(Sampled(3:4, ForwardOrdered(), Regular(1), Points(), NoMetadata())),
                        Y(Sampled(1:5, ForwardOrdered(), Regular(1), Points(), NoMetadata()))), (X, Y)) ==
                       (X(Sampled(3.5:2.0:3.5, ForwardOrdered(), Regular(2.0), Points(), NoMetadata())),
                        Y(Sampled(3.0:5.0:3.0, ForwardOrdered(), Regular(5.0), Points(), NoMetadata())))
 
-    @test _reducedims((X(Categorical([:a,:b])),
+    @test reducedims((X(Categorical([:a,:b])),
                        Y(Categorical(["1","2","3","4","5"]))), (X, Y)) ==
         (X(Categorical([:combined])), Y(Categorical(["combined"])))
 
-    @test _reducedims((X(NoLookup(Base.OneTo(10))),
+    @test reducedims((X(NoLookup(Base.OneTo(10))),
                  Y(NoLookup(Base.OneTo(10)))), (X(), Y())) ==
         (X(NoLookup(Base.OneTo(1))), Y(NoLookup(Base.OneTo(1))))
 
@@ -536,7 +536,7 @@ end
         timespan = [DateTime(2001, 1), DateTime(2001, 1, 3)]
         teststep = Dates.CompoundPeriod([Month(2), Day(6)])
         testdim = Ti(Sampled([DateTime(2001, 1, 2)], ForwardOrdered(), Regular(teststep), Points(), NoMetadata()))
-        reduceddim = _reducedims((Ti(Sampled(timespan, ForwardOrdered(), Regular(step_), Points(), NoMetadata())),), (Ti,))[1]
+        reduceddim = reducedims((Ti(Sampled(timespan, ForwardOrdered(), Regular(step_), Points(), NoMetadata())),), (Ti,))[1]
         @test typeof(testdim) == typeof(reduceddim)
         @test testdim == reduceddim
         @test step(testdim) == step(reduceddim)


### PR DESCRIPTION
Fixes #1163 by using `_dim_query()` internally to preserve type stability. Also switched to using `reducedims()` in the tests rather than `_reducedims()`.

Mostly written by Claude :robot: 