### PR TITLE
Delete unnecessary `eltype()` method

### DIFF
--- a/src/Lookups/lookup_arrays.jl
+++ b/src/Lookups/lookup_arrays.jl
@@ -20,7 +20,6 @@ dims(::Lookup) = nothing
 val(l::Lookup) = parent(l)
 locus(l::Lookup) = Center()
 
-Base.eltype(l::Lookup{T}) where T = T
 Base.parent(l::Lookup) = l.data
 Base.size(l::Lookup) = size(parent(l))
 Base.length(l::Lookup) = length(parent(l))


### PR DESCRIPTION
This already has a generic definition in Base: https://github.com/JuliaLang/julia/blob/release-1.13/base/abstractarray.jl#L245-L246

I think it's equally capable of being constant-folded, for me it benchmarks exactly the same as the old implementation. Fixes these invalidations seen on 1.13:
```julia
 inserting eltype(l::DimensionalData.Dimensions.Lookups.Lookup{T}) where T @ DimensionalData.Dimensions.Lookups ~/.julia/packages/DimensionalData/zaeVT/src/Lookups/lookup_arrays.jl:23 invalidated:
   backedges: 1: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}) (3 children)
              2: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::AbstractMatrix) (7 children)
              3: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::Union{Number, AbstractArray}) (78 children)
              4: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::AbstractArray{<:Complex}) (120 children)
              5: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::AbstractArray) (497 children)
```