### PR TITLE
avoid nested DimArrays when materializing from table

### DIFF
--- a/src/table_ops.jl
+++ b/src/table_ops.jl
@@ -10,9 +10,9 @@ Restore a dimensional array from its tabular representation.
 
 An `Array` containing the ordered valued in `data` with the size specified by `dims`.
 =#
-function restore_array(data::AbstractVector, indices::AbstractVector, dims::Tuple, missingval)
+function restore_array(data::AbstractVector{T}, indices::AbstractVector, dims::Tuple, missingval) where T
     # Allocate Destination Array
-    dst = DimArray{eltype(data)}(undef, dims)
+    dst = DimArray{T}(undef, dims)
     for (idx, d) in zip(indices, data)
         dst[idx] = d
     end
@@ -26,7 +26,7 @@ function restore_array(data::AbstractVector, indices::AbstractVector, dims::Tupl
         end
         return ifelse.(missing_rows, _missingval, dst)
     end
-    return dst
+    return parent(dst)
 end
 
 #=

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -216,7 +216,7 @@ end
         t1 = T(t1)
         t2 = T(t2)
         t3 = T(t3)
-        @testset "All dimensions passed (using $type)" begin
+        @testset "All dimensions passed (using $T)" begin
             # Restore DimArray from shuffled table
             for table in (t1, t3)
                 restored_da = DimArray(table, dims(ds))
@@ -257,7 +257,7 @@ end
             @test restored_stack.c[Y(2:100)] .|> ismissing .|> (!) |> all
         end
 
-        @testset "Dimensions automatically detected (using $type)" begin
+        @testset "Dimensions automatically detected (using $T)" begin
             da3 = DimArray(t)
             # Awkward test, see https://github.com/rafaqz/DimensionalData.jl/issues/953
             # If Dim{:X} == X then we can just test for equality
@@ -275,7 +275,7 @@ end
             end
         end
 
-        @testset "Dimensions partially specified (using $type)" begin
+        @testset "Dimensions partially specified (using $T)" begin
             for table in (t1, t3)
                 # setting the order returns ordered dimensions
                 da = DimArray(table, (X(Sampled(order = ReverseOrdered())), Y(Sampled(order=ForwardOrdered()))))
@@ -288,7 +288,7 @@ end
             @test parent(DimArray(t, (:X, :Y))) == parent(a)
             # passing in dimensions works for unconventional dimension names
             A = rand(dimz, name = :a)
-            table = type(A)
+            table = T(A)
             @test DimArray(table, (X, Y(Sampled(span = Irregular())), :test)) == A
             # Specifying dimensions types works even if it's illogical.
             dat = DimArray(t, (X(Sampled(span = Irregular(), order = Unordered())), Y(Categorical())))

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -211,15 +211,17 @@ end
 
     tabletypes = (Tables.rowtable, Tables.columntable, DataFrame)
 
-    for type in tabletypes
-        t = type(t)
-        t1 = type(t1)
-        t2 = type(t2)
-        t3 = type(t3)
+    for T in tabletypes
+        t = T(t)
+        t1 = T(t1)
+        t2 = T(t2)
+        t3 = T(t3)
         @testset "All dimensions passed (using $type)" begin
             # Restore DimArray from shuffled table
-            for table = (t1, t3)
-                @test all(DimArray(table, dims(ds)) .== a)
+            for table in (t1, t3)
+                restored_da = DimArray(table, dims(ds))
+                @test all(restored_da .== a)
+                @test parent(restored_da) isa Array
                 @test all(DimArray(table, dims(ds), name="a") .== a)
                 @test all(DimArray(table, dims(ds), name="b") .== b)
                 @test all(DimArray(table, dims(ds), name="c") .== c)


### PR DESCRIPTION
materializing from a table currently returns a DimArray with DimArray parent. which is unnecessary (and as it turns out is buggy with Makie)

just a simple `parent` fixes this.