### PR TITLE
Fix bins and categorical axes in violin/raincloud/boxplots

### DIFF
--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -169,7 +169,7 @@ for (p1) in PlotTypes_Cat_1D
     f1! = Symbol(f1, '!')
     
     @eval begin
-        function Makie.$f1(fig::MakieGrids, A::MayObs{AbstractDimArray}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
+        function Makie.$f1(fig::MakieGrids, A::MayObs{AbstractDimMatrix}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
             error_if_has_content(fig)
 
             ax_type = haskey(axis, :type) ? axis[:type] : default_axis_type($p1, A)
@@ -226,7 +226,7 @@ function axis_attributes(::Type{Series}, A::MayObs{DD.AbstractDimMatrix}; labeld
     )
 end
 
-function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimArray}; categoricaldim)
+function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimMatrix}; categoricaldim)
     categoricaldim = _categorical_or_dependent(to_value(A), categoricaldim)
     isnothing(categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups"))
 
@@ -664,10 +664,8 @@ function _lookup_to_vector(l)
         bs = intervalbounds(l)
         x = first.(bs)
         push!(x, last(last(bs)))
-    elseif iscategorical(l)
+    else # points or categorical
         get_number_version(l)
-    else # ispoints(l) but not categorical
-        collect(parent(l))
     end
 end
 

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -169,7 +169,7 @@ for (p1) in PlotTypes_Cat_1D
     f1! = Symbol(f1, '!')
     
     @eval begin
-        function Makie.$f1(fig::MakieGrids, A::MayObs{AbstractDimMatrix}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
+        function Makie.$f1(fig::MakieGrids, A::MayObs{DD.AbstractDimVecOrMat}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
             error_if_has_content(fig)
 
             ax_type = haskey(axis, :type) ? axis[:type] : default_axis_type($p1, A)
@@ -185,6 +185,10 @@ for (p1) in PlotTypes_Cat_1D
             add_labels_to_lscene(ax, axis_att)
 
             return Makie.AxisPlot(ax, p)
+        end
+
+        function Makie.$f1(fig::MakieGrids, A::MayObs{<:AbstractDimArray}; kwargs...)
+            throw(ArgumentError("$($f1) needs a 1D or 2D AbstractDimArray, got $(ndims(to_value(A))) dimensions"))
         end
     end
 end
@@ -226,7 +230,7 @@ function axis_attributes(::Type{Series}, A::MayObs{DD.AbstractDimMatrix}; labeld
     )
 end
 
-function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimMatrix}; categoricaldim)
+function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimVecOrMat}; categoricaldim)
     categoricaldim = _categorical_or_dependent(to_value(A), categoricaldim)
     isnothing(categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups"))
 

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -447,7 +447,7 @@ Makie.used_attributes(::Type{<:Union{VolumeSlices, Volume}}, A::DD.AbstractDimAr
 
 function Makie.convert_arguments(P::Type{T}, A::AbstractDimMatrix; xdim = nothing , ydim = nothing) where T<:Union{Contour, Contourf, Surface, Contour3d}
     dims_axes = get_dimensions_of_makie_axis(A, (xdim, ydim))
-    xlookup, ylookup = (lookup(dims_axes[1]), lookup(dims_axes[2])) .|> parent .|> get_number_version
+    xlookup, ylookup = (lookup(dims_axes[1]), lookup(dims_axes[2])) .|> get_number_version
     z = parent(permutedims(A, (dims_axes[1], dims_axes[2]))) 
     Makie.convert_arguments(P, xlookup, ylookup, z) 
 end
@@ -456,13 +456,13 @@ function Makie.convert_arguments(P::Type{<:Series}, A::AbstractDimMatrix; labeld
     categoricaldim = _categorical_or_dependent(A, labeldim)
     isnothing(categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups")) # This should never happen
     otherdim = only(otherdims(A, categoricaldim))
-    xs = parent(lookup(A, otherdim)) |> get_number_version 
+    xs = lookup(A, otherdim) |> get_number_version
     return Makie.convert_arguments(P, xs, parent(permutedims(A, (categoricaldim, otherdim))))
 end
 
 # PointBased conversions (scatter, lines, poly, etc)
 function Makie.convert_arguments(P::Makie.PointBased, A::AbstractDimVector)
-    xs = parent(lookup(A, 1)) |> get_number_version
+    xs = lookup(A, 1) |> get_number_version
     return Makie.convert_arguments(P, xs, parent(A))
 end
 
@@ -479,7 +479,7 @@ function Makie.convert_arguments(P::Makie.SampleBased, A::AbstractDimVector; cat
     if !isnothing(categoricaldim) 
         dimnum(A, categoricaldim) # Returns an error if dim does not exist
     end
-    xs = parent(lookup(A, 1)) |> get_number_version
+    xs = lookup(A, 1) |> get_number_version
     return Makie.convert_arguments(P, xs, parent(A))
 end
 
@@ -487,7 +487,7 @@ function Makie.convert_arguments(P::Type{<:RainClouds}, A::AbstractDimVector; ca
     if !isnothing(categoricaldim) 
         dimnum(A, categoricaldim) # Returns an error if dim does not exist
     end
-    xs = parent(lookup(A, 1)) |> get_number_version
+    xs = lookup(A, 1) |> get_number_version
     return Makie.convert_arguments(P, xs, parent(A))
 end
 
@@ -496,9 +496,9 @@ function Makie.convert_arguments(P::Type{<:Union{Makie.RainClouds, BoxPlot, Viol
     isnothing(dd_categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups")) # This should never happen
     otherdim = only(otherdims(A, dd_categoricaldim))
     # Stack categorical dimensions end-to-end
-    xs = repeat(parent(lookup(A, dd_categoricaldim)); inner=size(A, otherdim))
+    xs = repeat(get_number_version(lookup(A, dd_categoricaldim)); inner=size(A, otherdim))
     ys = vec(parent(permutedims(A, (otherdim, dd_categoricaldim))))
-    return Makie.convert_arguments(P, get_number_version(xs), ys)
+    return Makie.convert_arguments(P, xs, ys)
 end
 
 # Grid based conversions (surface, image, heatmap, contour, meshimage, etc)
@@ -524,7 +524,7 @@ end
 function Makie.convert_arguments(
     P::Type{Heatmap}, A::AbstractDimMatrix; xdim = nothing, ydim = nothing)
     dims_axes = get_dimensions_of_makie_axis(A, (xdim, ydim))
-    xlookup, ylookup = (lookup(dims_axes[1]), lookup(dims_axes[2])) .|> parent .|> get_number_version
+    xlookup, ylookup = (lookup(dims_axes[1]), lookup(dims_axes[2])) .|> get_number_version
     z = parent(permutedims(A, (dims_axes[1], dims_axes[2])))
     return Makie.convert_arguments(P, xlookup, ylookup, z)
 end
@@ -539,7 +539,7 @@ end
 
 function Makie.convert_arguments(P::Type{Makie.VolumeSlices}, A::AbstractDimArray{<:Any,3}; xdim = nothing, ydim = nothing, zdim = nothing)
     dims_axes = get_dimensions_of_makie_axis(A, (xdim, ydim, zdim))
-    xs, ys, zs = map(_lookup_to_vector, dims_axes) .|> get_number_version
+    xs, ys, zs = map(d -> _lookup_to_vector(lookup(d)), dims_axes)
     return Makie.convert_arguments(P, xs, ys, zs, parent(permutedims(A, dims_axes)))
 end
 
@@ -618,9 +618,8 @@ function get_axis_ticks(l::MayObs{D}, axis) where D<:DD.Dimension
 end
 
 get_number_version(x) = x
-get_number_version(x::AbstractVector{<:AbstractChar}) = Int.(x)
-get_number_version(x::AbstractVector{<:AbstractString}) = sum.(Int, x) # Sum all chars
-get_number_version(x::AbstractVector{<:Symbol}) = get_number_version(string.(x))
+get_number_version(x::AbstractCategorical) = eachindex(x)
+get_number_version(x::Lookup) = get_number_version(parent(x))
 get_number_version(x::IntervalSets.ClosedInterval{<:AbstractChar}) = IntervalSets.ClosedInterval((Int.(endpoints(x)) .+ (-.5, .5))...) # Needs to add half the step this do give the interval like heatmap
 get_number_version(x::IntervalSets.ClosedInterval) = x
 
@@ -662,7 +661,9 @@ function _lookup_to_vector(l)
         bs = intervalbounds(l)
         x = first.(bs)
         push!(x, last(last(bs)))
-    else # ispoints(l)
+    elseif iscategorical(l)
+        get_number_version(l)
+    else # ispoints(l) but not categorical
         collect(parent(l))
     end
 end

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -169,7 +169,7 @@ for (p1) in PlotTypes_Cat_1D
     f1! = Symbol(f1, '!')
     
     @eval begin
-        function Makie.$f1(fig::MakieGrids, A::MayObs{AbstractDimMatrix}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
+        function Makie.$f1(fig::MakieGrids, A::MayObs{AbstractDimArray}; categoricaldim = nothing, axis = (;), plot_user_attributes...)
             error_if_has_content(fig)
 
             ax_type = haskey(axis, :type) ? axis[:type] : default_axis_type($p1, A)
@@ -226,7 +226,7 @@ function axis_attributes(::Type{Series}, A::MayObs{DD.AbstractDimMatrix}; labeld
     )
 end
 
-function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimMatrix}; categoricaldim)
+function axis_attributes(::Type{<:Union{RainClouds, BoxPlot, Violin}}, A::MayObs{DD.AbstractDimArray}; categoricaldim)
     categoricaldim = _categorical_or_dependent(to_value(A), categoricaldim)
     isnothing(categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups"))
 

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -618,8 +618,10 @@ function get_axis_ticks(l::MayObs{D}, axis) where D<:DD.Dimension
 end
 
 get_number_version(x) = x
-# Preserve order from Lookup
-get_number_version(l::AbstractCategorical) = Int.(indexin(parent(l), unique(parent(l))))
+# Char lookups keep their codepoints, other categoricals are numbered in lookup order
+get_number_version(x::AbstractVector{<:AbstractChar}) = Int.(x)
+get_number_version(x::AbstractCategorical{<:AbstractChar}) = Int.(parent(x))
+get_number_version(x::AbstractCategorical) = Int.(indexin(parent(x), unique(parent(x))))
 get_number_version(x::Lookup) = get_number_version(parent(x))
 get_number_version(x::IntervalSets.ClosedInterval{<:AbstractChar}) = IntervalSets.ClosedInterval((Int.(endpoints(x)) .+ (-.5, .5))...) # Needs to add half the step this do give the interval like heatmap
 get_number_version(x::IntervalSets.ClosedInterval) = x

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -618,7 +618,8 @@ function get_axis_ticks(l::MayObs{D}, axis) where D<:DD.Dimension
 end
 
 get_number_version(x) = x
-get_number_version(x::AbstractCategorical) = eachindex(x)
+# Preserve order from Lookup
+get_number_version(l::AbstractCategorical) = Int.(indexin(parent(l), unique(parent(l))))
 get_number_version(x::Lookup) = get_number_version(parent(x))
 get_number_version(x::IntervalSets.ClosedInterval{<:AbstractChar}) = IntervalSets.ClosedInterval((Int.(endpoints(x)) .+ (-.5, .5))...) # Needs to add half the step this do give the interval like heatmap
 get_number_version(x::IntervalSets.ClosedInterval) = x

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -495,11 +495,10 @@ function Makie.convert_arguments(P::Type{<:Union{Makie.RainClouds, BoxPlot, Viol
     dd_categoricaldim = _categorical_or_dependent(A, categoricaldim)
     isnothing(dd_categoricaldim) && throw(ArgumentError("No dimensions have Categorical lookups")) # This should never happen
     otherdim = only(otherdims(A, dd_categoricaldim))
-    xs = lookup(A, dd_categoricaldim)
-    matrix_xs = repeat(parent(xs), outer = (1, size(A, otherdim)))
-
-    matrix_xs, parent(permutedims(A, (otherdim, dd_categoricaldim) ))
-    return Makie.convert_arguments(P, get_number_version(vec(matrix_xs)), parent(permutedims(A, (otherdim, dd_categoricaldim))) |> vec)
+    # Stack categorical dimensions end-to-end
+    xs = repeat(parent(lookup(A, dd_categoricaldim)); inner=size(A, otherdim))
+    ys = vec(parent(permutedims(A, (otherdim, dd_categoricaldim))))
+    return Makie.convert_arguments(P, get_number_version(xs), ys)
 end
 
 # Grid based conversions (surface, image, heatmap, contour, meshimage, etc)

--- a/ext/DimensionalDataMakieExt.jl
+++ b/ext/DimensionalDataMakieExt.jl
@@ -608,7 +608,7 @@ function get_axis_ticks(l::MayObs{D}, axis) where D<:DD.Dimension
             (; yticks= obs_f(i -> (unique(get_number_version(parent(i))), 
                 unique(string.(parent(lookup(i))))), l))
         else
-            (; zticks= obs_f(i -> unique((get_number_version(parent(i))), 
+            (; zticks= obs_f(i -> (unique(get_number_version(parent(i))),
                 unique(string.(parent(lookup(i))))), l))
         end
         dim_attr

--- a/test/makie.jl
+++ b/test/makie.jl
@@ -64,10 +64,10 @@ using DimensionalData: Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Uno
                 @test ax.ylabel[] == "test"
                 @test plt.label[] == "test"
                 @test all(last.(plt[1][]) .== Int.(y))
-                if dd_i isa DimArray{<:AbstractChar}
-                    @test all(first.(plt[1][]) .== Int.(x)) 
+                if eltype(x) <: AbstractChar
+                    @test all(first.(plt[1][]) .== Int.(x))
                 else
-                    @test all(first.(plt[1][]) .== sum.(Int, string.(x)))
+                    @test all(first.(plt[1][]) .== 1:5)
                 end
             end
         end
@@ -83,7 +83,7 @@ using DimensionalData: Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Uno
             @test ax.ylabel[] == "test"
             @test plt.label[] == "test"
             @test all(first.(plt[1][]) .== Int.(x))
-            @test all(last.(plt[1][]) .=== replace(y, missing => NaN)) 
+            @test all(last.(plt[1][]) .=== replace(y, missing => NaN))
         end
     end
 
@@ -124,22 +124,26 @@ using DimensionalData: Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Uno
             x = parent(lookup(to_value(dd_cat), Y))
             y = collect(parent(to_value(dd_cat)))
             fig, ax, plt = plot_i(obs(dd_cat))
-            @test all(plt[1][] .== repeat(97:98, outer = 6)) 
+            @test all(plt[1][] .== repeat(97:98, inner = 6))
             @test all(plt[2][] .== vec(y'))
             @test ax.xlabel[] == "X"
             @test ax.ylabel[] == "test"
             @test plt.label[] == "test"
 
             fig, ax, plt = plot_i(obs(dd_cat), categoricaldim = Y)
-            @test all(plt[1][] .== repeat(1:6, outer = 2))
+            @test all(plt[1][] .== repeat(1:6, inner = 2))
         end
     end
 
+    # multi-character labels are equally spaced, in lookup order
+    dd_cat_multi = DimArray(randn(4, 20), (X([:α, :Cyl, :Disp, :σ]), Y(1:20)), name = :test)
+    @test boxplot(dd_cat_multi).axis.xticks[] == ([1, 2, 3, 4], ["α", "Cyl", "Disp", "σ"])
 
     dd_cat = DimArray((1:6).^2, X(cat(fill('A', 3), fill('B', 3), dims = 1)), name = :test)
     for plot_i in (rainclouds, violin, boxplot)
         fig, ax, plt = plot_i(dd_cat)
         @test all(plt[1][] .== Int.(lookup(dd_cat, X)))
+        @test length.(plot_i(dd_cat).axis.xticks[]) == (2, 2)
         @test all(plt[2][] .== Int.(parent(dd_cat)))
         @test_throws ArgumentError plot_i(dd_cat, categoricaldim = Y) 
     end
@@ -316,7 +320,7 @@ end
 
     dd_mat_sym = DimArray( x.^1/2 .+ 0y'.^1/3, (X(Symbol.('a':'e')), Y(y)), name=:test)
     fig, ax, plt = contourf(dd_mat_sym)
-    @test plt[1][] == Int.(first.(string.(lookup(dd_mat_sym, X))))
+    @test plt[1][] == [1, 2, 3, 4, 5]
     @test plt[2][] == Int.(lookup(dd_mat_sym, Y))
     @test ax.xticks[][2] == string.(lookup(dd_mat_sym, X))
 

--- a/test/makie.jl
+++ b/test/makie.jl
@@ -125,7 +125,7 @@ using DimensionalData: Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Uno
             y = collect(parent(to_value(dd_cat)))
             fig, ax, plt = plot_i(obs(dd_cat))
             @test all(plt[1][] .== repeat(97:98, inner = 6))
-            @test all(plt[2][] .== vec(y'))
+            @test plt[2][] == vec(y')
             @test ax.xlabel[] == "X"
             @test ax.ylabel[] == "test"
             @test plt.label[] == "test"
@@ -143,7 +143,7 @@ using DimensionalData: Metadata, NoMetadata, ForwardOrdered, ReverseOrdered, Uno
     for plot_i in (rainclouds, violin, boxplot)
         fig, ax, plt = plot_i(dd_cat)
         @test all(plt[1][] .== Int.(lookup(dd_cat, X)))
-        @test length.(plot_i(dd_cat).axis.xticks[]) == (2, 2)
+        @test plot_i(dd_cat).axis.xticks[] == ([Int('A'),Int('B')], ["A", "B"])
         @test all(plt[2][] .== Int.(parent(dd_cat)))
         @test_throws ArgumentError plot_i(dd_cat, categoricaldim = Y) 
     end


### PR DESCRIPTION

Here's a PR for #1215 . There were in fact two bugs:

1. Values were mixed between categorical bins by `Makie.convert_arguments()` by using `outer` rather than `inner` in repeat.
2. X (categorical) axis positions were assigned by summing char values by `get_number_version()`, which led to weird positions for strings of length > 1.

When fixing (2.) I decided that the best behaviour would be to always preserve the order of the original `Lookup` and so modified the `get_number_version()` call by moving `parent()` inside the function so that it knows when it's passed a `Lookup`. 

However, I have a question: the code specifically converts `Char` lookups to numeric codes, so an axis of e.g. `['a', 'z']` would become `[97, 122]`. I've maintained that behaviour for fear of breaking another use case, only fixing bug (2.) for other categorical types like `String`. But it seems strange, and I wondered whether we wouldn't want to make `Char` consistent with `String`? 

I also fixed two separate bugs: z-axis labels were broken because of a misplaced bracket, and `DimVector`s were wrongly passed to base Makie by a `DimMatrix` type signature.

I used Claude to brainstorm, suggest tests and check for mistakes, but I reviewed all code myself.
It's my first time contributing to DimensionalData, so let me know if anything is out of place.
