### PR TITLE
fix xarray interop when a dimension name matches array attribute

### DIFF
--- a/ext/DimensionalDataPythonCallExt.jl
+++ b/ext/DimensionalDataPythonCallExt.jl
@@ -25,7 +25,7 @@ function PythonCall.pyconvert(::Type{DimArray}, x::Py, d=nothing; copy=false)
     new_dims = Dim[]
     for dim in reverse(dim_names) # Iterate in reverse order because of row/col major
         if dim in coord_names
-            coord_py = PyArray(getproperty(x, dim).data; copy=false)
+            coord_py = PyArray(x.coords[String(dim)].data; copy=false)
             coord = copy ? pyconvert(Array, coord_py) : coord_py
             push!(new_dims, Dim{dim}(coord))
         else
@@ -53,7 +53,7 @@ function PythonCall.pyconvert(::Type{DimStack}, x::Py, d=nothing; copy=false)
     variable_names = Symbol.(collect(x.data_vars.keys()))
     arrays = Dict{Symbol, DimArray}()
     for name in variable_names
-        arrays[name] = pyconvert(DimArray, getproperty(x, name); copy)
+        arrays[name] = pyconvert(DimArray, x.data_vars[String(name)]; copy)
     end
 
     metadata = pyconvert(Dict, x.attrs)

--- a/test/xarray.jl
+++ b/test/xarray.jl
@@ -72,6 +72,15 @@ x2 = xr.DataArray(data2,
     y = pyconvert(DimArray, x3)
     @test lookup(y, :w) == [1, 2]
     @test lookup(y, :z) == [1, 2, 3]
+
+    # Dimension names that happen to match DataArray attributes
+    x4 = xr.DataArray(rand(3, 2),
+                      dims=("variable", "var"),
+                      coords=Dict("variable" => [10, 20, 30], "var" => [1, 2]))
+    y = pyconvert(DimArray, x4)
+    @test name.(dims(y)) == (:var, :variable)
+    @test lookup(y, :variable) == [10, 20, 30]
+    @test lookup(y, :var) == [1, 2]
 end
 
 @testset "Dataset to DimStack" begin
@@ -86,6 +95,12 @@ end
 
     @test_throws ArgumentError pyconvert(DimStack, x)
     @test pyconvert(DimStack, x, 42) == 42
+
+    # Data variable names that shadow Dataset attributes must still resolve.
+    dataset2 = xr.Dataset(Dict("dims" => x, "attrs" => x2))
+    z2 = pyconvert(DimStack, dataset2)
+    @test Set(name(z2)) == Set((:dims, :attrs))
+    @test z2[:dims] == pyconvert(DimArray, x)
 end
 
 @testset "DimArray to Python conversion" begin

--- a/test/xarray.jl
+++ b/test/xarray.jl
@@ -96,7 +96,7 @@ end
     @test_throws ArgumentError pyconvert(DimStack, x)
     @test pyconvert(DimStack, x, 42) == 42
 
-    # Data variable names that shadow Dataset attributes must still resolve.
+    # Test variables "dims" and "attrs", which collide with xr.Dataset attributes.
     dataset2 = xr.Dataset(Dict("dims" => x, "attrs" => x2))
     z2 = pyconvert(DimStack, dataset2)
     @test Set(name(z2)) == Set((:dims, :attrs))


### PR DESCRIPTION
I ran into this issue with earth2studio using the name "variable" in its datasets.

For DataArray/Dataset, `getproperty(x, name)` breaks when a coord name matches an xarray attribute (e.g. "variable", "dims", "attrs"). This PR switches `getproperty` for `x.coords[...]` and `x.data_vars[...]`.

Disclosure: implemented by Claude (Fable 5.1) but reviewed by me.