### PR TITLE
Delete unnecessary `print` method

### DIFF
--- a/src/array/show.jl
+++ b/src/array/show.jl
@@ -302,9 +302,6 @@ function Base.alignment(io::IO, x::ShowWith)
         Base.alignment(io, x.val)
     end
 end
-function Base.print(io::IO, x::ShowWith)
-    printstyled(io, string(x.val); color = x.color, hidden = x.mode == :hide)
-end
 
 Base.iterate(x::ShowWith) = iterate(string(x.val))
 Base.iterate(x::ShowWith, i::Int) = iterate(string(x.val), i::Int)


### PR DESCRIPTION
- `length`, `isempty`, and `iterate` for `DimUnitRange` all have generic definitions in Base.
- Our `print(::IO, ::ShowWith)` is identical to `show(::IO, ::ShowWith)`, but according to the `print` docstring two-arg `print` is only needed if it's meant to differ from `show`.

Fixes these invalidations seen on 1.13rc3:
```julia
 inserting isempty(r::DimensionalData.Dimensions.DimUnitRange) @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/ggY1V/src/Dimensions/dimunitrange.jl:34 invalidated:
   backedges: 1: superseding isempty(r::AbstractUnitRange) @ Base range.jl:700 with MethodInstance for isempty(::AbstractUnitRange) (5 children)

 inserting length(r::DimensionalData.Dimensions.DimUnitRange) @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/ggY1V/src/Dimensions/dimunitrange.jl:34 invalidated:
   backedges:  1: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Compiler.MethodMatchInfo}) (1 children)
               2: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Compiler.ApplyCallInfo}) (1 children)
               3: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Compiler.CallMeta}) (1 children)
               4: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Compiler.NewPhiCNode2}) (1 children)
               5: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Union{Nothing, Compiler.ConstResult}}) (1 children)
               6: superseding length(r::OrdinalRange{T}) where T @ Base range.jl:766 with MethodInstance for length(::OrdinalRange{Union{Nothing, Compiler.AbstractIterationInfo}}) (1 children)
               7: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Union{Nothing, Compiler.AbstractIterationInfo}}) (5 children)
               8: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Union{Nothing, Compiler.ConstResult}}) (5 children)
               9: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Compiler.MethodMatchInfo}) (6 children)
              10: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Compiler.ApplyCallInfo}) (6 children)
              11: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Compiler.CallMeta}) (6 children)
              12: superseding length(r::AbstractUnitRange{T}) where T @ Base range.jl:783 with MethodInstance for length(::AbstractUnitRange{Compiler.NewPhiCNode2}) (6 children)

 inserting iterate(r::DimensionalData.Dimensions.DimUnitRange, i...) @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/ggY1V/src/Dimensions/dimunitrange.jl:37 invalidated:
   backedges:  1: superseding iterate(r::OrdinalRange) @ Base range.jl:924 with MethodInstance for iterate(::OrdinalRange{Tuple{LineNumberNode, Expr}}) (1 children)
               2: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Tuple{LineNumberNode, Expr}}, ::Any) (2 children)
               3: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Compiler.MethodMatchInfo}, ::Any) (3 children)
               4: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Compiler.ApplyCallInfo}, ::Any) (3 children)
               5: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Compiler.CallMeta}, ::Any) (3 children)
               6: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Compiler.NewPhiCNode2}, ::Any) (3 children)
               7: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Union{Nothing, Compiler.ConstResult}}, ::Any) (3 children)
               8: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Union{Nothing, Compiler.AbstractIterationInfo}}, ::Any) (3 children)
               9: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Compiler.MethodMatchInfo}, ::Any) (4 children)
              10: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Compiler.ApplyCallInfo}, ::Any) (4 children)
              11: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Union{Nothing, Compiler.AbstractIterationInfo}}, ::Any) (4 children)
              12: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Union{Nothing, Compiler.ConstResult}}, ::Any) (4 children)
              13: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Compiler.CallMeta}, ::Any) (4 children)
              14: superseding iterate(A::AbstractArray, state) @ Base abstractarray.jl:1247 with MethodInstance for iterate(::AbstractRange{Compiler.NewPhiCNode2}, ::Any) (4 children)
              15: superseding iterate(r::OrdinalRange{T}, i) where T @ Base range.jl:926 with MethodInstance for iterate(::OrdinalRange{Tuple{LineNumberNode, Expr}}, ::Any) (6 children)

 inserting print(io::IO, x::DimensionalData.ShowWith) @ DimensionalData ~/.julia/packages/DimensionalData/ggY1V/src/array/show.jl:305 invalidated:
   backedges: 1: superseding print(io::IO, s::AbstractString) @ Base strings/io.jl:190 with MethodInstance for print(::IOContext{REPL.LimitIO{Base.TTY}}, ::AbstractString) (2 children)
              2: superseding print(io::IO, s::AbstractString) @ Base strings/io.jl:190 with MethodInstance for print(::IOContext{IOBuffer}, ::AbstractString) (53 children)
              3: superseding print(io::IO, s::AbstractString) @ Base strings/io.jl:190 with MethodInstance for print(::IOBuffer, ::AbstractString) (61 children)
```

Part of https://github.com/rafaqz/DimensionalData.jl/issues/1046.