### PR TITLE
Fix docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.mem
 .DS_Store
 
-/Manifest.toml
+/Manifest*.toml
 /.vscode/
 tmp
 generated
@@ -17,7 +17,7 @@ docs/docs_site
 docs/build
 docs/var
 deps/build.jl
-Manifest.toml
+Manifest*.toml
 docs/.vitepress/dist
 docs/.vitepress/cache
 docs/src/.vitepress/dist

--- a/docs/src/stacks.md
+++ b/docs/src/stacks.md
@@ -120,7 +120,7 @@ f(x) = (x.a + x.b) * x.c
 f.(st)
 ````
 
-Wrapping an `AbstractDimStack` with [DimStackArray](@ref) returns a generator that inherits from `AbstactArray`.
+Wrapping an `AbstractDimStack` with [`DimStackArray`](@ref) returns a generator that inherits from `AbstactArray`.
 
 :::
 


### PR DESCRIPTION
Documenter 1.18 has stricter rules and requires backticks before `@ref`. There was just one place where these were missing