### PR TITLE
Use optimization level 0 in the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - macOS-latest
           - windows-latest
         arch:
-          - x64
+          - default
         allow_failure: [false]
         include:
           - version: 'nightly'
@@ -37,13 +37,15 @@ jobs:
             arch: x64
             allow_failure: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-runtest@latest
+        with:
+          optimize: 0
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Should make running them a bit faster. Also updated some other action versions.

Tried it locally on the FFT tests and the running time went from 25s -> 16s.